### PR TITLE
Fix env passing

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -21,7 +21,7 @@
 #	USER
 #	SHELL
 
-trap '[ "$?" -ne 0 ] && echo An error occurred' EXIT
+trap 'if [ "$?" -ne 0 ]; then echo An error occurred; fi; rm "$env_file"' EXIT
 
 # We depend on podman let's be sure we have it
 if ! command -v podman >/dev/null; then
@@ -33,6 +33,8 @@ fi
 verbose=0
 container_name="fedora-toolbox-35"
 container_command="${SHELL} -l"
+
+env_file="$(mktemp /tmp/distrobox-env.XXXXXX)"
 
 # Print usage to stdout.
 # Arguments:
@@ -126,9 +128,8 @@ generate_command() {
 	echo "--interactive --tty --user=${USER} --workdir=${HOME}"
 	echo "--env=DISTROBOX_ENTER_PATH=$(command -v distrobox-enter)"
 	# exporting current environment to container
-	for i in $(printenv); do
-		echo "--env=\"${i}\""
-	done
+	printenv > "${env_file}"
+	echo "--env-file=${env_file}"
 	# run selected pod with command+args
 	echo "${container_name} ${container_command}"
 }

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -21,7 +21,7 @@
 #	USER
 #	SHELL
 
-trap 'if [ "$?" -ne 0 ]; then echo An error occurred; fi; rm "$env_file"' EXIT
+trap '[ "$?" -ne 0 ] && echo An error occurred' EXIT
 
 # We depend on podman let's be sure we have it
 if ! command -v podman >/dev/null; then
@@ -33,8 +33,6 @@ fi
 verbose=0
 container_name="fedora-toolbox-35"
 container_command="${SHELL} -l"
-
-env_file="$(mktemp /tmp/distrobox-env.XXXXXX)"
 
 # Print usage to stdout.
 # Arguments:
@@ -128,8 +126,9 @@ generate_command() {
 	echo "--interactive --tty --user=${USER} --workdir=${HOME}"
 	echo "--env=DISTROBOX_ENTER_PATH=$(command -v distrobox-enter)"
 	# exporting current environment to container
-	printenv > "${env_file}"
-	echo "--env-file=${env_file}"
+	for i in $(printenv | grep '=' | grep -v ' '); do
+		echo "--env=\"${i}\""
+	done
 	# run selected pod with command+args
 	echo "${container_name} ${container_command}"
 }


### PR DESCRIPTION
Fix a regression I've introduced in commit: enter: [simplify env passing](https://github.com/89luca89/distrobox/commit/7b2585d39018a01295c60d74350b37479f864273)

On some host systems (eg: Fedora) we have multiline env variables like:

```
BASH_FUNC_which%%=() {  ( alias;
 eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
}
```

This is not supported in podman (or docker) env, so we need to filter those out