### PR TITLE
Support for additional volumes and flags

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -29,6 +29,7 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
+container_manager_additional_flags=""
 container_clone=""
 container_image="${DBX_CONTAINER_IMAGE:-""}"
 container_image_default="registry.fedoraproject.org/fedora-toolbox:35"
@@ -124,6 +125,20 @@ while :; do
 	-N | --non-interactive)
 		non_interactive=1
 		shift
+		;;
+	--volume)
+		if [ -n "$2" ]; then
+			container_manager_additional_flags="${container_manager_additional_flags} ${1} ${2}"
+			shift
+			shift
+		fi
+		;;
+	--additional-flags)
+		if [ -n "$2" ]; then
+			container_manager_additional_flags="${container_manager_additional_flags} ${2}"
+			shift
+			shift
+		fi
 		;;
 	--) # End of all options.
 		shift
@@ -324,6 +339,10 @@ generate_command() {
 		--annotation run.oci.keep_original_groups=1
 		--mount type=devpts,destination=/dev/pts"
 	fi
+
+	# Add additional flags
+	result_command="${result_command} ${container_manager_additional_flags}"
+
 	# Now execute the entrypoint, refer to `distrobox-init -h` for instructions
 	result_command="${result_command} ${container_image}
 		/usr/bin/entrypoint -v --name ${container_user_name}

--- a/distrobox-create
+++ b/distrobox-create
@@ -29,10 +29,10 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
-container_manager_additional_flags=""
 container_clone=""
 container_image="${DBX_CONTAINER_IMAGE:-""}"
 container_image_default="registry.fedoraproject.org/fedora-toolbox:35"
+container_manager_additional_flags=""
 container_name="${DBX_CONTAINER_NAME:-""}"
 container_user_custom_home=""
 container_user_gid="$(id -rg)"
@@ -61,6 +61,9 @@ Usage:
 	distrobox-create --image registry.fedoraproject.org/fedora-toolbox:35 --name fedora-toolbox-35
 	distrobox-create --clone fedora-toolbox-35 --name fedora-toolbox-35-copy
 	distrobox-create --image alpine my-alpine-container
+	distrobox create --image fedora:35 --name test --volume /opt/my-dir:/usr/local/my-dir:rw --additional-flags "--pids-limit -1"
+	distrobox create --image fedora:35 --name test--additional-flags "--env MY_VAR-value"
+
 	DBX_NON_INTERACTIVE=1 DBX_CONTAINER_NAME=test-alpine DBX_CONTAINER_IMAGE=alpine distrobox-create
 
 Options:
@@ -72,6 +75,8 @@ Options:
 				this will be useful to either rename an existing distrobox or have multiple copies
 				of the same environment.
 	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
+	--volume		additional volumes to add to the container
+	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -133,7 +138,7 @@ while :; do
 			shift
 		fi
 		;;
-	--additional-flags)
+	-a | --additional-flags)
 		if [ -n "$2" ]; then
 			container_manager_additional_flags="${container_manager_additional_flags} ${2}"
 			shift

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -32,6 +32,7 @@ container_command="${SHELL:-"bash"}"
 # Work around for shells that are not in the container's file system, nor PATH.
 # For example in hosts that do not follow FHS, like NixOS or for shells in custom
 # exotic paths.
+container_manager_additional_flags=""
 container_command="$(basename "${container_command}") -l"
 container_name="${DBX_CONTAINER_NAME:-""}"
 container_name_default="fedora-toolbox-35"
@@ -87,6 +88,13 @@ while :; do
 	-n | --name)
 		if [ -n "$2" ]; then
 			container_name="$2"
+			shift
+			shift
+		fi
+		;;
+	--additional-flags)
+		if [ -n "$2" ]; then
+			container_manager_additional_flags="${container_manager_additional_flags} ${2}"
 			shift
 			shift
 		fi
