### PR TITLE
Feature/compatibility test

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,138 @@
+---
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Prepare distros matrix
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set-matrix.outputs.targets }}
+    steps:
+
+      - uses: actions/checkout@v2
+
+      # Fetch from compatibility table all the distros supported
+      - id: set-matrix
+        run: |
+            echo "::set-output name=targets::$(grep -E 'docker.io|quay.io|ghcr|registry.|ecr.' docs/compatibility.md |
+              cut -d'|' -f 4 |
+              sed 's/<br>/\n/g' |
+              tr -d ' ' |
+              tail -n +2 |
+              jq -R -s -c 'split("\n")[:-1]')"
+
+  run:
+
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: ${{fromJSON(needs.setup.outputs.targets)}}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Ensure distrobox create works:
+      - name: Distrobox create
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox create --yes -i "${image}" --name "${container_name}"
+
+      # Ensure distrobox enter and init works:
+      - name: Distrobox enter - init
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox enter --name "${container_name}" -- whoami
+
+      # Ensure distrobox enter and init works:
+      - name: Distrobox enter - user
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          # Assert that distrobox exported binary indeed works
+          set -x
+          command_output="$(./distrobox enter --name "${container_name}" -- whoami | tr -d '\r')"
+          expected_output="$(whoami)"
+          if [ "$command_output" != "$expected_output" ]; then
+            exit 1
+          fi
+
+      # Ensure distrobox enter and init works:
+      - name: Distrobox enter - command
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          # Assert that distrobox exported binary indeed works
+          set -x
+          command_output="$(./distrobox enter --name "${container_name}" -- uname -n | tr -d '\r')"
+          expected_output="${container_name}.$(uname -n)"
+          if [ "$command_output" != "$expected_output" ]; then
+            exit 1
+          fi
+
+      # Ensure distrobox export works:
+      - name: Distrobox export
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path /tmp/
+          # Assert that distrobox exported binary indeed works
+          set -x
+          command_output="$(/tmp/uname -n | tr -d '\r')"
+          expected_output="${container_name}.$(uname -n)"
+          if [ "$command_output" != "$expected_output" ]; then
+            exit 1
+          fi
+
+      # Ensure distrobox export works:
+      - name: Distrobox export - sudo
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path /tmp/
+          # Assert that distrobox exported binary indeed works
+          set -x
+          command_output="$(/tmp/uname -n | tr -d '\r')"
+          expected_output="${container_name}.$(uname -n)"
+          if [ "$command_output" != "$expected_output" ]; then
+            exit 1
+          fi
+
+      # Ensure distrobox list works:
+      - name: Distrobox list
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox list | grep "${container_name}" | grep "${image}" | grep Up
+
+      # Ensure distrobox stop works:
+      - name: Distrobox stop
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox stop --yes "${container_name}"
+
+      # Ensure distrobox rm works:
+      - name: Distrobox rm
+        if: ${{ always() }}
+        run: |
+          image=${{ matrix.distribution }}
+          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
+          ./distrobox rm --force --name "${container_name}"

--- a/distrobox-create
+++ b/distrobox-create
@@ -237,7 +237,7 @@ fi
 #	registry.fedoraproject.org/fedora-toolbox:35 -> fedora-toolbox-35
 #	ghcr.io/void-linux/void-linux:latest-full-x86_64 -> void-linux-latest-full-x86_64
 if [ -z "${container_name}" ]; then
-	container_name="$(basename "${container_image}" | sed -E 's/:/-/g')"
+	container_name="$(basename "${container_image}" | sed -E 's/[:.]/-/g')"
 fi
 
 # We depend on a container manager let's be sure we have it

--- a/distrobox-init
+++ b/distrobox-init
@@ -251,7 +251,7 @@ if ! command -v find || ! command -v mount || ! command -v passwd ||
 		dnf install -y \
 			"${shell_pkg}" \
 			findutils \
-			ncurses-base \
+			ncurses \
 			passwd \
 			procps-ng \
 			shadow-utils \
