### PR TITLE
create/export: Prefer 'uname -m' to /etc/hostname

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -244,7 +244,7 @@ generate_command() {
 	result_command="${container_manager} create"
 	# use the host's namespace for ipc, network, pid, ulimit
 	result_command="${result_command}
-		--hostname ${container_name}.$(cut -d'.' -f1 /etc/hostname)
+		--hostname ${container_name}.$(uname -n)
 		--ipc host
 		--name ${container_name}
 		--network host

--- a/distrobox-export
+++ b/distrobox-export
@@ -197,7 +197,7 @@ if [ -n "${exported_bin}" ] && [ -z "${dest_path}" ]; then
 fi
 
 # We can assume this as we set it the same as container name during creation.
-container_name=$(cut -d'.' -f1 /etc/hostname)
+container_name=$(uname -n)
 # Prefix to add to an existing command to work throught the container
 container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} -H -n ${container_name} -- \"${is_sudo} "
 if [ -z "${exported_app_label}" ]; then


### PR DESCRIPTION
In a Fedora VM that I created on my MacBook Air, `/etc/hostname` is empty,
which means the container's hostname ends with just a period, which
looks odd:

```
$ cat /etc/hostname

$ ./distrobox enter -n fedora -- cat /etc/hostname
fedora.
```

Prefer `uname -n`, which shows the host machine's hostname properly.

```
$ uname -n
fedora

$ ./distrobox enter -n fedora -- uname -n
fedora.fedora

$ ./distrobox enter -n fedora -- cat /etc/hostname
fedora.fedora
```

`uname` is described by POSIX and should be available by default on every
modern Linux system, as it is typically a part of the coreutils package.

Link: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/uname.html