### PR TITLE
Add Gentoo to supported host distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Distrobox has been successfully tested on:
 | Debian | 11 | |
 | Fedora | 34, 35 | |
 | Fedora Silverblue | 34, 35 | |
+| Gentoo | | To setup rootless podman, look [HERE](https://wiki.gentoo.org/wiki/Podman) |
 | OpenSUSE | Leap 15, Tumbleweed | |
 | Ubuntu | 20.04, 21.10 | Older versions based on 20.04 needs external repos to install newer Podman and Docker releases. </br> Derivatives like Pop_OS!, Mint and Elementary OS should work the same. |
 | EndlessOS | 4.0.0 | |


### PR DESCRIPTION
As I tested distrobox on Gentoo during #11 and still use it, I think we can add Gentoo to the list.