@@ -205,6 +213,9 @@ generate_command() {
 	if [ "${verbose}" -ne 0 ]; then
 		set -o xtrace
 	fi
+
+	# Add additional flags
+	result_command="${result_command} ${container_manager_additional_flags}"
 
 	# Run selected container with specified command.
 	result_command="${result_command} ${container_name} ${container_command}"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -32,8 +32,8 @@ container_command="${SHELL:-"bash"}"
 # Work around for shells that are not in the container's file system, nor PATH.
 # For example in hosts that do not follow FHS, like NixOS or for shells in custom
 # exotic paths.
-container_manager_additional_flags=""
 container_command="$(basename "${container_command}") -l"
+container_manager_additional_flags=""
 container_name="${DBX_CONTAINER_NAME:-""}"
 container_name_default="fedora-toolbox-35"
 headless=0
@@ -53,12 +53,16 @@ Usage:
 
 	distrobox-enter --name fedora-toolbox-35 -- bash -l
 	distrobox-enter my-alpine-container -- sh -l
+	distrobox-enter --additional-flags "--preserve-fds" --name test -- bash -l
+	distrobox-enter --additional-flags "--env MY_VAR=value" --name test -- bash -l
+	MY_VAR=value distrobox-enter --additional-flags "--preserve-fds" --name test -- bash -l
 
 Options:
 
 	--name/-n:		name for the distrobox						default: fedora-toolbox-35
 	--/-e:			end arguments execute the rest as command to execute at login	default: bash -l
 	--headless/-H:		do not instantiate a tty
+	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -92,7 +96,7 @@ while :; do
 			shift
 		fi
 		;;
-	--additional-flags)
+	-a | --additional-flags)
 		if [ -n "$2" ]; then
 			container_manager_additional_flags="${container_manager_additional_flags} ${2}"
 			shift

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -10,6 +10,8 @@ Usage:
 	distrobox-create --image registry.fedoraproject.org/fedora-toolbox:35 --name fedora-toolbox-35
 	distrobox-create --clone fedora-toolbox-35 --name fedora-toolbox-35-copy
 	distrobox-create --image alpine my-alpine-container
+	distrobox create --image fedora:35 --name test --volume /opt/my-dir:/usr/local/my-dir:rw --additional-flags "--pids-limit -1"
+	distrobox create --image fedora:35 --name test--additional-flags "--env MY_VAR-value"
 
 You can also use environment variables to specify container name and image
 
@@ -30,6 +32,8 @@ Options:
 				this will be useful to either rename an existing distrobox or have multiple copies
 				of the same environment.
 	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
+	--volume		additional volumes to add to the container
+	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -37,3 +37,27 @@ Options:
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
+
+The `--additional-flags` or `-a` is useful to modify defaults in the container creations.
+For example:
+
+	distrobox create -i docker.io/library/archlinux -n dev-arch
+
+	podman container inspect dev-arch | jq '.[0].HostConfig.PidsLimit'
+	2048
+
+	distrobox rm -f dev-arch
+	distrobox create -i docker.io/library/archlinux -n dev-arch --volume $CBL_TC:/tc --additional-flags "--pids-limit -1"
+
+	podman container inspect dev-arch | jq '.[0].HostConfig,.PidsLimit'
+	0
+
+Additional volumes can be specified using the `--volume` flag. This flag follows the same standard as `docker` and `podman`
+to specify the mount point so `--volume SOURCE_PATH:DEST_PATH:MODE`.
+
+	distrobox create --image docker.io/library/archlinux --name dev-arch --volume /usr/share/:/var/test:ro
+
+During container creation, it is possible to specify (using the additional-flags) some environment variables that will
+persist in the container and be independent from your environment:
+
+	distrobox create --image fedora:35 --name test--additional-flags "--env MY_VAR-value"

--- a/docs/usage/distrobox-enter.md
+++ b/docs/usage/distrobox-enter.md
@@ -29,3 +29,15 @@ Options:
 	--version/-V:		show version
 
 This is used to enter the distrobox itself. Personally, I just create multiple profiles in my `gnome-terminal` to have multiple distros accessible.