@@ -353,7 +353,7 @@ if ! command -v find || ! command -v mount || ! command -v passwd ||
 		yum install -y \
 			"${shell_pkg}" \
 			findutils \
-			ncurses-base \
+			ncurses \
 			passwd \
 			procps \
 			shadow-utils \

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -91,7 +91,7 @@ Distrobox guests tested successfully with the following container images:
 | Debian | Testing    | docker.io/library/debian:testing <br> docker.io/library/debian:testing-backports    |
 | Debian | Unstable | docker.io/library/debian:unstable    |
 | Neurodebian | nd100 | docker.io/library/neurodebian:nd100 |
-| Fedora | 34<br>35<br>36<br>37<br>Rawhide | registry.fedoraproject.org/fedora-toolbox:34<br> docker.io/library/fedora:34<br>registry.fedoraproject.org/fedora-toolbox:35<br>docker.io/library/fedora:35<br>docker.io/library/fedora:36<br>docker.io/library/fedora:37<br>docker.io/library/fedora:rawhide    |
+| Fedora | 34<br>35<br>36<br>37<br>Rawhide | registry.fedoraproject.org/fedora-toolbox:34<br> docker.io/library/fedora:34<br>registry.fedoraproject.org/fedora-toolbox:35<br>docker.io/library/fedora:35<br>docker.io/library/fedora:36<br>registry.fedoraproject.org/fedora:37<br>docker.io/library/fedora:rawhide    |
 | Mageia | 8 | docker.io/library/mageia |
 | Opensuse | Leap | registry.opensuse.org/opensuse/leap:latest    |
 | Opensuse | Tumbleweed | registry.opensuse.org/opensuse/tumbleweed:latest <br> registry.opensuse.org/opensuse/toolbox:latest    |
@@ -102,7 +102,7 @@ Distrobox guests tested successfully with the following container images:
 | Slackware | current | docker.io/vbatts/slackware:current    |
 | Ubuntu | 14.04<br>16.04<br>18.04<br>20.04<br>21.10<br>22.04 | docker.io/library/ubuntu:14.04<br>docker.io/library/ubuntu:16.04<br>docker.io/library/ubuntu:18.04<br>docker.io/library/ubuntu:20.04<br>docker.io/library/ubuntu:21.10<br>docker.io/library/ubuntu:22.04    |
 | Kali Linux | rolling | docker.io/kalilinux/kali-rolling:latest |
-| Void Linux | | ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64 <br> ghcr.io/void-linux/void-linux:latest-thin-bb-x86_64-musl <br> ghcr.io/void-linux/void-linux:latest-full-x86_64 <br> ghcr.io/void-linux/void-linux:latest-full-x86_64-musl |
+| Void Linux | | ghcr.io/void-linux/void-linux:latest-full-x86_64 <br> ghcr.io/void-linux/void-linux:latest-full-x86_64-musl |
 | Gentoo Linux | rolling | You will have to [Build your own](distrobox_gentoo.md) to have a complete Gentoo docker image |
 
 Note however that if you use a non-toolbox preconfigured image (e.g. images pre-baked to work with https://github.com/containers/toolbox), the **first** `distrobox-enter` you'll perform

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -84,7 +84,7 @@ Distrobox guests tested successfully with the following container images:
 | AmazonLinux | 2022  | public.ecr.aws/amazonlinux/amazonlinux:2022 |
 | Archlinux     | | docker.io/library/archlinux:latest    |
 | ClearLinux |      | docker.io/library/clearlinux:latest<br>docker.io/library/clearlinux:base    |
-| CentOS | 7<br>8 | quay.io/centos/centos:7<br>quay.io/centos/centos:8  |
+| CentOS | 7 | quay.io/centos/centos:7  |
 | CentOS Stream | 8<br>9 | quay.io/centos/centos:stream8<br>quay.io/centos/centos:stream9  |
 | RedHat (UBI) | 7<br>8 | registry.access.redhat.com/ubi7/ubi<br>registry.access.redhat.com/ubi7/ubi-init<br>registry.access.redhat.com/ubi8/ubi<br>registry.access.redhat.com/ubi8/ubi-init  |
 | Debian | 8<br>9<br>10<br>11 | docker.io/library/debian:8<br>docker.io/library/debian:9<br>docker.io/library/debian:10<br>docker.io/library/debian:stable<br>docker.io/library/debian:stable-backports    |
@@ -99,7 +99,6 @@ Distrobox guests tested successfully with the following container images:
 | Rocky Linux | 8 | docker.io/rockylinux/rockylinux:8    |
 | Scientific Linux | 7 | docker.io/library/sl:7    |
 | Slackware | 14.2 | docker.io/vbatts/slackware:14.2    |
-| Slackware | current | docker.io/vbatts/slackware:current    |
 | Ubuntu | 14.04<br>16.04<br>18.04<br>20.04<br>21.10<br>22.04 | docker.io/library/ubuntu:14.04<br>docker.io/library/ubuntu:16.04<br>docker.io/library/ubuntu:18.04<br>docker.io/library/ubuntu:20.04<br>docker.io/library/ubuntu:21.10<br>docker.io/library/ubuntu:22.04    |
 | Kali Linux | rolling | docker.io/kalilinux/kali-rolling:latest |
 | Void Linux | | ghcr.io/void-linux/void-linux:latest-full-x86_64 <br> ghcr.io/void-linux/void-linux:latest-full-x86_64-musl |

--- a/tests/compatibility-test
+++ b/tests/compatibility-test
@@ -66,7 +66,9 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 image_list=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2)
-image_total=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2 | wc -l)
+image_total=$(echo "${image_list}" | wc -l)
+
+exit 1
 
 index=0
 for image in ${image_list}; do

