### PR TITLE
Improve support for NixOS, and add more info about NixOS support to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Distrobox has been successfully tested on:
 | EndlessOS | 4.0.0 | |
 | OpenSUSE | Leap 15</br>Tumbleweed | |
 | OpenSUSE MicroOS | 20211209 | |
-| NixOS | 21.11 | To install distrobox:</br>`mkdir -p ~/.local/bin`</br>Add `PATH=$PATH:$HOME/.local/bin` to your bashrc</br>Execute [THIS](#installation) command without sudo.</br>To setup Docker, look [HERE](https://nixos.wiki/wiki/Docker) </br>To setup Podman, look [HERE](https://nixos.wiki/wiki/Podman) and [HERE](https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947) |
+| NixOS | 21.11 | __NOTE NixOS support is preliminary, and there are many bugs present, any help in improving support is appreciated__ </br> Currently you must have your default shell set to Bash, if it is not, make sure you edit your configuration.nix so that it is. </br> To install distrobox:</br>`mkdir -p ~/.local/bin`</br>Add `PATH=$PATH:$HOME/.local/bin` to your bashrc</br>Execute [THIS](#installation) command without sudo.</br>To setup Docker, look [HERE](https://nixos.wiki/wiki/Docker) </br>To setup Podman, look [HERE](https://nixos.wiki/wiki/Podman) and [HERE](https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947) |
 | Void Linux | glibc | Systemd service export will not work.</br>To setup graphical app exporting, you need to install `xhost` and add this to your `~/.xinitrc`: </br> `xhost +si:localuser:$USER`.  |
 
 #### New Host Distro support

--- a/distrobox-init
+++ b/distrobox-init
@@ -385,7 +385,7 @@ passwd --delete root
 if [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-        if [ ! -f "${container_user_home}/$(basename "${skel_file}")" -a !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
+		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" -a !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
 			cp "${skel_file}" "${container_user_home}"
 			chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/$(basename "${skel_file}")"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -385,7 +385,7 @@ passwd --delete root
 if [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" || ! -L "${container_user_home}/$(basename "${skel_file}")" ]; then
+		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" ] && [ !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
 			cp "${skel_file}" "${container_user_home}"
 			chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/$(basename "${skel_file}")"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -385,7 +385,7 @@ passwd --delete root
 if [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" -a !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
+		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" || ! -L "${container_user_home}/$(basename "${skel_file}")" ]; then
 			cp "${skel_file}" "${container_user_home}"
 			chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/$(basename "${skel_file}")"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -385,7 +385,7 @@ passwd --delete root
 if [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" ]; then
+        if [ ! -f "${container_user_home}/$(basename "${skel_file}")" -a !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
 			cp "${skel_file}" "${container_user_home}"
 			chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/$(basename "${skel_file}")"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -385,7 +385,7 @@ passwd --delete root
 if [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" ] && [ !-L "${container_user_home}/$(basename "${skel_file}")" ]; then
+		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" ] && [ ! -L "${container_user_home}/$(basename "${skel_file}")" ]; then
 			cp "${skel_file}" "${container_user_home}"
 			chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/$(basename "${skel_file}")"
 		fi


### PR DESCRIPTION
There are still a lot of bugs with NixOS which I am working to iron out, such as the following:

* Distrobox cannot be installed in /nix/store, not a huge deal, but very nice to have.
* Container distros don't support sudo, I don't no why, I just get an error whenever I try to become a super user.
* Kali does not come with DPKG or apt preinstalled, again I don't know why, but it is a pretty important feature of Kali

However, I was able to imporve NixOS support with this PR. I changed distrobox-init so that it recognizes symbolicly linked dotfiles, which many NixOS users (including myself) have. ﻿
