### PR TITLE
Specify image name flaglessly

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -155,6 +155,9 @@ while :; do
 		if [ -z "${container_name}" ] && [ -n "$1" ]; then
 			container_name="$1"
 			shift
+		elif [ -z "${container_image}" ] && [ -n "$1" ]; then
+			container_image="$1"
+			shift
 		else
 			break
 		fi


### PR DESCRIPTION
Modified `distrobox-create` to also accept flaglessly specifying image.

Now these would equal the same thing:
- `distrobox-create alpine alpine:latest`
- `distrobox-create -n alpine alpine:latest`
- `distrobox-create alpine -i alpine:latest`

Hopefully somebody finds this useful.