### PR TITLE
init: Check existence of /etc/apt/apt.conf.d

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -401,10 +401,12 @@ elif [ -d "/etc/dpkg/dpkg.cfg.d/" ]; then
 
 	# Also we put a hook to clear some critical paths that do not play well
 	# with read only filesystems, like systemd.
-	cat <<EOF >/etc/apt/apt.conf.d/00_distrobox
+	if [ -d "/etc/apt/apt.conf.d/" ]; then
+		cat <<EOF >/etc/apt/apt.conf.d/00_distrobox
 DPkg::Pre-Invoke {"umount /var/log/journal";};
 DPkg::Post-Invoke {"mount --rbind -o ro /run/host/var/log/journal /var/log/journal";};
 EOF
+	fi
 fi
 
 mkdir -p /etc/sudoers.d


### PR DESCRIPTION
When using a container image that has `dpkg` installed in it that is not
`apt` based (such as Arch Linux), there is an error entering the container
for the first time:

```
$ distrobox create -i ghcr.io/nathanchance/dev/arch -n dev-arch

$ distrobox enter --name dev-arch
Starting container dev-arch
run this command to follow along:
        podman logs -f dev-arch
2022-01-20T16:05:25.003933000-07:00 /usr/sbin/mount
2022-01-20T16:05:25.004121000-07:00 /usr/sbin/mount
2022-01-20T16:05:25.004326000-07:00 /usr/sbin/passwd
2022-01-20T16:05:25.004505000-07:00 /usr/sbin/sudo
2022-01-20T16:05:25.004662000-07:00 /usr/sbin/useradd
2022-01-20T16:05:25.004808000-07:00 /usr/sbin/usermod
2022-01-20T16:05:25.004952000-07:00 /usr/sbin/fish
2022-01-20T16:05:25.123743000-07:00 Error: An error occurred

An error occurred

$ podman logs -f dev-arch
...
+ '[' -d /etc/dpkg/dpkg.cfg.d/ ']'
+ set +o xtrace
+ cat
/usr/bin/entrypoint: line 404: /etc/apt/apt.conf.d/00_distrobox: No such file or directory
Error: An error occurred
...
```

Check for the existence of `/etc/apt/apt.conf.d` first before attempting
to write a file into the directory.