### PR TITLE
Feature/docker support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         # uses: luizm/action-sh-checker@7f44869033b40ee4ffe7dc76c87a1bc66e3d025a
         uses: luizm/action-sh-checker@v0.3.0
         env:
-          SHELLCHECK_OPTS: -o all -Cnever -Sstyle -a -f gcc -x
+          SHELLCHECK_OPTS: -s sh -o all -Cnever -Sstyle -a -f gcc -x
           SHFMT_OPTS: -s # arguments to shfmt.
         with:
           sh_checker_comment: false

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Main concern is having basic linux utilities (`mount`), basic user management ut
 It depends either on `podman` configured in `rootless mode`
 or on `docker` configured without sudo (you're in the `docker` group)
 
-Minimum podman version: **2.1.0**
-Minimum docker version: 18.06.1
+- Minimum podman version: **2.1.0**
+- Minimum docker version: **18.06.1**
 
 Follow the official installation guide here:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ graphical apps (X11/Wayland) and audio.
   * [Why?](#why-)
     + [Aims](#aims)
 - [Compatibility](#compatibility)
+    + [Supported container managers](#supported-container-managers)
     + [Host Distros](#host-distros)
       - [New Host Distro support](#new-host-distro-support)
     + [Containers Distros](#containers-distros)
@@ -31,7 +32,6 @@ graphical apps (X11/Wayland) and audio.
     + [Application and service exporting](#application-and-service-exporting)
       - [Init the distrobox](#init-the-distrobox)
 - [Installation](#installation)
-- [Dependencies](#dependencies)
 - [Useful tips](#useful-tips)
   * [Container save and restore](#container-save-and-restore)
   * [Check used resources](#check-used-resources)
@@ -104,7 +104,22 @@ but that's all doable in the container itself after bootstrapping it.
 
 Main concern is having basic linux utilities (`mount`), basic user management utilities (`usermod, passwd`) and `sudo` correctly set.
 
-### Host Distros
+### Supported container managers
+
+`distrobox` can run on either `podman` or `docker`
+
+It depends either on `podman` configured in `rootless mode`
+or on `docker` configured without sudo (you're in the `docker` group)
+
+Minimum podman version: **2.1.0**
+Minimum docker version: 18.06.1
+
+Follow the official installation guide here:
+
+  - https://podman.io/getting-started/installation
+  - https://docs.docker.com/engine/install
+
+### Host Ditros
 
 Distrobox has been successfully tested on:
 
@@ -366,21 +381,6 @@ or if you want to select a custom directory to install without sudo:
 Else you can clone the project using `git clone` or using the `download zip` voice after clicking the green button above.
 
 Enter the directory and run `./install`, by default it will attempt to install in `/usr/local/bin`, you can specify another directory if needed with `./install -p ~/.local/bin`
-
-# Dependencies
-
-It depends either on `podman` configured in `rootless mode`
-or on `docker` configured without sudo (you're in the `docker` group)
-
-Check out your distro's documentation to check how to.
-
----
-
-Minimum podman version supported is 2.10
-
-Follow the official installation guide here: https://podman.io/getting-started/installation
-
-Minimum docker version supported is 18.03.1
 
 # Useful tips
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Distrobox has been successfully tested on:
 
 #### New Host Distro support
 
-If your distro of choice is not in the list open an issue requesting support for it.
+If your distro of choice is not in the list open an issue requesting support for it,
+we can work together to check if it is possible to add support for it.
 
 Or just try using it anyway, if it works, open an issue
 and it will be added to the list!
@@ -186,7 +187,8 @@ This will **not** occur after the first time, **subsequent enters will be much f
 
 #### New Distro support
 
-If your distro of choice is not in the list open an issue requesting support for it.
+If your distro of choice is not in the list open an issue requesting support for it,
+we can work together to check if it is possible to add support for it.
 
 Or just try using it anyway, if it works, open an issue
 and it will be added to the list!

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Follow the official installation guide here:
   - https://podman.io/getting-started/installation
   - https://docs.docker.com/engine/install
 
-### Host Ditros
+### Host Distros
 
 Distrobox has been successfully tested on:
 
@@ -221,6 +221,8 @@ Options:
 distrobox-enter takes care of entering the container with the name specified.
 Default command executed is your SHELL, buf you can specify different shells or
 entire commands to execute.
+If using it inside a script, an application or a service, you can specify the
+--headless mode to disable tty and interactivity.
 
 Usage:
 
@@ -230,6 +232,7 @@ Options:
 
 	--name/-n:		name for the distrobox						default: fedora-toolbox-35
 	--/-e:			end arguments execute the rest as command to execute at login	default: bash -l
+	--headless/-H:		do not instantiate a tty
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ graphical apps (X11/Wayland) and audio.
   * [Container save and restore](#container-save-and-restore)
   * [Check used resources](#check-used-resources)
   * [Using podman inside a distrobox](#using-podman-inside-a-distrobox)
-
+  * [Using docker inside a distrobox](#using-docker-inside-a-distrobox)
+- [Authors](#authors)
+- [License](#license)
 
 ## What it does
 
-Simply put it's a fancy `podman` wrapper to create and start containers highly integrated with the hosts.
+Simply put it's a fancy wrapper around `podman` or `docker` to create and start containers highly integrated with the hosts.
 
 The distrobox environment is based on an OCI image.
 This image is used to create a container that seamlessly integrates with the rest of the operating system by providing access to the user's home directory,
@@ -67,7 +69,7 @@ It is divided in 4 parts:
 
 ### Aims
 
-This project aims to bring **any distro userland to any other distro** supporting podman.
+This project aims to bring **any distro userland to any other distro** supporting podman or docker.
 It has been written in POSIX sh to be as portable as possible and not have problems with glibc version's compatibility.
 
 It also aims to enter the container **as fast as possible**, every millisecond adds up if you use the it
@@ -91,7 +93,6 @@ user   0m0,116s
 sys    0m0,063s
 
 ```
-
 I would like to keep it always below the [Doherty Treshold](https://lawsofux.com/doherty-threshold/) of 400ms.
 
 # Compatibility
@@ -368,33 +369,42 @@ Enter the directory and run `./install`, by default it will attempt to install i
 
 # Dependencies
 
-It depends on `podman` configured in `rootless mode`
+It depends either on `podman` configured in `rootless mode`
+or on `docker` configured without sudo (you're in the `docker` group)
 
 Check out your distro's documentation to check how to.
 
 ---
 
-Please be aware that old version of podman (prior to 1.6.4) have an issue with restarting a stopped container, this will create problems to re-enter an already created distrobox.
+Minimum podman version supported is 2.10
 
 Follow the official installation guide here: https://podman.io/getting-started/installation
 
-To ensure you have a recent version on your host.
+Minimum docker version supported is 18.03.1
 
 # Useful tips
 
 ## Container save and restore
 
-To save, export and reuse an already configured container, you can leverage `podman save` and `podman import`
+To save, export and reuse an already configured container, you can leverage `podman save` or `docker save` and `podman import` or `docker import`
 to basically create snapshots of your environment.
 
 ---
 
 To save a container to an image:
 
+with podman:
+
 ```
 podman container commit -p distrobox_name image_name_you_choose
-
 podman save image_name_you_choose:latest | gzip > image_name_you_choose.tar.gz
+```
+
+with docker:
+
+```
+docker container commit -p distrobox_name image_name_you_choose
+docker save image_name_you_choose:latest | gzip > image_name_you_choose.tar.gz
 ```
 
 This will create a tar.gz of the container of your choice in that exact moment.
@@ -406,6 +416,12 @@ just run
 
 ```
 podman import image_name_you_choose.tar.gz
+```
+
+or
+
+```
+docker import image_name_you_choose.tar.gz
 ```
 
 And create a new container based on that image:
@@ -422,20 +438,20 @@ in simple (and scriptable) steps.
 
 - You can always check how much space a `distrobox` is taking by using `podman` command:
 
-	`podman system df -v`
+`podman system df -v` or `docker system df -v`
 
 - You can check running `distrobox` using:
 
-	`podman ps -a`
+`podman ps -a` or `docker ps -a`
 
 - You can remove a `distrobox` using
 
-	`podman rm distrobox_name`
+`podman rm distrobox_name` or `docker rm distrobox_name`
 
 ## Using podman inside a distrobox
 
-You can use `podman socket` to control host's podman from inside a `distrobox`,
-just use:
+If `distrobox` is using `podman` as container engine, you can use `podman socket` to
+control host's podman from inside a `distrobox`, just use:
 
 `podman --remote`
 
@@ -445,7 +461,14 @@ It may be necessary to enable the socket on your host system by using:
 
 `systemctl --user enable --now podman.socket`
 
+## Using docker inside a distrobox
 
+You can use `docker` to control host's podman from inside a `distrobox`,
+by default if `distrobox` is using docker as a container engine, it will mount the
+docker.sock into the container.
+
+So in the container just install `docker`, add yourself to the `docker` group, and
+you should be good to go.
 
 # Authors
 

--- a/distrobox-create
+++ b/distrobox-create
@@ -164,7 +164,7 @@ generate_command() {
 	#
 	# for example using `podman --remote` to control the host's podman from inside
 	# the container or accessing docker and libvirt sockets.
-	host_sockets="$(find /run -iname "*socket" ! -path "/run/user/*" 2>/dev/null || :)"
+	host_sockets="$(find /run -iname "*sock" ! -path "/run/user/*" 2>/dev/null || :)"
 	for host_socket in ${host_sockets}; do
 		result_command="${result_command} --volume ${host_socket}:${host_socket}"
 	done

--- a/distrobox-create
+++ b/distrobox-create
@@ -215,7 +215,7 @@ fi
 
 # Check if the container already exists.
 # If it does, notify the user and exit.
-if "${container_manager}" inspect --type container "${container_name}"; then
+if "${container_manager}" inspect --type container "${container_name}" >/dev/null 2>&1; then
 	printf "Distrobox named '%s' already exists.\n" "${container_name}"
 	printf "To enter, run:\n"
 	printf "\tdistrobox-enter --name %s\n" "${container_name}"
@@ -224,7 +224,7 @@ fi
 
 # First, check if the image exists in the host.
 # If not prompt to download it.
-if ! ${container_manager} inspect --type image "${container_image}"; then
+if ! ${container_manager} inspect --type image "${container_image}" >/dev/null 2>&1; then
 	# Prompt to download it.
 	printf >&2 "Image not found.\n"
 	printf >&2 "Do you want to pull the image now?[y/n] "

--- a/distrobox-create
+++ b/distrobox-create
@@ -166,7 +166,10 @@ generate_command() {
 	# the container or accessing docker and libvirt sockets.
 	host_sockets="$(find /run -iname "*sock" ! -path "/run/user/*" 2>/dev/null || :)"
 	for host_socket in ${host_sockets}; do
-		result_command="${result_command} --volume ${host_socket}:${host_socket}"
+		if [ -r "${host_socket}" ]; then
+			result_command="${result_command}
+				--volume $(realpath "${host_socket}"):${host_socket}"
+		fi
 	done
 
 	# These are dynamic configs needed by the container to function properly
@@ -179,7 +182,7 @@ generate_command() {
 	host_links="/etc/host.conf /etc/hosts /etc/resolv.conf /etc/localtime"
 	for host_link in ${host_links}; do
 		# Check if the file exists first
-		if [ -f "${host_link}" ]; then
+		if [ -f "${host_link}" ] && [ -r "${host_link}" ]; then
 			# Use realpath to not have multi symlink mess
 			result_command="${result_command}
 				--volume $(realpath "${host_link}"):${host_link}:ro"
@@ -212,7 +215,7 @@ fi
 
 # Check if the container already exists.
 # If it does, notify the user and exit.
-if "${container_manager}" ps -a | grep -qE "(^| )${container_name}( |$)"; then
+if "${container_manager}" inspect --type container "${container_name}"; then
 	printf "Distrobox named '%s' already exists.\n" "${container_name}"
 	printf "To enter, run:\n"
 	printf "\tdistrobox-enter --name %s\n" "${container_name}"
@@ -221,7 +224,7 @@ fi
 
 # First, check if the image exists in the host.
 # If not prompt to download it.
-if [ -z "$(${container_manager} images -q "${container_image}")" ]; then
+if ! ${container_manager} inspect --type image "${container_image}"; then
 	# Prompt to download it.
 	printf >&2 "Image not found.\n"
 	printf >&2 "Do you want to pull the image now?[y/n] "
@@ -250,7 +253,7 @@ fi
 cmd="$(generate_command)"
 # Eval the generated command. If successful display an helpful message.
 # shellcheck disable=SC2086
-if eval ${cmd}; then
+if ${cmd}; then
 	printf "Distrobox '%s' successfully created.\n" "${container_name}"
 	printf "To enter, run:\n"
 	printf "\tdistrobox-enter --name %s\n" "${container_name}"

--- a/distrobox-create
+++ b/distrobox-create
@@ -93,25 +93,31 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
-# We depend on podman let's be sure we have it
-if ! command -v podman >/dev/null; then
-	printf >&2 "Missing dependency: podman\n"
+# We depend on a container manager let's be sure we have it
+# First we use podman, else docker
+container_manager="podman"
+if ! command -v podman >/dev/null && command -v docker >/dev/null; then
+	container_manager="docker"
+elif ! command -v podman >/dev/null && ! command -v docker >/dev/null; then
+	printf >&2 "Missing dependency: we need a container manager\n."
+	printf >&2 "Please install one of podman or docker.\n"
 	exit 127
 fi
 
-# Generate Podman command to execute.
+# Generate Podman or Docker command to execute.
 # Arguments:
 #   None
 # Outputs:
-#   prints the podman command to create the distrobox container
+#   prints the podman or docker command to create the distrobox container
 generate_command() {
 	# Set the container hostname the same as the container name.
 	# use the host's namespace for ipc, network, pid, ulimit
-	result_command="podman create"
-	# add podman verbose if -v is specified
+	result_command="${container_manager}"
+	# add  verbose if -v is specified
 	if [ "${verbose}" -ne 0 ]; then
 		result_command="${result_command} --log-level debug"
 	fi
+	result_command="${result_command} create"
 	result_command="${result_command}
 		--env=\"SHELL=${SHELL}\"
 		--env=\"XDG_RUNTIME_DIR=/run/user/${container_user_uid}\"
@@ -122,9 +128,7 @@ generate_command() {
 		--pid host
 		--privileged
 		--security-opt label=disable
-		--user root:root
-		--userns keep-id
-		--ulimit host"
+		--user root:root"
 
 	# let's check if we can include distrobox-export or not
 	if [ -n "${distrobox_export_path}" ]; then
@@ -146,8 +150,7 @@ generate_command() {
 		--volume /:/run/host:rslave
 		--volume /dev:/dev:rslave
 		--volume /sys:/sys:rslave
-		--volume /tmp:/tmp:rslave
-		--mount type=devpts,destination=/dev/pts"
+		--volume /tmp:/tmp:rslave"
 
 	# Mount also the XDG_RUNTIME_DIR to ensure functionality of the apps.
 	if [ -d "/run/user/${container_user_uid}" ]; then
@@ -182,6 +185,12 @@ generate_command() {
 		fi
 	done
 
+	if [ "${container_manager}" = "podman" ]; then
+		result_command="${result_command}
+		--userns keep-id
+		--ulimit host
+		--mount type=devpts,destination=/dev/pts"
+	fi
 	# Now execute the entrypoint, refer to `distrobox-init -h` for instructions
 	result_command="${result_command} ${container_image}
 		/usr/bin/entrypoint -v --name ${container_user_name}
@@ -202,7 +211,7 @@ fi
 
 # Check if the container already exists.
 # If it does, notify the user and exit.
-if podman ps -a | grep -qE "(^| )${container_name}( |$)"; then
+if "${container_manager}" ps -a | grep -qE "(^| )${container_name}( |$)"; then
 	printf "Distrobox named '%s' already exists.\n" "${container_name}"
 	printf "To enter, run:\n"
 	printf "\tdistrobox-enter --name %s\n" "${container_name}"
@@ -211,7 +220,7 @@ fi
 
 # First, check if the image exists in the host.
 # If not prompt to download it.
-if [ -z "$(podman images -q "${container_image}")" ]; then
+if [ -z "$(${container_manager} images -q "${container_image}")" ]; then
 	# Prompt to download it.
 	printf >&2 "Image not found.\n"
 	printf >&2 "Do you want to pull the image now?[y/n] "
@@ -221,11 +230,11 @@ if [ -z "$(podman images -q "${container_image}")" ]; then
 	case "${response}" in
 	y | Y | yes | Yes)
 		# Pull the image
-		podman pull "${container_image}"
+		"${container_manager}" pull "${container_image}"
 		;;
 	n | N | no | No)
 		printf >&2 "next time, run this command first:\n"
-		printf >&2 "  podman pull %s\n" "${container_image}"
+		printf >&2 "\t%s pull %s\n" "${container_manager}" "${container_image}"
 		exit 0
 		;;
 	*) # Default case: If no more options then break out of the loop.

--- a/distrobox-create
+++ b/distrobox-create
@@ -253,7 +253,7 @@ fi
 cmd="$(generate_command)"
 # Eval the generated command. If successful display an helpful message.
 # shellcheck disable=SC2086
-if ${cmd}; then
+if eval ${cmd}; then
 	printf "Distrobox '%s' successfully created.\n" "${container_name}"
 	printf "To enter, run:\n"
 	printf "\tdistrobox-enter --name %s\n" "${container_name}"

--- a/distrobox-create
+++ b/distrobox-create
@@ -96,12 +96,13 @@ fi
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
 container_manager="podman"
-if ! command -v podman >/dev/null && command -v docker >/dev/null; then
+if ! command -v podman >/dev/null; then
 	container_manager="docker"
-elif ! command -v podman >/dev/null && ! command -v docker >/dev/null; then
-	printf >&2 "Missing dependency: we need a container manager\n."
-	printf >&2 "Please install one of podman or docker.\n"
-	exit 127
+	if ! command -v docker >/dev/null; then
+		printf >&2 "Missing dependency: we need a container manager\n."
+		printf >&2 "Please install one of podman or docker.\n"
+		exit 127
+	fi
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -90,12 +90,13 @@ fi
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
 container_manager="podman"
-if ! command -v podman >/dev/null && command -v docker >/dev/null; then
+if ! command -v podman >/dev/null; then
 	container_manager="docker"
-elif ! command -v podman >/dev/null && ! command -v docker >/dev/null; then
-	printf >&2 "Missing dependency: we need a container manager\n."
-	printf >&2 "Please install one of podman or docker.\n"
-	exit 127
+	if ! command -v docker >/dev/null; then
+		printf >&2 "Missing dependency: we need a container manager\n."
+		printf >&2 "Please install one of podman or docker.\n"
+		exit 127
+	fi
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -27,6 +27,8 @@ distrobox version: ${version}
 distrobox-enter takes care of entering the container with the name specified.
 Default command executed is your SHELL, buf you can specify different shells or
 entire commands to execute.
+If using it inside a script, an application or a service, you can specify the
+--headless mode to disable tty and interactivity.
 
 Usage:
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -204,4 +204,4 @@ fi
 # Generate the exec command and run it
 cmd="$(generate_command)"
 # shellcheck disable=SC2086
-${cmd}
+eval ${cmd}

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -132,7 +132,7 @@ generate_command() {
 	# and export them to the container.
 	set +o xtrace
 	# disable logging fot this snippet, or it will be too talkative.
-	for i in $(printenv | grep '=' | grep -v ' '); do
+	for i in $(printenv | grep '=' | grep -v ' ' | grep -v '"'); do
 		result_command="${result_command} --env=\"${i}\""
 	done
 	# re-enable logging if it was enabled previously.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -147,8 +147,11 @@ generate_command() {
 	printf "%s" "${result_command}"
 }
 
-# Does the container exists?
-if ! "${container_manager}" ps -a | grep -qE "(^| )${container_name}( |$)"; then
+# Inspect the container we're working with.
+container_status="$("${container_manager}" inspect --type container "${container_name}" --format '{{.State.Status}}')"
+container_exists="$?"
+# Does the container exists? check if inspect reported errors
+if [ "${container_exists}" -gt 0 ]; then
 	# If not, prompt to create it first
 	printf >&2 "Cannot find container %s, does it exist?\n" "${container_name}"
 	printf >&2 "\nTry running first:\n"
@@ -157,7 +160,7 @@ if ! "${container_manager}" ps -a | grep -qE "(^| )${container_name}( |$)"; then
 fi
 
 # If the container is not already running, we need to start if first
-if ! "${container_manager}" ps | grep -qE "(^| )${container_name}( |$)"; then
+if [ "${container_status}" != "running" ]; then
 	# If container is not running, start it first
 	# Here, we save the timestamp before launching the start command, so we can
 	# be sure we're working with this very same session of logs later.
@@ -201,4 +204,4 @@ fi
 # Generate the exec command and run it
 cmd="$(generate_command)"
 # shellcheck disable=SC2086
-eval ${cmd}
+${cmd}

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -10,6 +10,7 @@ trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 # Defaults
 container_command="${SHELL:-"bash"} -l"
 container_name="fedora-toolbox-35"
+headless=0
 verbose=0
 version="distrobox_version_placeholder"
 
@@ -35,6 +36,7 @@ Options:
 
 	--name/-n:		name for the distrobox						default: fedora-toolbox-35
 	--/-e:			end arguments execute the rest as command to execute at login	default: bash -l
+	--headless/-H:		do not instantiate a tty
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -52,6 +54,10 @@ while :; do
 	-v | --verbose)
 		shift
 		verbose=1
+		;;
+	-H | --headless)
+		shift
+		headless=1
 		;;
 	-V | --version)
 		printf "distrobox: %s\n" "${version}"
@@ -81,27 +87,37 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
-# We depend on podman let's be sure we have it.
-if ! command -v podman >/dev/null; then
-	printf >&2 "Missing dependency: podman\n"
+# We depend on a container manager let's be sure we have it
+# First we use podman, else docker
+container_manager="podman"
+if ! command -v podman >/dev/null && command -v docker >/dev/null; then
+	container_manager="docker"
+elif ! command -v podman >/dev/null && ! command -v docker >/dev/null; then
+	printf >&2 "Missing dependency: we need a container manager\n."
+	printf >&2 "Please install one of podman or docker.\n"
 	exit 127
 fi
 
-# Generate Podman command to execute.
+# Generate Podman or Docker command to execute.
 # Arguments:
 #   None
 # Outputs:
-#   prints the podman command to enter the distrobox container
+#   prints the podman or docker command to enter the distrobox container
 generate_command() {
-	result_command="podman exec"
-	# add podman verbose if -v is specified
+	result_command="${container_manager}"
+	# add  verbose if -v is specified
 	if [ "${verbose}" -ne 0 ]; then
 		result_command="${result_command} --log-level debug"
 	fi
+	result_command="${result_command} exec"
 	result_command="${result_command}
-		--interactive
-		--tty
 		--user=${USER}"
+
+	if [ "${headless}" -eq 0 ]; then
+		result_command="${result_command}
+			--interactive
+			--tty"
+	fi
 	# Entering container using our user and workdir.
 	# Start container from working directory. Else default to home. Else do /.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
@@ -129,7 +145,7 @@ generate_command() {
 }
 
 # Does the container exists?
-if ! podman ps -a | grep -qE "(^| )${container_name}( |$)"; then
+if ! "${container_manager}" ps -a | grep -qE "(^| )${container_name}( |$)"; then
 	# If not, prompt to create it first
 	printf >&2 "Cannot find container %s, does it exist?\n" "${container_name}"
 	printf >&2 "\nTry running first:\n"
@@ -138,16 +154,16 @@ if ! podman ps -a | grep -qE "(^| )${container_name}( |$)"; then
 fi
 
 # If the container is not already running, we need to start if first
-if ! podman ps | grep -qE "(^| )${container_name}( |$)"; then
+if ! "${container_manager}" ps | grep -qE "(^| )${container_name}( |$)"; then
 	# If container is not running, start it first
 	# Here, we save the timestamp before launching the start command, so we can
 	# be sure we're working with this very same session of logs later.
 	log_timestamp="$(date +%FT%T.%N%:z)"
-	podman start "${container_name}" >/dev/null
+	"${container_manager}" start "${container_name}" >/dev/null
 
 	printf >&2 "Starting container %s\n" "${container_name}"
 	printf >&2 "run this command to follow along:\n"
-	printf >&2 "\tpodman logs -f %s\n" "${container_name}"
+	printf >&2 "\t%s logs -f %s\n" "${container_manager}" "${container_name}"
 
 	# Wait for container to start successfully.
 	# We will probe the container logs every 1s to check if we have either:
@@ -155,12 +171,12 @@ if ! podman ps | grep -qE "(^| )${container_name}( |$)"; then
 	#
 	# In the end, print eventual Warnings that occurred.
 	while :; do
-		podman_log="$(podman logs -t -n \
+		container_manager_log="$("${container_manager}" logs -t \
 			--since "${log_timestamp}" \
 			"${container_name}" 2>/dev/null)"
-		case "${podman_log}" in
+		case "${container_manager_log}" in
 		*"Error"*)
-			printf >&2 "%s\n" "${podman_log}"
+			printf >&2 "%s\n" "${container_manager_log}"
 			exit 1
 			;;
 		*"container_setup_done"*)
@@ -174,7 +190,7 @@ if ! podman ps | grep -qE "(^| )${container_name}( |$)"; then
 	done
 	printf >&2 "\ndone!\n"
 	# Print eventual warnings in the log.
-	podman logs -t -n \
+	"${container_manager}" logs -t \
 		--since "${log_timestamp}" \
 		"${container_name}" 2>/dev/null | grep "Warning" >&2 || :
 fi

--- a/distrobox-export
+++ b/distrobox-export
@@ -422,8 +422,7 @@ export_service() {
 			# Add commmand_prefix
 			# Add extra flags
 			# Add closing quote
-			cat "${temp_file}" |
-				sed "s|^${exec_cmd}=|${exec_cmd}=${container_command_prefix}|g" |
+			sed "s|^${exec_cmd}=|${exec_cmd}=${container_command_prefix}|g" "${temp_file}" |
 				sed "s|^${exec_cmd}=.*|& ${extra_flags}|g" |
 				sed "s|^${exec_cmd}=.*|&\"|g" >"${exported_service_fullpath}"
 			# in the end we add the final quote we've opened in the "container_command_prefix"

--- a/distrobox-export
+++ b/distrobox-export
@@ -174,7 +174,7 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 # Check we're running inside a container and not on the host
-if [ ! -f /run/.containerenv ]; then
+if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
 	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
 	exit 126
 fi
@@ -207,7 +207,7 @@ fi
 # We can assume this as we set it the same as container name during creation.
 container_name=$(cat /etc/hostname)
 # Prefix to add to an existing command to work throught the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} --name ${container_name} -- \"${is_sudo} "
+container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} --headless --name ${container_name} -- \"${is_sudo} "
 
 # Print generated script from template
 # Arguments:
@@ -408,6 +408,9 @@ export_service() {
 	# Create temp file with random name
 	temp_file="$(mktemp -u)"
 	# Replace all Exec occurrencies
+	if [ ! -d "/run/host/${HOME}/.config/systemd/user/" ]; then
+		mkdir -p "/run/host/${HOME}/.config/systemd/user/"
+	fi
 	cat "${service_file}" >"${exported_service_file}" 2>/dev/null
 	for exec_cmd in ExecStart ExecStartPre ExecStartPost ExecReload ExecStop ExecStopPost; do
 		# Save to temp file

--- a/distrobox-export
+++ b/distrobox-export
@@ -370,33 +370,10 @@ export_application() {
 #	new systemd unit in /run/host/$HOME/.config/systemd/user/
 #	or error code.
 export_service() {
-	# this is the output file we will produce.
-	exported_service_file="/run/host/${HOME}/.config/systemd/user/${exported_service}-${container_name}.service"
-
-	# If we're deleting it, just do it and exit
-	if [ "${exported_delete}" -ne 0 ]; then
-		if [ ! -f "${exported_service_file}" ]; then
-			printf >&2 "Error: cannot find service %s.\nWas it exported?.\n" "${exported_service}-${container_name}"
-			return 1
-		fi
-		rm -f "${exported_service_file}"
-		printf "Service %s successfully removed.\nOK!\n" "${exported_service}-${container_name}"
-		return 0
-	fi
-	# Check if it is already exported
-	if [ -f "${exported_service_file}" ] &&
-		grep -q "${container_command_prefix}" "${exported_service_file}"; then
-
-		printf "Service %s is already exported.\n\n" "${exported_service}-${container_name}"
-		printf "To check the status, run:\n\tsystemctl --user status %s \n" "${exported_service}-${container_name}.service"
-		printf "To start it, run:\n\tsystemctl --user start %s \n" "${exported_service}-${container_name}.service"
-		printf "To start it at login, run:\n\tsystemctl --user enable %s \n" "${exported_service}-${container_name}.service"
-		return 0
-	fi
 
 	# find the service file in the common
 	service_file=$(find \
-		/etc/systemd/system/ /lib/systemd/system/ /usr/lib/systemd/system/ "${HOME}".config/systemd/user/ \
+		/etc/systemd/system/ /lib/systemd/system/ /usr/lib/systemd/system/ "${HOME}"/.config/systemd/user/ \
 		-type f -name "${exported_service}*" 2>/dev/null | tail -1)
 	# Check that we found some service files first.
 	if [ -z "${service_file}" ]; then
@@ -405,36 +382,61 @@ export_service() {
 		return 127
 	fi
 
+	# this is the output file we will produce.
+	exported_service_file="${container_name}-$(basename "${service_file}")"
+	exported_service_fullpath="/run/host/${HOME}/.config/systemd/user/${exported_service_file}"
+
+	# If we're deleting it, just do it and exit
+	if [ "${exported_delete}" -ne 0 ]; then
+		if [ ! -f "${exported_service_fullpath}" ]; then
+			printf >&2 "Error: cannot find service %s.\nWas it exported?.\n" "${exported_service_file}"
+			return 1
+		fi
+		rm -f "${exported_service_fullpath}"
+		printf "Service %s successfully removed.\nOK!\n" "${exported_service_file}"
+		return 0
+	fi
+	# Check if it is already exported
+	if [ -f "${exported_service_fullpath}" ] &&
+		grep -q "${container_command_prefix}" "${exported_service_fullpath}"; then
+
+		printf "Service %s is already exported.\n\n" "${exported_service_file}"
+		printf "\nTo check the status, run:\n\tsystemctl --user status %s \n" "${exported_service_file}"
+		printf "\nTo start it, run:\n\tsystemctl --user start %s \n" "${exported_service_file}"
+		printf "\nTo start it at login, run:\n\tsystemctl --user enable %s \n" "${exported_service_file}"
+		return 0
+	fi
+
 	# Create temp file with random name
 	temp_file="$(mktemp -u)"
 	# Replace all Exec occurrencies
 	if [ ! -d "/run/host/${HOME}/.config/systemd/user/" ]; then
 		mkdir -p "/run/host/${HOME}/.config/systemd/user/"
 	fi
-	cat "${service_file}" >"${exported_service_file}" 2>/dev/null
+	cat "${service_file}" >"${exported_service_fullpath}" 2>/dev/null
 	for exec_cmd in ExecStart ExecStartPre ExecStartPost ExecReload ExecStop ExecStopPost; do
 		# Save to temp file
-		cat "${exported_service_file}" >"${temp_file}" 2>/dev/null
+		cat "${exported_service_fullpath}" >"${temp_file}" 2>/dev/null
 		# Add prefix only if not present
 		if ! grep "${exec_cmd}" "${temp_file}" | grep -q "${container_command_prefix}"; then
 			# Add commmand_prefix
 			# Add extra flags
 			# Add closing quote
-			tail -n+2 "${temp_file}" |
+			cat "${temp_file}" |
 				sed "s|^${exec_cmd}=|${exec_cmd}=${container_command_prefix}|g" |
 				sed "s|^${exec_cmd}=.*|& ${extra_flags}|g" |
-				sed "s|^${exec_cmd}=.*|&\"|g" >"${exported_service_file}"
+				sed "s|^${exec_cmd}=.*|&\"|g" >"${exported_service_fullpath}"
 			# in the end we add the final quote we've opened in the "container_command_prefix"
 		fi
 	done
 	# Cleanup
 	rm -f "${temp_file}"
 
-	printf "Service %s successfully exported.\nOK\n" "${exported_service}-${container_name}"
-	printf "%s will appear in your services list in a few seconds.\n\n" "${exported_service}-${container_name}"
-	printf "To check the status, run:\n\tsystemctl --user status %s \n" "${exported_service}-${container_name}.service"
-	printf "To start it, run:\n\tsystemctl --user start %s \n" "${exported_service}-${container_name}.service"
-	printf "To start it at login, run:\n\tsystemctl --user enable %s \n" "${exported_service}-${container_name}.service"
+	printf "Service %s successfully exported.\nOK\n" "${exported_service_file}"
+	printf "%s will appear in your services list in a few seconds.\n\n" "${exported_service_file}"
+	printf "\nTo check the status, run:\n\tsystemctl --user status %s \n" "${exported_service_file}"
+	printf "\nTo start it, run:\n\tsystemctl --user start %s \n" "${exported_service_file}"
+	printf "\nTo start it at login, run:\n\tsystemctl --user enable %s \n" "${exported_service_file}"
 
 	return 0
 }

--- a/distrobox-export
+++ b/distrobox-export
@@ -207,7 +207,7 @@ fi
 # We can assume this as we set it the same as container name during creation.
 container_name=$(cat /etc/hostname)
 # Prefix to add to an existing command to work throught the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} --headless --name ${container_name} -- \"${is_sudo} "
+container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} -H -n ${container_name} -- \"${is_sudo} "
 
 # Print generated script from template
 # Arguments:
@@ -220,7 +220,7 @@ generate_script() {
 # distrobox_binary
 # name: ${container_name}
 if [ ! -f /run/.containerenv ]; then
-    ${DISTROBOX_ENTER_PATH:-"distrobox-enter"} --name ${container_name} --${is_sudo} ${exported_bin} ${extra_flags} \$@
+    ${DISTROBOX_ENTER_PATH:-"distrobox-enter"} -n ${container_name} -- ${is_sudo} ${exported_bin} ${extra_flags} \$@
 else
     ${exported_bin} \$@
 fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -102,7 +102,7 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 # Check we're running inside a container and not on the host
-if [ ! -f /run/.containerenv ]; then
+if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
 	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
 	printf >&2 "distrobox-init should only be used as an entrypoint for a distrobox!\n"
 	exit 126


### PR DESCRIPTION
Work in progress to add `docker` support to distrobox.
This work is part of the issue #8 

Right now the container manager is automatically detected, with a preference of podman over docker.

Not all flags are supported by docker so these flags will be behind a container manager check:

```sh
if [ "${container_manager}" = "podman" ]; then
result_command="${result_command}
--userns keep-id
--ulimit host
--mount type=devpts,destination=/dev/pts"
fi
```

---

The add of a `--headless` flag to `distrobox-enter` was needed because `docker` has problems instantiating a tty if not ran from a terminal itself, this is a non-problem on `podman`, so to work around this, I've added this flag to optionally disable `--interactive --tty` flags.

This is applied to services and apps exported.

---


This should be ok for the non-rootless use-case of docker (adding yourself to docker group).

Need to investigate rootless docker setups.