### PR TITLE
init: explicit version for opensuse

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -296,7 +296,7 @@ if ! command -v find || ! command -v mount || ! command -v passwd ||
 		zypper install -y \
 			"${shell_pkg}" \
 			findutils \
-			libvte-2 \
+			libvte-2_91-0 \
 			ncurses \
 			procps \
 			shadow \


### PR DESCRIPTION
Resolves #149. 

Fixed by changing the `libvte-2` package.

Tested on tumbleweed and leap (15.4 and 15.2).