### PR TITLE
distrobox-init: Fix permissions of $HOME/.local/share

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -456,6 +456,8 @@ mkdir -p "${container_user_home}/.local/share/themes"
 mkdir -p "${container_user_home}/.local/share/icons"
 mkdir -p "${container_user_home}/.local/share/fonts"
 # Fix permissions for home directories
+chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/.local"
+chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/.local/share"
 chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/.local/share/themes"
 chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/.local/share/icons"
 chown "${container_user_uid}":"${container_user_gid}" "${container_user_home}/.local/share/fonts"


### PR DESCRIPTION
If the user uses a custom HOME folder that does not contain anything,
the permissions of `$HOME/.local/share` are messed up:

```
$ ls -al $HOME/.local/share
total 20
drwxr-xr-x  5 root   root   4096 Jan 19 12:54 .
drwxr-xr-x  3 root   root   4096 Jan 19 12:54 ..
drwxr-xr-x  3 nobody nobody 4096 Dec 13 08:05 fonts
drwxr-xr-x 12 nobody nobody 4096 Dec 13 08:05 icons
drwxr-xr-x  5 nobody nobody 4096 Dec 13 08:05 themes
```

This impacts certain software that needs to write to `$HOME/.local/share`,
such as fish shell, which saves the user's command history there.

Fix up the permissions of `$HOME/.local` and `$HOME/.local/share` in the
same manner as the themes, icons, and fonts folders so that the
container's user can read and write to those folders freely:

```
$ ls -al $HOME/.local/share
total 24
drwxr-xr-x  6 nathan nathan 4096 Jan 19 13:00 .
drwxr-xr-x  3 nathan nathan 4096 Jan 19 13:00 ..
drwx------  3 nathan nathan 4096 Jan 19 13:00 fish
drwxr-xr-x  3 nobody nobody 4096 Dec 13 08:05 fonts
drwxr-xr-x 12 nobody nobody 4096 Dec 13 08:05 icons
drwxr-xr-x  5 nobody nobody 4096 Dec 13 08:05 themes
```

Closes: https://github.com/89luca89/distrobox/issues/130