### PR TITLE
init: use different check for user existence

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -363,7 +363,7 @@ if ! grep -q "${container_user_name}" /etc/group; then
 	groupadd --force --gid "${container_user_gid}" "${container_user_name}"
 fi
 # Let's add our user to the container if the user already exists, just go ahead.
-if ! id "${container_user_name}"; then
+if ! grep -q "${container_user_name}" /etc/passwd; then
 	if ! useradd \
 		--home-dir "${container_user_home}" \
 		--no-create-home \


### PR DESCRIPTION
Fix #84 