### PR TITLE
Feature/nixos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ Distrobox has been successfully tested on:
 | Fedora | 34, 35 | |
 | Fedora Silverblue | 34, 35 | |
 | Gentoo | | To setup rootless podman, look [HERE](https://wiki.gentoo.org/wiki/Podman) |
-| OpenSUSE | Leap 15, Tumbleweed | |
 | Ubuntu | 20.04, 21.10 | Older versions based on 20.04 needs external repos to install newer Podman and Docker releases. </br> Derivatives like Pop_OS!, Mint and Elementary OS should work the same. |
 | EndlessOS | 4.0.0 | |
+| OpenSUSE | Leap 15, Tumbleweed | |
 | OpenSUSE MicroOS | 20211209 | |
+| NixOS | 21.11 | To setup Docker, look [HERE](https://nixos.wiki/wiki/Docker) </br>To setup Podman, look [HERE](https://nixos.wiki/wiki/Podman) and [HERE](https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947) |
 
 #### New Host Distro support
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -147,6 +147,16 @@ generate_command() {
 	for i in $(printenv | grep '=' | grep -v ' ' | grep -v '"'); do
 		result_command="${result_command} --env=\"${i}\""
 	done
+	# Ensure the standard FHS program paths are in PATH environment
+	standard_paths="/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin"
+	container_paths="${PATH}"
+	# add to the PATH only after the host's paths, and only if not already present.
+	for standard_path in ${standard_paths}; do
+		if [ -n "${container_paths##*${standard_path}*}" ]; then
+			container_paths="${container_paths}:${standard_path}"
+		fi
+	done
+	result_command="${result_command} --env=\"PATH=${container_paths}\""
 	# re-enable logging if it was enabled previously.
 	if [ "${verbose}" -ne 0 ]; then
 		set -o xtrace

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -8,7 +8,11 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
-container_command="${SHELL:-"bash"} -l"
+container_command="${SHELL:-"bash"}"
+# Work around for shells that are not in the container's file system, nor PATH.
+# For example in hosts that do not follow FHS, like NixOS or for shells in custom
+# exotic paths.
+container_command="$(basename "${container_command}") -l"
 container_name="fedora-toolbox-35"
 headless=0
 verbose=0


### PR DESCRIPTION
Fix #33 

To work on non FHS compliant distributions, we can work around some problems by:

- using `basename` to normalize the login shell to the container
- add to PATH variable in the container the regular paths to binaries on an FHS distro:
	- /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin
