### PR TITLE
WIP: prevent docker root to modify stuff on host #201

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -338,15 +338,28 @@ generate_command() {
 	#
 	# Mount also the distrobox-init utility as the container entrypoint.
 	result_command="${result_command}
-		--env \"SHELL=${SHELL:-"/bin/bash"}\"
 		--env \"HOME=${container_user_home}\"
+		--env \"SHELL=${SHELL:-"/bin/bash"}\"
+		--volume /:/run/host:ro
 		--volume \"${container_user_home}\":\"${container_user_home}\":rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
-		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
-		--volume /:/run/host:rslave
-		--volume /dev:/dev:rslave
-		--volume /sys:/sys:rslave
-		--volume /tmp:/tmp:rslave"
+		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro"
+
+	rslave_mounts="/media /mnt /run/media /srv /tmp"
+	for rslave_mount in ${rslave_mounts}; do
+		# Check if the file exists first
+		if [ -e "${rslave_mount}" ]; then
+			result_command="${result_command} --volume \"${rslave_mount}\":\"${rslave_mount}\":rslave"
+		fi
+	done
+
+	ro_mounts="/dev /sys"
+	for ro_mount in ${ro_mounts}; do
+		# Check if the file exists first
+		if [ -e "${ro_mount}" ]; then
+			result_command="${result_command} --volume \"${ro_mount}\":\"${ro_mount}\":ro"
+		fi
+	done
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.

--- a/distrobox-init
+++ b/distrobox-init
@@ -400,13 +400,10 @@ done
 # We'll also bind mount READ-WRITE useful mountpoints to pass external drives and libvirt from
 # the host to the container
 HOST_MOUNTS="
-	/media
 	/mnt
 	/run/libvirt
-	/run/media
 	/run/systemd/journal
 	/run/udev
-	/srv
 	/var/lib/libvirt
 	/var/mnt"
 for host_mount in ${HOST_MOUNTS}; do


### PR DESCRIPTION
As of now, rootless docker prevents host network, pid and ipc so we cannot do an unprivileged docker like on podman
But this means docker is running as root, and the root inside the container corresponds to the one on the host

Having passwordless sudo here can be dangerous, so let's make docker behave more similarly to how the rootless podman version works:

Let's mount /run/host, /sys, /proc and /dev as readonly, leave only selected paths as read-write like: /media /mnt /run/media /srv /tmp
