### PR TITLE
gen-man: exit if dependency is not met

### DIFF
--- a/man/gen-man
+++ b/man/gen-man
@@ -8,6 +8,7 @@ installation.
 
 https://github.com/rtomayko/ronn
 '
+	exit 1
 fi
 
 for i in "$(dirname "${0}")"/../docs/usage/distrobox-*; do


### PR DESCRIPTION
Self explanatory title. I have updated the `gen-man` script to exit if `ronn` is not installed.