### PR TITLE
Fix for #60

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -201,7 +201,9 @@ if ! command -v mount || ! command -v passwd ||
 			procps-ng \
 			shadow-utils \
 			sudo \
-			util-linux
+			util-linux \
+			vte-profile \
+			glibc-langpack-en
 
 	elif command -v pacman; then
 		pacman -Sy --noconfirm \


### PR DESCRIPTION
I don't know if this introduces some other issue, but now CentOS Stream 9 and RH UBI8 don't show the reported messages anymore