### PR TITLE
Fix grep match of very short user or group names.

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -510,11 +510,11 @@ if ! grep -q "${container_user_name} ALL = (root) NOPASSWD:ALL" /etc/sudoers.d/s
 fi
 
 # If not existing, ensure we have a group for our user.
-if ! grep -q "${container_user_name}" /etc/group; then
+if ! grep -q "^${container_user_name}:" /etc/group; then
 	groupadd --force --gid "${container_user_gid}" "${container_user_name}"
 fi
 # Let's add our user to the container. if the user already exists, enforce properties.
-if ! grep -q "${container_user_name}" /etc/passwd; then
+if ! grep -q "^${container_user_name}:" /etc/passwd; then
 	if ! useradd \
 		--home-dir "${container_user_home}" \
 		--no-create-home \


### PR DESCRIPTION
my host linux user is a single character (aka "d"), `distrobox-init` was failing to create user and group because the character `d` matches many users and groups. This fix ensure very short usernames are handled correctly. 

I've tested it only in a Centos 7 container, but it should work on other distros.