### PR TITLE
Add license header and SPDX-License-Identifier

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -3,6 +3,7 @@
 #
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
+# Copyright (C) 2021 distrobox contributors
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/distrobox-create
+++ b/distrobox-create
@@ -1,4 +1,20 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project: https://github.com/89luca89/distrobox
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-create
+++ b/distrobox-create
@@ -4,6 +4,7 @@
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
 # Copyright (C) 2021 distrobox contributors
+#
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -3,6 +3,8 @@
 #
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
+# Copyright (C) 2021 distrobox contributors
+#
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -1,4 +1,20 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project: https://github.com/89luca89/distrobox
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-export
+++ b/distrobox-export
@@ -3,6 +3,8 @@
 #
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
+# Copyright (C) 2021 distrobox contributors
+#
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/distrobox-export
+++ b/distrobox-export
@@ -1,4 +1,20 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project: https://github.com/89luca89/distrobox
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
 # POSIX
 # Expected env variables:
 #	HOME

--- a/distrobox-init
+++ b/distrobox-init
@@ -3,6 +3,8 @@
 #
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
+# Copyright (C) 2021 distrobox contributors
+#
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/distrobox-init
+++ b/distrobox-init
@@ -1,4 +1,20 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project: https://github.com/89luca89/distrobox
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
 # POSIX
 # Expected env variables:
 #	HOME

--- a/install
+++ b/install
@@ -3,6 +3,8 @@
 #
 # This file is part of the distrobox project: https://github.com/89luca89/distrobox
 #
+# Copyright (C) 2021 distrobox contributors
+#
 # distrobox is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3
 # as published by the Free Software Foundation.

--- a/install
+++ b/install
@@ -1,4 +1,20 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project: https://github.com/89luca89/distrobox
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
 # POSIX
 
 dest_path="/usr/local/bin"


### PR DESCRIPTION
I'm not a lawyer, but IMHO a license header in each script looks more professional :sweat_smile: and maybe in line with some policy.