### PR TITLE
create, enter: more concise messages

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -396,5 +396,5 @@ cmd="$(generate_command)"
 if eval ${cmd}; then
 	printf "Distrobox '%s' successfully created.\n" "${container_name}"
 	printf "To enter, run:\n"
-	printf "\tdistrobox-enter --name %s\n" "${container_name}"
+	printf "\tdistrobox-enter %s\n" "${container_name}"
 fi

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -222,7 +222,7 @@ if [ "${container_exists}" -gt 0 ]; then
 	# If not, prompt to create it first
 	printf >&2 "Cannot find container %s, does it exist?\n" "${container_name}"
 	printf >&2 "\nTry running first:\n"
-	printf >&2 "\tdistrobox-create --name <name-of-container> --image <remote>/<docker>:<tag>\n"
+	printf >&2 "\tdistrobox-create <name-of-container> --image <remote>/<docker>:<tag>\n"
 	exit 1
 fi
 


### PR DESCRIPTION
I removed the `--name` flag from the output message in `distrobox-create` and `distrobox-enter` making it straight to the point.