+
+
+The `--additional-flags` or `-a` is useful to modify default command when executing in the container.
+For example:
+
+	distrobox enter -n dev-arch --additional-flags "--env my_var=test" -- printenv &| grep my_var
+	my_var=test
+
+This is possible also using normal env variables:
+
+	my_var=test distrobox enter -n dev-arch --additional-flags -- printenv &| grep my_var
+	my_var=test

--- a/docs/usage/distrobox-enter.md
+++ b/docs/usage/distrobox-enter.md
@@ -10,6 +10,9 @@ Usage:
 
 	distrobox-enter --name fedora-toolbox-35 -- bash -l
 	distrobox-enter my-alpine-container -- sh -l
+	distrobox-enter --additional-flags "--preserve-fds" --name test -- bash -l
+	distrobox-enter --additional-flags "--env MY_VAR=value" --name test -- bash -l
+	MY_VAR=value distrobox-enter --additional-flags "--preserve-fds" --name test -- bash -l
 
 Supported environment variables:
 
@@ -20,6 +23,7 @@ Options:
 	--name/-n:		name for the distrobox						default: fedora-toolbox-35
 	--/-e:			end arguments execute the rest as command to execute at login	default: bash -l
 	--headless/-H:		do not instantiate a tty
+	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -12,6 +12,8 @@ Usage:
 distrobox\-create \-\-image registry\.fedoraproject\.org/fedora\-toolbox:35 \-\-name fedora\-toolbox\-35
 distrobox\-create \-\-clone fedora\-toolbox\-35 \-\-name fedora\-toolbox\-35\-copy
 distrobox\-create \-\-image alpine my\-alpine\-container
+distrobox create \-\-image fedora:35 \-\-name test \-\-volume /opt/my\-dir:/usr/local/my\-dir:rw \-\-additional\-flags "\-\-pids\-limit \-1"
+distrobox create \-\-image fedora:35 \-\-name test\-\-additional\-flags "\-\-env MY_VAR\-value"
 .fi
 .IP "" 0
 .P
@@ -41,6 +43,8 @@ Options:
 			this will be useful to either rename an existing distrobox or have multiple copies
 			of the same environment\.
 \-\-home/\-H		select a custom HOME directory for the container\. Useful to avoid host\'s home littering with temp files\.
+\-\-volume		additional volumes to add to the container
+\-\-additional\-flags/\-a:	additional flags to pass to the container manager command
 \-\-help/\-h:		show this message
 \-\-verbose/\-v:		show more verbosity
 \-\-version/\-V:		show version

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -50,4 +50,34 @@ Options:
 \-\-version/\-V:		show version
 .fi
 .IP "" 0
+.P
+The \fB\-\-additional\-flags\fR or \fB\-a\fR is useful to modify defaults in the container creations\. For example:
+.IP "" 4
+.nf
+distrobox create \-i docker\.io/library/archlinux \-n dev\-arch
+
+podman container inspect dev\-arch | jq \'\.[0]\.HostConfig\.PidsLimit\'
+2048
+
+distrobox rm \-f dev\-arch
+distrobox create \-i docker\.io/library/archlinux \-n dev\-arch \-\-volume $CBL_TC:/tc \-\-additional\-flags "\-\-pids\-limit \-1"
+
+podman container inspect dev\-arch | jq \'\.[0]\.HostConfig,\.PidsLimit\'
+0
+.fi
+.IP "" 0
+.P
+Additional volumes can be specified using the \fB\-\-volume\fR flag\. This flag follows the same standard as \fBdocker\fR and \fBpodman\fR to specify the mount point so \fB\-\-volume SOURCE_PATH:DEST_PATH:MODE\fR\.
+.IP "" 4
+.nf
+distrobox create \-\-image docker\.io/library/archlinux \-\-name dev\-arch \-\-volume /usr/share/:/var/test:ro
+.fi
+.IP "" 0
+.P
+During container creation, it is possible to specify (using the additional\-flags) some environment variables that will persist in the container and be independent from your environment:
+.IP "" 4
+.nf
+distrobox create \-\-image fedora:35 \-\-name test\-\-additional\-flags "\-\-env MY_VAR\-value"
+.fi
+.IP "" 0
 

