### PR TITLE
enter: Enter at workdir through child path of '/run/host'

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -218,7 +218,7 @@ generate_command() {
 	# Start container from working directory. Else default to home. Else do /.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
 	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
-	container_available_workdir="$(echo "/run/host/${workdir}" | sed -e 's/"/\\\"/g')"
+	container_available_workdir="/run/host/${workdir}"
 	result_command="${result_command}
 		--workdir=\"${container_available_workdir}\"
 		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -219,9 +219,13 @@ generate_command() {
 	# Since we are entering from host, drop at workdir through '/run/host'
 	# which represents host's root inside container. Any directory on host
 	# even if not explicitly mounted is bound to exist under /run/host.
+	# Since user $HOME is very likely present in container, enter there directly
+	# to avoid confusing the user about shifted paths.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
 	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
-	workdir="/run/host/${workdir}"
+	if [ -n "${workdir##*"${HOME}"*}" ]; then
+		workdir="/run/host/${workdir}"
+	fi
 	result_command="${result_command}
 		--workdir=\"${workdir}\"
 		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -218,9 +218,10 @@ generate_command() {
 	# Start container from working directory. Else default to home. Else do /.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
 	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
+	container_available_workdir="$(echo "/run/host/${workdir}" | sed -e 's/"/\\\"/g')"
 	result_command="${result_command}
-		--workdir=\"${workdir}\"
-		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}"\"
+		--workdir=\"${container_available_workdir}\"
+		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
 
 	# Loop through all the environment vars
 	# and export them to the container.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -216,11 +216,14 @@ generate_command() {
 
 	# Entering container using our user and workdir.
 	# Start container from working directory. Else default to home. Else do /.
+	# Since we are entering from host, drop at workdir through '/run/host'
+	# which represents host's root inside container. Any directory on host
+	# even if not explicitly mounted is bound to exist under /run/host.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
 	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
-	container_available_workdir="/run/host/${workdir}"
+	workdir="/run/host/${workdir}"
 	result_command="${result_command}
-		--workdir=\"${container_available_workdir}\"
+		--workdir=\"${workdir}\"
 		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
 
 	# Loop through all the environment vars


### PR DESCRIPTION
Despite tight integration, some host workdir paths may not exist in container.
So always drop at workdir through '/run/host' path which is bound to exist.
User can then cd as desired.

This also avoids some confusion. For example:
```
user@host:/etc$
user@host:/etc$ distrobox-enter guest
user@guest:/etc$ 
```
`/etc` on line-1 and `/etc` on line-3 are two different directories. 
It's not very intuitive that the working directory has changed while name remains identical.

Especially when for a different starting path we see different behaviour :
```
user@host:/home/user$
user@host:/home/user$ distrobox-enter guest
user@guest:/home/user$
```
Here the `/home/user` on line-1 and `/home/user` on line-3 _are the same_ directory. 

With this pull request, on enter, user will always drop to the same directory they were in on host
using a path through /run/host subtree.

```
user@host:/etc$
user@host:/etc$ distrobox-enter guest
user@guest:/run/host/etc$
```