--- a/tests/compatibility-test
+++ b/tests/compatibility-test
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
+
+verbose=0
+image_index=0
+# Dont' run this command as sudo.
+if [ "$(id -u)" -eq 0 ]; then
+	printf >&2 "Running %s as sudo is not supported.\n" "${0}"
+	printf >&2 "Please check the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\t"
+	printf >&2 "or consult the documentation page on:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	exit 1
+fi
+
+# Print usage to stdout.
+# Arguments:
+#   None
+# Outputs:
+#   print usage with examples.
+show_help() {
+	cat <<EOF
+Usage:
+
+	compatibility-test [--index X]
+
+Options:
+
+	--index/i:		from which index image to start
+	--help/-h:		show this message
+	--verbose/-v:		show more verbosity
+
+EOF
+}
+
+# Parse arguments
+while :; do
+	case $1 in
+	-h | --help)
+		# Call a "show_help" function to display a synopsis, then exit.
+		show_help
+		exit 0
+		;;
+	-v | --verbose)
+		shift
+		verbose=1
+		;;
+	-i | --index)
+		if [ -n "$2" ]; then
+			image_index="$2"
+			shift
+			shift
+		fi
+		;;
+	*) # Default case: If no more options then break out of the loop.
+		break ;;
+	esac
+done
+
+set -o errexit
+set -o nounset
+# set verbosity
+if [ "${verbose}" -ne 0 ]; then
+	set -o xtrace
+fi
+
+image_list=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2)
+image_total=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2 | wc -l)
+
+index=0
+for image in $image_list; do
+	index=$((index + 1))
+	echo "##### Image $index/$image_total - $image"
+	if [ "$index" -lt "$image_index" ]; then
+		continue
+	fi
+
+	container_name="$(basename "${image}" | sed -E 's/:/-/g')"
+	"$(dirname "${0}")"/../distrobox create --yes -i "${image}" --name "${container_name}"
+	"$(dirname "${0}")"/../distrobox enter --name "${container_name}" -- whoami
+	"$(dirname "${0}")"/../distrobox stop --yes "${container_name}"
+	"$(dirname "${0}")"/../distrobox rm --force --name "${container_name}"
+done

--- a/tests/compatibility-test
+++ b/tests/compatibility-test
@@ -69,16 +69,22 @@ image_list=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"
 image_total=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2 | wc -l)
 
 index=0
-for image in $image_list; do
+for image in ${image_list}; do
 	index=$((index + 1))