--- a/man/man1/distrobox-enter.1
+++ b/man/man1/distrobox-enter.1
@@ -38,3 +38,20 @@ Options:
 .IP "" 0
 .P
 This is used to enter the distrobox itself\. Personally, I just create multiple profiles in my \fBgnome\-terminal\fR to have multiple distros accessible\.
+.P
+The \fB\-\-additional\-flags\fR or \fB\-a\fR is useful to modify default command when executing in the container\. For example:
+.IP "" 4
+.nf
+distrobox enter \-n dev\-arch \-\-additional\-flags "\-\-env my_var=test" \-\- printenv &| grep my_var
+my_var=test
+.fi
+.IP "" 0
+.P
+This is possible also using normal env variables:
+.IP "" 4
+.nf
+my_var=test distrobox enter \-n dev\-arch \-\-additional\-flags \-\- printenv &| grep my_var
+my_var=test
+.fi
+.IP "" 0
+

--- a/man/man1/distrobox-enter.1
+++ b/man/man1/distrobox-enter.1
@@ -11,6 +11,9 @@ Usage:
 .nf
 distrobox\-enter \-\-name fedora\-toolbox\-35 \-\- bash \-l
 distrobox\-enter my\-alpine\-container \-\- sh \-l
+distrobox\-enter \-\-additional\-flags "\-\-preserve\-fds" \-\-name test \-\- bash \-l
+distrobox\-enter \-\-additional\-flags "\-\-env MY_VAR=value" \-\-name test \-\- bash \-l
+MY_VAR=value distrobox\-enter \-\-additional\-flags "\-\-preserve\-fds" \-\-name test \-\- bash \-l
 .fi
 .IP "" 0
 .P
@@ -27,6 +30,7 @@ Options:
 \-\-name/\-n:		name for the distrobox						default: fedora\-toolbox\-35
 \-\-/\-e:			end arguments execute the rest as command to execute at login	default: bash \-l
 \-\-headless/\-H:		do not instantiate a tty
+\-\-additional\-flags/\-a:	additional flags to pass to the container manager command
 \-\-help/\-h:		show this message
 \-\-verbose/\-v:		show more verbosity
 \-\-version/\-V:		show version

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -12,6 +12,8 @@ Usage:
 distrobox\-create \-\-image registry\.fedoraproject\.org/fedora\-toolbox:35 \-\-name fedora\-toolbox\-35
 distrobox\-create \-\-clone fedora\-toolbox\-35 \-\-name fedora\-toolbox\-35\-copy
 distrobox\-create \-\-image alpine my\-alpine\-container
+distrobox create \-\-image fedora:35 \-\-name test \-\-volume /opt/my\-dir:/usr/local/my\-dir:rw \-\-additional\-flags "\-\-pids\-limit \-1"
+distrobox create \-\-image fedora:35 \-\-name test\-\-additional\-flags "\-\-env MY_VAR\-value"
 .fi
 .IP "" 0
 .P
@@ -41,6 +43,8 @@ Options:
 			this will be useful to either rename an existing distrobox or have multiple copies
 			of the same environment\.
 \-\-home/\-H		select a custom HOME directory for the container\. Useful to avoid host\'s home littering with temp files\.
+\-\-volume		additional volumes to add to the container
+\-\-additional\-flags/\-a:	additional flags to pass to the container manager command
 \-\-help/\-h:		show this message
 \-\-verbose/\-v:		show more verbosity
 \-\-version/\-V:		show version
@@ -60,6 +64,9 @@ Usage:
 .nf
 distrobox\-enter \-\-name fedora\-toolbox\-35 \-\- bash \-l
 distrobox\-enter my\-alpine\-container \-\- sh \-l
+distrobox\-enter \-\-additional\-flags "\-\-preserve\-fds" \-\-name test \-\- bash \-l
+distrobox\-enter \-\-additional\-flags "\-\-env MY_VAR=value" \-\-name test \-\- bash \-l
+MY_VAR=value distrobox\-enter \-\-additional\-flags "\-\-preserve\-fds" \-\-name test \-\- bash \-l
 .fi
 .IP "" 0
 .P
