### PR TITLE
Update README: Arch installation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,11 +109,13 @@ sudo dnf copr enable alciregi/distrobox
 sudo dnf install distrobox
 ```
 
-On Arch Linux systems, `distrobox` is available in the AUR:
+On Arch Linux systems, `distrobox` is available in the AUR and can be installed using your prefered AUR helper:
 
 ```
-yay install distrobox
+yay -S distrobox
 ```
+
+`distrobox-git` is also available pulls directly from the main branch.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ On Arch Linux systems, `distrobox` is available in the AUR and can be installed 
 yay -S distrobox
 ```
 
-`distrobox-git` is also available pulls directly from the main branch.
+`distrobox-git` is also available. This package pulls directly from the main git branch.
 
 ---
 


### PR DESCRIPTION
Proper syntax for installing packages with `yay` is `yay -S $PKG_NAME`.