-	echo "##### Image $index/$image_total - $image"
-	if [ "$index" -lt "$image_index" ]; then
+	echo "##### Image ${index}/${image_total} - ${image}"
+	if [ "${index}" -lt "${image_index}" ]; then
 		continue
 	fi
 
 	container_name="$(basename "${image}" | sed -E 's/:/-/g')"
+	# Ensure distrobox create works:
 	"$(dirname "${0}")"/../distrobox create --yes -i "${image}" --name "${container_name}"
+	# Ensure distrobox enter and init works:
 	"$(dirname "${0}")"/../distrobox enter --name "${container_name}" -- whoami
+	# Ensure distrobox list works:
+	"$(dirname "${0}")"/../distrobox list | grep "${container_name}" | grep "${image}" | grep Up
+	# Ensure distrobox stop works:
 	"$(dirname "${0}")"/../distrobox stop --yes "${container_name}"
+	# Ensure distrobox rm works:
 	"$(dirname "${0}")"/../distrobox rm --force --name "${container_name}"
 done

--- a/tests/compatibility-test
+++ b/tests/compatibility-test
@@ -3,7 +3,8 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 verbose=0
-image_index=0
+start_index=0
+end_index=0
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
 	printf >&2 "Running %s as sudo is not supported.\n" "${0}"
@@ -27,7 +28,8 @@ Usage:
 
 Options:
 
-	--index/i:		from which index image to start
+	--start-index/si:		from which index image to start [default=0]
+	--end-index/ei:		from which index image to start [default=last]
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 
@@ -46,9 +48,16 @@ while :; do
 		shift
 		verbose=1
 		;;
-	-i | --index)
+	-si | --start-index)
 		if [ -n "$2" ]; then
-			image_index="$2"
+			start_index="$2"
+			shift
+			shift
+		fi
+		;;
+	-ei | --end-index)
+		if [ -n "$2" ]; then
+			end_index="$2"
 			shift
 			shift
 		fi
@@ -66,18 +75,22 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 image_list=$(grep -E "docker.io|quay.io|ghcr|registry.|ecr." "$(dirname "${0}")"/../docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | tail -n +2)
-image_total=$(echo "${image_list}" | wc -l)
+if [ "${end_index}" -eq 0 ]; then
+	end_index=$(echo "${image_list}" | wc -l)
+fi
 
-exit 1
-
-index=0
+progress=1
 for image in ${image_list}; do
-	index=$((index + 1))
-	echo "##### Image ${index}/${image_total} - ${image}"
-	if [ "${index}" -lt "${image_index}" ]; then
+	# POSIX SH does not support C-style loops, let's check boundaries manually.
+	if [ "${progress}" -lt "${start_index}" ]; then
+		# increase counter
+		progress=$((progress + 1))
 		continue
+	elif [ "${progress}" -gt "${end_index}" ]; then
+		break
 	fi
 
+	echo "##### Image ${progress}/${end_index} - ${image}"
 	container_name="$(basename "${image}" | sed -E 's/:/-/g')"
 	# Ensure distrobox create works:
 	"$(dirname "${0}")"/../distrobox create --yes -i "${image}" --name "${container_name}"
@@ -89,4 +102,7 @@ for image in ${image_list}; do
 	"$(dirname "${0}")"/../distrobox stop --yes "${container_name}"
 	# Ensure distrobox rm works:
 	"$(dirname "${0}")"/../distrobox rm --force --name "${container_name}"
+
+	# increase counter
+	progress=$((progress + 1))
 done


### PR DESCRIPTION
This is a pretty simplistic test, for now it implements only a `whoami` 
This will ensure that at least the `distrobox-init` process does not error out on all the distributions supported.
This will also ensure that `distrobox-rm`, `distrobox-stop` and `distrobox-list` work as expected.

The source of truth is the compatibility table in the documentation, so we ensure it is always up to date and tested fully.

For now the test is performed manually as it is quite intensive (more than 50 images to test), we will also need to find a service that can host such a large and time consuming test

Todo list:

- [ ] find other commands to test in the exec
- [ ] find a service where we can automate this