### PR TITLE
Prefix install/uninstall option

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -220,7 +220,7 @@ generate_command() {
 	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
 	result_command="${result_command}
 		--workdir=\"${workdir}\"
-		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}"\"
+		--env=\"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
 
 	# Loop through all the environment vars
 	# and export them to the container.

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,7 +134,7 @@ If you like to live your life dangerously, you can trust me and simply run this 
 
 or if you want to select a custom directory to install without sudo:
 
-`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- -p ~/.local`
+`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local`
 
 Else you can clone the project using `git clone` or using the latest release [HERE](https://github.com/89luca89/distrobox/releases/latest).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,11 +134,13 @@ If you like to live your life dangerously, you can trust me and simply run this 
 
 or if you want to select a custom directory to install without sudo:
 
-`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- -p ~/.local/bin`
+`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- -p ~/.local`
 
 Else you can clone the project using `git clone` or using the latest release [HERE](https://github.com/89luca89/distrobox/releases/latest).
 
-Enter the directory and run `./install`, by default it will attempt to install in `~/.local/bin` but if you run the script as root, it will default to `/usr/local/bin`. You can specify a custom directory with the `-p` flag such as `./install -p ~/.bin`. 
+Enter the directory and run `./install`, by default it will attempt to install in `~/.local` but if you run the script as root, it will default to `/usr/local`. You can specify a custom directory with the `--prefix` flag such as `./install --prefix ~/.distrobox`. 
+
+Prefix explained: main distrobox files get installed to `${prefix}/bin` whereas the manpages get installed to `${prefix}/share/man`.
 
 Or check the [Host Distros](compatibility.md#host-distros) compatibility list for distro-specific instructions.
 
@@ -157,11 +159,11 @@ If you installed distrobox using the `install` script in the default install dir
 
 or if you specified a custom path:
 
-`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- -p ~/.local/bin`
+`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- --prefix ~/.local`
 
 Else if cloned the project using `git clone` or using the latest archive release from [HERE](https://github.com/89luca89/distrobox/releases/latest),
 
-enter the directory and run `./uninstall`, by default it will assume the install directory was `/usr/local/bin`, you can specify another directory if needed with `./uninstall -p ~/.local/bin`
+enter the directory and run `./uninstall`, by default it will assume the install directory was `/usr/local` if ran as root or `~/.local`, you can specify another directory if needed with `./uninstall --prefix ~/.local`
 
 ---
 

--- a/install
+++ b/install
@@ -68,7 +68,7 @@ while :; do
 	esac
 done
 
-if [[ ${dest_path} && ${prefix} ]]; then
+if [[ "${dest_path}" && "${prefix}" ]]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/install
+++ b/install
@@ -28,11 +28,11 @@ verbose=0
 #   print usage with examples.
 show_help() {
 	cat <<EOF
-install -P /usr/local
+install --prefix /usr/local
 
 Options:
 	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
-	--path/-p:		path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
+	--path/-p:		(DEPRECATED) path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
 EOF
@@ -85,6 +85,7 @@ if [ -z "${dest_path}" ]; then
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
 else
+	printf >&2 "Warning: --prefix/-p is deprecated. Please refer to the documentation and switch to --prefix/-P.\n"
 	# dest_path is already set
 	man_dest_path="${dest_path}/../share/man/man1"
 fi

--- a/install
+++ b/install
@@ -85,7 +85,7 @@ if [ -z "${dest_path}" ]; then
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
 else
-	printf >&2 "Warning: --prefix/-p is deprecated. Please refer to the documentation and switch to --prefix/-P.\n"
+	printf >&2 "Warning: -p/--path is deprecated. Please refer to the documentation and switch to -P/--prefix.\n"
 	# dest_path is already set
 	man_dest_path="${dest_path}/../share/man/man1"
 fi

--- a/install
+++ b/install
@@ -69,7 +69,7 @@ while :; do
 	esac
 done
 
-if [ "${dest_path}" ] && [ "${prefix}" ]; then
+if [ -n "${dest_path}" ] && [ -n "${prefix}" ]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/install
+++ b/install
@@ -68,7 +68,7 @@ while :; do
 	esac
 done
 
-if [[ "${dest_path}" && "${prefix}" ]]; then
+if [[ ${dest_path} && ${prefix} ]]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/install
+++ b/install
@@ -19,12 +19,6 @@
 
 # POSIX
 
-dest_path="/usr/local/bin"
-# in case we're not root, just default to the home directory
-if [ "$(id -u)" -ne 0 ]; then
-	dest_path="${HOME}/.local/bin"
-fi
-
 verbose=0
 
 # Print usage to stdout.
@@ -62,10 +56,37 @@ while :; do
 			shift
 		fi
 		;;
+	-P | --prefix)
+		if [ -n "$2" ]; then
+			prefix="$2"
+			shift
+			shift
+		fi
+		;;
 	*) # Default case: If no more options then break out of the loop.
 		break ;;
 	esac
 done
+
+if [[ ${dest_path} && ${prefix} ]]; then
+	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
+	exit 1
+fi
+
+if [ -z "${dest_path}" ]; then
+	if [ -z "${prefix}"]; then
+		prefix="/usr/local"
+		# in case we're not root, just default to the home directory
+		if [ "$(id -u)" -ne 0 ]; then
+			prefix="${HOME}/.local"
+		fi
+	fi
+	dest_path="${prefix}/bin"
+	man_dest_path="${prefix}/share/man/man1"
+else
+	# dest_path is already set
+	man_dest_path="${dest_path}/../share/man/man1"
+fi
 
 set -o errexit
 set -o nounset
@@ -73,8 +94,6 @@ set -o nounset
 if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
-
-man_dest_path="${dest_path}/../share/man/man1"
 
 # get current dir
 curr_dir=$(dirname "$0")

--- a/install
+++ b/install
@@ -28,9 +28,10 @@ verbose=0
 #   print usage with examples.
 show_help() {
 	cat <<EOF
-install -p /usr/local/bin
+install -P /usr/local
 
 Options:
+	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
 	--path/-p:		path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
@@ -68,13 +69,13 @@ while :; do
 	esac
 done
 
-if [[ ${dest_path} && ${prefix} ]]; then
+if [ "${dest_path}" ] && [ "${prefix}" ]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi
 
 if [ -z "${dest_path}" ]; then
-	if [ -z "${prefix}"]; then
+	if [ -z "${prefix}" ]; then
 		prefix="/usr/local"
 		# in case we're not root, just default to the home directory
 		if [ "$(id -u)" -ne 0 ]; then

--- a/uninstall
+++ b/uninstall
@@ -19,12 +19,6 @@
 
 # POSIX
 
-dest_path="/usr/local/bin"
-# in case we're not root, just default to the home directory
-if [ "$(id -u)" -ne 0 ]; then
-	dest_path="${HOME}/.local/bin"
-fi
-
 verbose=0
 
 # Print usage to stdout.
@@ -62,10 +56,37 @@ while :; do
 			shift
 		fi
 		;;
+	-P | --prefix)
+		if [ -n "$2" ]; then
+			prefix="$2"
+			shift
+			shift
+		fi
+		;;
 	*) # Default case: If no more options then break out of the loop.
 		break ;;
 	esac
 done
+
+if [[ ${dest_path} && ${prefix} ]]; then
+	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
+	exit 1
+fi
+
+if [ -z "${dest_path}" ]; then
+	if [ -z "${prefix}" ]; then
+		prefix="/usr/local"
+		# in case we're not root, just default to the home directory
+		if [ "$(id -u)" -ne 0 ]; then
+			prefix="${HOME}/.local"
+		fi
+	fi
+	dest_path="${prefix}/bin"
+	man_dest_path="${prefix}/share/man/man1"
+else
+	# dest_path is already set
+	man_dest_path="${dest_path}/../share/man/man1"
+fi
 
 set -o errexit
 set -o nounset
@@ -82,7 +103,7 @@ fi
 for file in "${dest_path}/distrobox"*; do
 	[ -e "${file}" ] && rm -i "${file}"
 done
-for file in "${dest_path}/../share/man/man1/distrobox"*; do
+for file in "${man_dest_path}/distrobox"*; do
 	[ -e "${file}" ] && rm -i "${file}"
 done
 echo "Thank you for using Distrobox. Uninstall complete."

--- a/uninstall
+++ b/uninstall
@@ -28,11 +28,11 @@ verbose=0
 #   print usage with examples.
 show_help() {
 	cat <<EOF
-uninstall -P /usr/local
+uninstall --prefix /usr/local
 
 Options:
 	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
-	--path/-p:		path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
+	--path/-p:		(DEPRECATED) path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
 EOF
@@ -85,6 +85,7 @@ if [ -z "${dest_path}" ]; then
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
 else
+	printf >&2 "Warning: --prefix/-p is deprecated. Please refer to the documentation and switch to --prefix/-P.\n"
 	# dest_path is already set
 	man_dest_path="${dest_path}/../share/man/man1"
 fi

--- a/uninstall
+++ b/uninstall
@@ -68,7 +68,7 @@ while :; do
 	esac
 done
 
-if [[ ${dest_path} && ${prefix} ]]; then
+if [[ "${dest_path}" && "${prefix}" ]]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/uninstall
+++ b/uninstall
@@ -85,7 +85,7 @@ if [ -z "${dest_path}" ]; then
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
 else
-	printf >&2 "Warning: --prefix/-p is deprecated. Please refer to the documentation and switch to --prefix/-P.\n"
+	printf >&2 "Warning: -p/--path is deprecated. Please refer to the documentation and switch to -P/--prefix.\n"
 	# dest_path is already set
 	man_dest_path="${dest_path}/../share/man/man1"
 fi

--- a/uninstall
+++ b/uninstall
@@ -69,7 +69,7 @@ while :; do
 	esac
 done
 
-if [ "${dest_path}" ] && [ "${prefix}" ]; then
+if [ -n "${dest_path}" ] && [ -n "${prefix}" ]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/uninstall
+++ b/uninstall
@@ -68,7 +68,7 @@ while :; do
 	esac
 done
 
-if [[ "${dest_path}" && "${prefix}" ]]; then
+if [[ ${dest_path} && ${prefix} ]]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi

--- a/uninstall
+++ b/uninstall
@@ -28,9 +28,10 @@ verbose=0
 #   print usage with examples.
 show_help() {
 	cat <<EOF
-uninstall -p /usr/local/bin
+uninstall -P /usr/local
 
 Options:
+	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
 	--path/-p:		path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
@@ -68,7 +69,7 @@ while :; do
 	esac
 done
 
-if [[ ${dest_path} && ${prefix} ]]; then
+if [ "${dest_path}" ] && [ "${prefix}" ]; then
 	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
 	exit 1
 fi


### PR DESCRIPTION
I have added the `--prefix` option to both installer and uninstaller.

Main installation path should now be `$prefix/bin` and man path should be `$prefix/share/man`.
`-p` still exists for backwards compatibility and both scripts make sure only "one is present".