### PR TITLE
create/init: move mounting of dynamic configs from init to create

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -90,6 +90,7 @@ fi
 generate_command() {
 
 	host_folders="/ /etc /media /mnt /run /tmp /usr /var"
+	host_links="/etc/host.conf /etc/hosts /etc/resolv.conf /etc/localtime /etc/timezone"
 
 	# Set the container hostname the same as the container name.
 	# use the host's namespace for ipc, network, pid, ulimit
@@ -101,9 +102,6 @@ generate_command() {
 	--env=\"XDG_RUNTIME_DIR=/run/user/${container_user_uid}\"
 	--hostname ${container_name}
 	--ipc host"
-	# if [ -f /dev/pts ]; then
-	# 	echo "--mount type=devpts,destination=/dev/pts"
-	# fi
 	# mount useful stuff inside the container.
 	# we also mount host's root filesystem to /run/host, to be
 	# able to syphon dynamic configurations from the host
@@ -129,10 +127,20 @@ generate_command() {
 	echo "--volume ${container_user_home}:${container_user_home}:rslave
 	--volume /dev:/dev:rslave"
 
-	# Check if host folder exists before mounting it
+	# useful mounts from host to the container using /run/host as a base
 	for host_folder in ${host_folders}; do
+		# Check if the folder exists first
 		if [ -d "${host_folder}" ]; then
 			echo "--volume ${host_folder}:/run/host${host_folder}:rslave"
+		fi
+	done
+	# those are dynamic configs needed by the container to function properly
+	# and integrate with the host
+	for link in ${host_links}; do
+		# Check if the file exists first
+		if [ -f "${link}" ]; then
+			# Use realpath to not have multi symlink mess
+			echo "--volume $(realpath "${link}"):${link}:ro"
 		fi
 	done
 
@@ -143,6 +151,10 @@ generate_command() {
 	# mount also the XDG_RUNTIME_DIR to ensure functionality of the apps
 	if [ -d /run/user/"${container_user_uid}" ]; then
 		echo "--volume /run/user/${container_user_uid}:/run/user/${container_user_uid}"
+	fi
+	# mount devpts
+	if [ -f /dev/pts ]; then
+		echo "--mount type=devpts,destination=/dev/pts"
 	fi
 
 	# find all the user's socket and mount them inside the container

--- a/distrobox-init
+++ b/distrobox-init
@@ -159,21 +159,6 @@ list_sudo_groups() (
 	return 0
 )
 
-# We will use host's dynamic config for some functionalities, ensure they are
-# symlinks to host's file inside the container.
-#
-# We do this before checking dependencies, as network access will be needed to
-# install them if not found.
-HOST_LINKS="/etc/host.conf /etc/hosts /etc/resolv.conf /etc/localtime /etc/timezone"
-for link in ${HOST_LINKS}; do
-	# Check if the file exists first
-	if [ -f /run/host"${link}" ]; then
-		rm -f "${link}"
-		# Use realpath to not have multi symlink messes
-		ln -s "$(realpath /run/host"${link}")" "${link}"
-	fi
-done
-
 # Extract shell name from the $SHELL environment variable
 # If not present as package in the container, we want to install it.
 shell_pkg="$(basename "${SHELL}")"


### PR DESCRIPTION
Right now in `create` we mount `/` as `/run/host/` inside the container
this is ok for later bind-mounts but for some files it is causing problems

One of them is `/etc/resolv.conf` that is a symlink when it's managed by `systemd-resolved`

As some setups do relative links like:

`lrwxrwxrwx. 1 root root unconfined_u:object_r:net_conf_t:s0 39 Nov 15 10:39 /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf`

And others do absolute links like:

`lrwxrwxrwx. 1 root root system_u:object_r:net_conf_t:s0 32 Dec 6 18:13 /etc/resolv.conf -> /run/systemd/resolve/resolv.conf`

(NOTE: both of them are from a fresh Fedora 35 workstation installation)

The absolute links will **fail** inside the container, so during the `init` phase, we have problems (for eg: no internet access)

Solution:

Move this phase to the `create` phase, so we can use `realpath` to resolve the links on the host itself, and mount them as read-only inside the container