### PR TITLE
install: remove redundant dot

### DIFF
--- a/install
+++ b/install
@@ -158,4 +158,4 @@ else
 fi
 
 printf >&2 "Successfully installed to %s.\n" "${dest_path}"
-printf >&2 "Be sure that %s. is in your \$PATH environment variable for it to work.\n" "${dest_path}"
+printf >&2 "Be sure that %s is in your \$PATH environment variable for it to work.\n" "${dest_path}"


### PR DESCRIPTION
Previous install output would be like this `Be sure that /usr/local/bin. is in your $PATH environment variable for it to work.`. I have removed the trailing dot right after the path.