### PR TITLE
WIP: Fix/201

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -418,7 +418,7 @@ generate_command() {
 		# Check if the file exists first
 		if [ -f "${host_link}" ] && [ -r "${host_link}" ]; then
 			result_command="${result_command}
-			--volume \"${host_link}\":\"${host_link}\":ro"
+			--volume \"$(realpath "${host_link}")\":\"${host_link}\":ro"
 		fi
 	done
 


### PR DESCRIPTION
As of now, rootless docker prevents  host network, pid and ipc so we cannot do an unprivileged docker like on podman
But this means docker is running as root, and the root inside the container corresponds to the one on the host

Having passwordless sudo here can be dangerous, so let's make docker behave more similarly to how the rootless podman version works:

Let's mount /run/host, /sys, /proc and /dev as readonly, leave only selected paths as read-write like: /media /mnt /run/media /srv /tmp

This is a work to fix #201 