### PR TITLE
create: fix endless find when gvfs volumes are mounted

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -231,7 +231,7 @@ generate_command() {
 	#
 	# for example using `podman --remote` to control the host's podman from inside
 	# the container or accessing docker and libvirt sockets.
-	host_sockets="$(find /run -iname "*sock" ! -path "/run/user/*" 2>/dev/null || :)"
+	host_sockets="$(find /run -name 'user' -prune -o -name "*sock*" -print 2>/dev/null || :)"
 	for host_socket in ${host_sockets}; do
 		if [ -r "${host_socket}" ]; then
 			result_command="${result_command}


### PR DESCRIPTION
Fix #47 

Use prune in the find, as exclude will still look into the excluded paths