### PR TITLE
init: If user already exists in /etc/passwd set props again, do not skip

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -461,6 +461,8 @@ if ! grep -q "${container_user_name}" /etc/passwd; then
 		printf "Warning: there was a problem setting up the user\n"
 	fi
 else
+	# This situation is presented when podman or docker already creates the user for us inside container.
+	# We should modify the user's prepopulated shadowfile entry though as per user's active preferences. 
 	if ! usermod \
 		--home "${container_user_home}" \
 		--shell "${SHELL:-"/bin/bash"}" \

--- a/distrobox-init
+++ b/distrobox-init
@@ -448,11 +448,21 @@ fi
 if ! grep -q "${container_user_name}" /etc/group; then
 	groupadd --force --gid "${container_user_gid}" "${container_user_name}"
 fi
-# Let's add our user to the container if the user already exists, just go ahead.
+# Let's add our user to the container. if the user already exists, enforce properties.
 if ! grep -q "${container_user_name}" /etc/passwd; then
 	if ! useradd \
 		--home-dir "${container_user_home}" \
 		--no-create-home \
+		--shell "${SHELL:-"/bin/bash"}" \
+		--uid "${container_user_uid}" \
+		--gid "${container_user_gid}" \
+		"${container_user_name}"; then
+
+		printf "Warning: there was a problem setting up the user\n"
+	fi
+else
+	if ! usermod \
+		--home "${container_user_home}" \
 		--shell "${SHELL:-"/bin/bash"}" \
 		--uid "${container_user_uid}" \
 		--gid "${container_user_gid}" \


### PR DESCRIPTION
This fixes #175 where home field in /etc/passwd diverges from value of $HOME
which then causes unexpected behaviour.
When user is pre-prepopulated due to some reason the old behaviour was to skip useradd.
So path in /etc/passwd could be different than one manually set (ex. when user asks for custom home).

Fix bug by force-setting properties with _usermod_ if user already exists.