@@ -76,6 +83,7 @@ Options:
 \-\-name/\-n:		name for the distrobox						default: fedora\-toolbox\-35
 \-\-/\-e:			end arguments execute the rest as command to execute at login	default: bash \-l
 \-\-headless/\-H:		do not instantiate a tty
+\-\-additional\-flags/\-a:	additional flags to pass to the container manager command
 \-\-help/\-h:		show this message
 \-\-verbose/\-v:		show more verbosity
 \-\-version/\-V:		show version

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -50,6 +50,36 @@ Options:
 \-\-version/\-V:		show version
 .fi
 .IP "" 0
+.P
+The \fB\-\-additional\-flags\fR or \fB\-a\fR is useful to modify defaults in the container creations\. For example:
+.IP "" 4
+.nf
+distrobox create \-i docker\.io/library/archlinux \-n dev\-arch
+
+podman container inspect dev\-arch | jq \'\.[0]\.HostConfig\.PidsLimit\'
+2048
+
+distrobox rm \-f dev\-arch
+distrobox create \-i docker\.io/library/archlinux \-n dev\-arch \-\-volume $CBL_TC:/tc \-\-additional\-flags "\-\-pids\-limit \-1"
+
+podman container inspect dev\-arch | jq \'\.[0]\.HostConfig,\.PidsLimit\'
+0
+.fi
+.IP "" 0
+.P
+Additional volumes can be specified using the \fB\-\-volume\fR flag\. This flag follows the same standard as \fBdocker\fR and \fBpodman\fR to specify the mount point so \fB\-\-volume SOURCE_PATH:DEST_PATH:MODE\fR\.
+.IP "" 4
+.nf
+distrobox create \-\-image docker\.io/library/archlinux \-\-name dev\-arch \-\-volume /usr/share/:/var/test:ro
+.fi
+.IP "" 0
+.P
+During container creation, it is possible to specify (using the additional\-flags) some environment variables that will persist in the container and be independent from your environment:
+.IP "" 4
+.nf
+distrobox create \-\-image fedora:35 \-\-name test\-\-additional\-flags "\-\-env MY_VAR\-value"
+.fi
+.IP "" 0
 
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
@@ -91,6 +121,23 @@ Options:
 .IP "" 0
 .P
 This is used to enter the distrobox itself\. Personally, I just create multiple profiles in my \fBgnome\-terminal\fR to have multiple distros accessible\.
+.P
+The \fB\-\-additional\-flags\fR or \fB\-a\fR is useful to modify default command when executing in the container\. For example:
+.IP "" 4
+.nf
+distrobox enter \-n dev\-arch \-\-additional\-flags "\-\-env my_var=test" \-\- printenv &| grep my_var
+my_var=test
+.fi
+.IP "" 0
+.P
+This is possible also using normal env variables:
+.IP "" 4
+.nf
+my_var=test distrobox enter \-n dev\-arch \-\-additional\-flags \-\- printenv &| grep my_var
+my_var=test
+.fi
+.IP "" 0
+
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
 .TH "DISTROBOX\-EXPORT\.1" "" "January 2022" "Distrobox" "Distrobox"


### PR DESCRIPTION
Adding additional volumes of flags to the container manager command is useful for more advanced use of the tool.

The most common flag is `--volume` which should be just a pass-trough to the container manager command.
For anything else, provide a `--additional-flags` 

This involves both `create` and `enter`

Example usages:

`distrobox create --image fedora:35 --name test --volume /opt/my-dir:/usr/local/my-dir:rw --additional-flags "--pids-limit -1"`

`distrobox-enter  --additional-flags "--preserve-fds" --name test -- bash -l`

To pass additional environments variable, it is possible to use both additional-flags and the normal env export:

`MY_VAR=value distrobox-enter  --additional-flags "--preserve-fds" --name test -- bash -l`
`distrobox-enter  --additional-flags "--env MY_VAR=value" --name test -- bash -l`

For a permanently exported variable, it can be passed to the create command:

`distrobox create --image fedora:35 --name test--additional-flags "--env MY_VAR-value"`


Closes: #135 