### PR TITLE
init: check if file exists before linking and link it's realpath

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -1,20 +1,4 @@
 #!/bin/sh
-# Copyright (C) 2021 Luca Di Maio
-# This file is part of distrobox <https://github.com/89luca89/distrobox>.
-#
-# distrobox is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# distrobox is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with distrobox. If not, see <http://www.gnu.org/licenses/>.
-
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -1,20 +1,4 @@
 #!/bin/sh
-# Copyright (C) 2021 Luca Di Maio
-# This file is part of distrobox <https://github.com/89luca89/distrobox>.
-#
-# distrobox is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# distrobox is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with distrobox. If not, see <http://www.gnu.org/licenses/>.
-
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-export
+++ b/distrobox-export
@@ -1,20 +1,4 @@
 #!/bin/sh
-# Copyright (C) 2021 Luca Di Maio
-# This file is part of distrobox <https://github.com/89luca89/distrobox>.
-#
-# distrobox is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# distrobox is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with distrobox. If not, see <http://www.gnu.org/licenses/>.
-
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-init
+++ b/distrobox-init
@@ -1,20 +1,4 @@
 #!/bin/sh
-# Copyright (C) 2021 Luca Di Maio
-# This file is part of distrobox <https://github.com/89luca89/distrobox>.
-#
-# distrobox is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# distrobox is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with distrobox. If not, see <http://www.gnu.org/licenses/>.
-
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-init
+++ b/distrobox-init
@@ -182,8 +182,12 @@ list_sudo_groups() (
 # install them if not found.
 HOST_LINKS="/etc/host.conf /etc/hosts /etc/resolv.conf /etc/localtime /etc/timezone"
 for link in ${HOST_LINKS}; do
-	rm -f "${link}"
-	ln -s /run/host"${link}" "${link}"
+	# Check if the file exists first
+	if [ -f /run/host"${link}" ]; then
+		rm -f "${link}"
+		# Use realpath to not have multi symlink messes
+		ln -s "$(realpath /run/host"${link}")" "${link}"
+	fi
 done
 
 # Extract shell name from the $SHELL environment variable
@@ -229,8 +233,9 @@ for mount in ${HOST_MOUNTS}; do
 	mount_bind /run/host"${mount}" "${mount}" rw
 done
 
-# Ensure passwordless sudo is set up for user
+# Do not check fqdn when doing sudo, it will not work anyways
 echo "Defaults !fqdn" >>/etc/sudoers
+# Ensure passwordless sudo is set up for user
 echo "${container_user_name} ALL = (root) NOPASSWD:ALL" >>/etc/sudoers
 
 # Let's add our user to the container

--- a/install
+++ b/install
@@ -1,20 +1,4 @@
 #!/bin/sh
-# Copyright (C) 2021 Luca Di Maio
-# This file is part of distrobox <https://github.com/89luca89/distrobox>.
-#
-# distrobox is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# distrobox is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with distrobox. If not, see <http://www.gnu.org/licenses/>.
-
 # POSIX
 
 dest_path="/usr/local/bin"


### PR DESCRIPTION
Work to fix #19 
in some cases we want to symlink what it's already a symlink
so we should use `realpath` to link the original file always