### PR TITLE
WIP: support environment variables to change defaults

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -44,6 +44,9 @@ jobs:
       max-parallel: 8
       matrix:
         distribution: ${{fromJSON(needs.setup.outputs.targets)}}
+        container_manager: ["podman", "docker"]
+    env:
+      DBX_CONTAINER_MANAGER: ${{ matrix.container_manager }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -54,6 +54,7 @@ jobs:
 
       # Ensure distrobox create works:
       - name: Distrobox create
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
@@ -61,6 +62,7 @@ jobs:
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - init
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
@@ -68,12 +70,13 @@ jobs:
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - user
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- whoami | tr -d '\r')"
+          command_output="$(./distrobox enter --name "${container_name}" -- whoami | tr -d '\r' | tr -d '^@')"
           expected_output="$(whoami)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -81,12 +84,13 @@ jobs:
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - command
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- uname -n | tr -d '\r')"
+          command_output="$(./distrobox enter --name "${container_name}" -- uname -n | tr -d '\r' | tr -d '^@')"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -94,13 +98,14 @@ jobs:
 
       # Ensure distrobox export works:
       - name: Distrobox export
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path /tmp/
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(/tmp/uname -n | tr -d '\r')"
+          command_output="$(/tmp/uname -n | tr -d '\r' | tr -d '^@')"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -108,13 +113,14 @@ jobs:
 
       # Ensure distrobox export works:
       - name: Distrobox export - sudo
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path /tmp/
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(/tmp/uname -n | tr -d '\r')"
+          command_output="$(/tmp/uname -n | tr -d '\r' | tr -d '^@')"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -125,7 +131,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox list | grep "${container_name}" | grep "${image}" | grep Up
+          ./distrobox list | grep "${container_name}" | grep "${image}" | grep -E "Up|running"
 
       # Ensure distrobox stop works:
       - name: Distrobox stop

--- a/distrobox-create
+++ b/distrobox-create
@@ -23,6 +23,7 @@
 #	HOME
 #	USER
 # Optional env variables:
+#	DBX_CONTAINER_MANAGER
 #	DBX_CONTAINER_IMAGE
 #	DBX_CONTAINER_NAME
 #	DBX_NON_INTERACTIVE
@@ -44,6 +45,7 @@ container_clone=""
 container_image="${DBX_CONTAINER_IMAGE:-""}"
 container_image_default="registry.fedoraproject.org/fedora-toolbox:35"
 container_init_hook=""
+container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 container_manager_additional_flags=""
 container_name="${DBX_CONTAINER_NAME:-""}"
 container_user_custom_home=""
@@ -242,22 +244,40 @@ fi
 
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
-container_manager="podman"
+case "${container_manager}" in
+autodetect)
+	if command -v podman >/dev/null; then
+		container_manager="podman"
+	elif command -v docker >/dev/null; then
+		container_manager="docker"
+	else
+		container_manager="not_found"
+	fi
+	;;
+podman)
+	container_manager="podman"
+	;;
+docker)
+	container_manager="docker"
+	;;
+*)
+	printf >&2 "Invalid input %s.\n" "${container_manager}"
+	printf >&2 "The available choices are: 'autodetect', 'podman', 'docker'\n"
+	container_manager="not_found"
+	;;
+esac
+
 # Be sure we have a container manager to work with.
 if ! command -v "${container_manager}" >/dev/null; then
-	# If no podman, try docker.
-	container_manager="docker"
-	if ! command -v docker >/dev/null; then
-		# Error: we need at least one between docker or podman.
-		printf >&2 "Missing dependency: we need a container manager.\n"
-		printf >&2 "Please install one of podman or docker.\n"
-		printf >&2 "You can follow the documentation on:\n"
-		printf >&2 "\tman distrobox-compatibility\n"
-		printf >&2 "or:\n"
-		printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
-		if [ "${dryrun}" -eq 0 ]; then
-			exit 127
-		fi
+	# Error: we need at least one between docker or podman.
+	printf >&2 "Missing dependency: we need a container manager.\n"
+	printf >&2 "Please install one of podman or docker.\n"
+	printf >&2 "You can follow the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\n"
+	printf >&2 "or:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	if [ "${dryrun}" -eq 0 ]; then
+		exit 127
 	fi
 fi
 # add  verbose if -v is specified

--- a/distrobox-create
+++ b/distrobox-create
@@ -43,17 +43,18 @@ fi
 
 # Defaults
 container_clone=""
-container_image="${DBX_CONTAINER_IMAGE:-""}"
+container_image=""
 container_image_default="registry.fedoraproject.org/fedora-toolbox:35"
 container_init_hook=""
-container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
+container_manager="autodetect"
 container_manager_additional_flags=""
-container_name="${DBX_CONTAINER_NAME:-""}"
-container_user_custom_home="${DBX_CONTAINER_CUSTOM_HOME:-""}"
+container_name=""
+container_user_custom_home=""
 container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"
 container_user_uid="$(id -ru)"
+non_interactive=""
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -64,11 +65,29 @@ distrobox_export_path="$(cd "$(dirname "${0}")" && pwd)/distrobox-export"
 # in PATH for them.
 [ ! -e "${distrobox_entrypoint_path}" ] && distrobox_entrypoint_path="$(command -v distrobox-init)"
 [ ! -e "${distrobox_export_path}" ] && distrobox_export_path="$(command -v distrobox-export)"
-non_interactive="${DBX_NON_INTERACTIVE:-0}"
 dryrun=0
 init=0
 verbose=0
 version="1.2.14"
+
+# Source configuration files, this is done in an hierarchy so local files have
+# priority over system defaults
+# leave priority to environment variables.
+config_files="
+	/usr/share/distrobox/distrobox.conf
+	/etc/distrobox/distrobox.conf
+	${HOME}/.config/distrobox/distrobox.conf
+	${HOME}/.distroboxrc
+"
+for config_file in ${config_files}; do
+	# shellcheck disable=SC1090
+	[ -e "${config_file}" ] && . "${config_file}"
+done
+[ -n "${DBX_CONTAINER_CUSTOM_HOME}" ] && container_user_custom_home="${DBX_CONTAINER_CUSTOM_HOME}"
+[ -n "${DBX_CONTAINER_IMAGE}" ] && container_image="${DBX_CONTAINER_IMAGE}"
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
+[ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
+[ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
 
 # Print usage to stdout.
 # Arguments:
@@ -202,7 +221,7 @@ while :; do
 	*) # Default case: If no more options then break out of the loop.
 		# If we have a flagless option and container_name is not specified
 		# then let's accept argument as container_name
-		if [ -z "${container_name}" ] && [ -n "$1" ]; then
+		if [ -n "$1" ]; then
 			container_name="$1"
 			shift
 		else

--- a/distrobox-create
+++ b/distrobox-create
@@ -54,7 +54,7 @@ container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"
 container_user_uid="$(id -ru)"
-non_interactive=""
+non_interactive=0
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package

--- a/distrobox-create
+++ b/distrobox-create
@@ -23,8 +23,9 @@
 #	HOME
 #	USER
 # Optional env variables:
-#	DBX_CONTAINER_MANAGER
+#	DBX_CONTAINER_CUSTOM_HOME
 #	DBX_CONTAINER_IMAGE
+#	DBX_CONTAINER_MANAGER
 #	DBX_CONTAINER_NAME
 #	DBX_NON_INTERACTIVE
 
@@ -48,7 +49,7 @@ container_init_hook=""
 container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 container_manager_additional_flags=""
 container_name="${DBX_CONTAINER_NAME:-""}"
-container_user_custom_home=""
+container_user_custom_home="${DBX_CONTAINER_CUSTOM_HOME:-""}"
 container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -47,7 +47,9 @@ container_command="${SHELL:-"bash"}"
 container_command="$(basename "${container_command}") -l"
 container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 container_manager_additional_flags=""
-container_name="${DBX_CONTAINER_NAME:-"fedora-toolbox-35"}"
+container_name="${DBX_CONTAINER_NAME:-""}"
+container_name_default="fedora-toolbox-35"
+
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -206,6 +208,10 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
+fi
+# Set default container_name if no one is specified.
+if [ -z "${container_name}" ]; then
+	container_name="${container_name_default}"
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -41,14 +41,13 @@ fi
 
 # Defaults
 container_command="${SHELL:-"bash"}"
+container_manager="autodetect"
+container_name="fedora-toolbox-35"
 # Work around for shells that are not in the container's file system, nor PATH.
 # For example in hosts that do not follow FHS, like NixOS or for shells in custom
 # exotic paths.
 container_command="$(basename "${container_command}") -l"
-container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 container_manager_additional_flags=""
-container_name="${DBX_CONTAINER_NAME:-""}"
-container_name_default="fedora-toolbox-35"
 
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
@@ -59,6 +58,22 @@ dryrun=0
 headless=0
 verbose=0
 version="1.2.14"
+
+# Source configuration files, this is done in an hierarchy so local files have
+# priority over system defaults
+# leave priority to environment variables.
+config_files="
+	/usr/share/distrobox/distrobox.conf
+	/etc/distrobox/distrobox.conf
+	${HOME}/.config/distrobox/distrobox.conf
+	${HOME}/.distroboxrc
+"
+for config_file in ${config_files}; do
+	# shellcheck disable=SC1090
+	[ -e "${config_file}" ] && . "${config_file}"
+done
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
+[ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 
 # Print usage to stdout.
 # Arguments:
@@ -136,7 +151,7 @@ while :; do
 	*) # Default case: If no more options then break out of the loop.
 		# If we have a flagless option and container_name is not specified
 		# then let's accept argument as container_name
-		if [ -z "${container_name}" ] && [ -n "$1" ]; then
+		if [ -n "$1" ]; then
 			container_name="$1"
 			shift
 		else
@@ -208,10 +223,6 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
-fi
-# Set default container_name if no one is specified.
-if [ -z "${container_name}" ]; then
-	container_name="${container_name_default}"
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -25,6 +25,7 @@
 #	SHELL
 # Optional env variables:
 #	DBX_CONTAINER_NAME
+#	DBX_CONTAINER_MANAGER
 
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
@@ -44,9 +45,9 @@ container_command="${SHELL:-"bash"}"
 # For example in hosts that do not follow FHS, like NixOS or for shells in custom
 # exotic paths.
 container_command="$(basename "${container_command}") -l"
+container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 container_manager_additional_flags=""
-container_name="${DBX_CONTAINER_NAME:-""}"
-container_name_default="fedora-toolbox-35"
+container_name="${DBX_CONTAINER_NAME:-"fedora-toolbox-35"}"
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -152,22 +153,40 @@ fi
 
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
-container_manager="podman"
+case "${container_manager}" in
+autodetect)
+	if command -v podman >/dev/null; then
+		container_manager="podman"
+	elif command -v docker >/dev/null; then
+		container_manager="docker"
+	else
+		container_manager="not_found"
+	fi
+	;;
+podman)
+	container_manager="podman"
+	;;
+docker)
+	container_manager="docker"
+	;;
+*)
+	printf >&2 "Invalid input %s.\n" "${container_manager}"
+	printf >&2 "The available choices are: 'autodetect', 'podman', 'docker'\n"
+	container_manager="not_found"
+	;;
+esac
+
 # Be sure we have a container manager to work with.
 if ! command -v "${container_manager}" >/dev/null; then
-	# If no podman, try docker.
-	container_manager="docker"
-	if ! command -v docker >/dev/null; then
-		# Error: we need at least one between docker or podman.
-		printf >&2 "Missing dependency: we need a container manager.\n"
-		printf >&2 "Please install one of podman or docker.\n"
-		printf >&2 "You can follow the documentation on:\n"
-		printf >&2 "\tman distrobox-compatibility\n"
-		printf >&2 "or:\n"
-		printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
-		if [ "${dryrun}" -eq 0 ]; then
-			exit 127
-		fi
+	# Error: we need at least one between docker or podman.
+	printf >&2 "Missing dependency: we need a container manager.\n"
+	printf >&2 "Please install one of podman or docker.\n"
+	printf >&2 "You can follow the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\n"
+	printf >&2 "or:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	if [ "${dryrun}" -eq 0 ]; then
+		exit 127
 	fi
 fi
 # Small performance optimization, using podman socket shaves
@@ -187,10 +206,6 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
-fi
-# Set default container_name if no one is specified.
-if [ -z "${container_name}" ]; then
-	container_name="${container_name_default}"
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-init
+++ b/distrobox-init
@@ -512,7 +512,6 @@ if ! grep -q "^${container_user_name}:" /etc/passwd; then
 	if ! useradd \
 		--home-dir "${container_user_home}" \
 		--no-create-home \
-		--badname \
 		--shell "${SHELL:-"/bin/bash"}" \
 		--uid "${container_user_uid}" \
 		--gid "${container_user_gid}" \

--- a/distrobox-list
+++ b/distrobox-list
@@ -35,7 +35,22 @@ fi
 # Defaults
 verbose=0
 version="1.2.14"
-container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
+container_manager="autodetect"
+
+# Source configuration files, this is done in an hierarchy so local files have
+# priority over system defaults
+# leave priority to environment variables.
+config_files="
+	/usr/share/distrobox/distrobox.conf
+	/etc/distrobox/distrobox.conf
+	${HOME}/.config/distrobox/distrobox.conf
+	${HOME}/.distroboxrc
+"
+for config_file in ${config_files}; do
+	# shellcheck disable=SC1090
+	[ -e "${config_file}" ] && . "${config_file}"
+done
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 
 # Print usage to stdout.
 # Arguments:

--- a/distrobox-list
+++ b/distrobox-list
@@ -19,6 +19,8 @@
 # along with distrobox; if not, see <http://www.gnu.org/licenses/>.
 
 # POSIX
+# Optional env variables:
+#	DBX_CONTAINER_MANAGER
 
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
@@ -33,6 +35,7 @@ fi
 # Defaults
 verbose=0
 version="1.2.14"
+container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
 
 # Print usage to stdout.
 # Arguments:
@@ -89,23 +92,40 @@ fi
 
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
-container_manager="podman"
-# Be sure we have a container manager to work with.
-if ! command -v podman >/dev/null; then
-	# If no podman, try docker.
-	container_manager="docker"
-	if ! command -v docker >/dev/null; then
-		# Error: we need at least one between docker or podman.
-		printf >&2 "Missing dependency: we need a container manager.\n"
-		printf >&2 "Please install one of podman or docker.\n"
-		printf >&2 "You can follow the documentation on:\n"
-		printf >&2 "\tman distrobox-compatibility\n"
-		printf >&2 "or:\n"
-		printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
-		exit 127
+case "${container_manager}" in
+autodetect)
+	if command -v podman >/dev/null; then
+		container_manager="podman"
+	elif command -v docker >/dev/null; then
+		container_manager="docker"
+	else
+		container_manager="not_found"
 	fi
-fi
+	;;
+podman)
+	container_manager="podman"
+	;;
+docker)
+	container_manager="docker"
+	;;
+*)
+	printf >&2 "Invalid input %s.\n" "${container_manager}"
+	printf >&2 "The available choices are: 'autodetect', 'podman', 'docker'\n"
+	container_manager="not_found"
+	;;
+esac
 
+# Be sure we have a container manager to work with.
+if ! command -v "${container_manager}" >/dev/null; then
+	# Error: we need at least one between docker or podman.
+	printf >&2 "Missing dependency: we need a container manager.\n"
+	printf >&2 "Please install one of podman or docker.\n"
+	printf >&2 "You can follow the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\n"
+	printf >&2 "or:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	exit 127
+fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -19,6 +19,10 @@
 # along with distrobox; if not, see <http://www.gnu.org/licenses/>.
 
 # POSIX
+# Optional env variables:
+#   DBX_CONTAINER_NAME
+#   DBX_NON_INTERACTIVE
+#	DBX_CONTAINER_MANAGER
 
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
@@ -31,9 +35,10 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Defaults
-container_name="${DB_CONTAINER_NAME:-""}"
-force=0
+container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
+container_name="${DBX_CONTAINER_NAME:-""fedora-toolbox-35}"
 non_interactive="${DBX_NON_INTERACTIVE:-0}"
+force=0
 verbose=0
 version="1.2.14"
 
@@ -121,21 +126,39 @@ fi
 
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
-container_manager="podman"
-# Be sure we have a container manager to work with.
-if ! command -v podman >/dev/null; then
-	# If no podman, try docker.
-	container_manager="docker"
-	if ! command -v docker >/dev/null; then
-		# Error: we need at least one between docker or podman.
-		printf >&2 "Missing dependency: we need a container manager.\n"
-		printf >&2 "Please install one of podman or docker.\n"
-		printf >&2 "You can follow the documentation on:\n"
-		printf >&2 "\tman distrobox-compatibility\n"
-		printf >&2 "or:\n"
-		printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
-		exit 127
+case "${container_manager}" in
+autodetect)
+	if command -v podman >/dev/null; then
+		container_manager="podman"
+	elif command -v docker >/dev/null; then
+		container_manager="docker"
+	else
+		container_manager="not_found"
 	fi
+	;;
+podman)
+	container_manager="podman"
+	;;
+docker)
+	container_manager="docker"
+	;;
+*)
+	printf >&2 "Invalid input %s.\n" "${container_manager}"
+	printf >&2 "The available choices are: 'autodetect', 'podman', 'docker'\n"
+	container_manager="not_found"
+	;;
+esac
+
+# Be sure we have a container manager to work with.
+if ! command -v "${container_manager}" >/dev/null; then
+	# Error: we need at least one between docker or podman.
+	printf >&2 "Missing dependency: we need a container manager.\n"
+	printf >&2 "Please install one of podman or docker.\n"
+	printf >&2 "You can follow the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\n"
+	printf >&2 "or:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	exit 127
 fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -20,9 +20,9 @@
 
 # POSIX
 # Optional env variables:
+#	DBX_CONTAINER_MANAGER
 #   DBX_CONTAINER_NAME
 #   DBX_NON_INTERACTIVE
-#	DBX_CONTAINER_MANAGER
 
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
@@ -114,9 +114,6 @@ while :; do
 		;;
 	esac
 done
-# Ensure the foundamental variables are set and not empty, we will not proceed if
-# they are not all set.
-[ -z "${container_name}" ] && printf "Error: Invalid arguments, missing container name\n" && exit 2
 
 set -o errexit
 set -o nounset

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -36,7 +36,8 @@ fi
 
 # Defaults
 container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
-container_name="${DBX_CONTAINER_NAME:-""fedora-toolbox-35}"
+container_name="${DBX_CONTAINER_NAME:-""}"
+container_name_default="fedora-toolbox-35"
 non_interactive="${DBX_NON_INTERACTIVE:-0}"
 force=0
 verbose=0
@@ -163,6 +164,10 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
+fi
+# Set default container_name if no one is specified.
+if [ -z "${container_name}" ]; then
+	container_name="${container_name_default}"
 fi
 
 # Inspect the container we're working with.

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -35,13 +35,29 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Defaults
-container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
-container_name="${DBX_CONTAINER_NAME:-""}"
-container_name_default="fedora-toolbox-35"
-non_interactive="${DBX_NON_INTERACTIVE:-0}"
+container_manager="autodetect"
+container_name="fedora-toolbox-35"
 force=0
+non_interactive=""
 verbose=0
 version="1.2.14"
+
+# Source configuration files, this is done in an hierarchy so local files have
+# priority over system defaults
+# leave priority to environment variables.
+config_files="
+	/usr/share/distrobox/distrobox.conf
+	/etc/distrobox/distrobox.conf
+	${HOME}/.config/distrobox/distrobox.conf
+	${HOME}/.distroboxrc
+"
+for config_file in ${config_files}; do
+	# shellcheck disable=SC1090
+	[ -e "${config_file}" ] && . "${config_file}"
+done
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
+[ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
+[ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
 
 # Print usage to stdout.
 # Arguments:
@@ -105,7 +121,7 @@ while :; do
 	*) # Default case: If no more options then break out of the loop.
 		# If we have a flagless option and container_name is not specified
 		# then let's accept argument as container_name
-		if [ -z "${container_name}" ] && [ -n "$1" ]; then
+		if [ -n "$1" ]; then
 			container_name="$1"
 			shift
 		else
@@ -161,10 +177,6 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
-fi
-# Set default container_name if no one is specified.
-if [ -z "${container_name}" ]; then
-	container_name="${container_name_default}"
 fi
 
 # Inspect the container we're working with.

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -38,7 +38,7 @@ fi
 container_manager="autodetect"
 container_name="fedora-toolbox-35"
 force=0
-non_interactive=""
+non_interactive=0
 verbose=0
 version="1.2.14"
 

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -37,7 +37,7 @@ fi
 # Defaults
 container_manager="autodetect"
 container_name="fedora-toolbox-35"
-non_interactive=""
+non_interactive=0
 verbose=0
 version="1.2.14"
 

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -36,7 +36,8 @@ fi
 
 # Defaults
 container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
-container_name="${DBX_CONTAINER_NAME:-"fedora-toolbox-35"}"
+container_name="${DBX_CONTAINER_NAME:-""}"
+container_name_default="fedora-toolbox-35"
 non_interactive="${DBX_NON_INTERACTIVE:-0}"
 verbose=0
 version="1.2.14"
@@ -158,6 +159,10 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
+fi
+# Set default container_name if no one is specified.
+if [ -z "${container_name}" ]; then
+	container_name="${container_name_default}"
 fi
 
 # Inspect the container we're working with.

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -35,12 +35,28 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Defaults
-container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
-container_name="${DBX_CONTAINER_NAME:-""}"
-container_name_default="fedora-toolbox-35"
-non_interactive="${DBX_NON_INTERACTIVE:-0}"
+container_manager="autodetect"
+container_name="fedora-toolbox-35"
+non_interactive=""
 verbose=0
 version="1.2.14"
+
+# Source configuration files, this is done in an hierarchy so local files have
+# priority over system defaults
+# leave priority to environment variables.
+config_files="
+	/usr/share/distrobox/distrobox.conf
+	/etc/distrobox/distrobox.conf
+	${HOME}/.config/distrobox/distrobox.conf
+	${HOME}/.distroboxrc
+"
+for config_file in ${config_files}; do
+	# shellcheck disable=SC1090
+	[ -e "${config_file}" ] && . "${config_file}"
+done
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
+[ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
+[ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
 
 # Print usage to stdout.
 # Arguments:
@@ -100,7 +116,7 @@ while :; do
 	*) # Default case: If no more options then break out of the loop.
 		# If we have a flagless option and container_name is not specified
 		# then let's accept argument as container_name
-		if [ -z "${container_name}" ] && [ -n "$1" ]; then
+		if [ -n "$1" ]; then
 			container_name="$1"
 			shift
 		else
@@ -156,10 +172,6 @@ fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then
 	container_manager="${container_manager} --log-level debug"
-fi
-# Set default container_name if no one is specified.
-if [ -z "${container_name}" ]; then
-	container_name="${container_name_default}"
 fi
 
 # Inspect the container we're working with.

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -19,6 +19,10 @@
 # along with distrobox; if not, see <http://www.gnu.org/licenses/>.
 
 # POSIX
+# Optional env variables:
+#   DBX_CONTAINER_NAME
+#   DBX_NON_INTERACTIVE
+#	DBX_CONTAINER_MANAGER
 
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
@@ -31,7 +35,8 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Defaults
-container_name="${DB_CONTAINER_NAME:-""}"
+container_manager="${DBX_CONTAINER_MANAGER:-"autodetect"}"
+container_name="${DBX_CONTAINER_NAME:-"fedora-toolbox-35"}"
 non_interactive="${DBX_NON_INTERACTIVE:-0}"
 verbose=0
 version="1.2.14"
@@ -116,21 +121,39 @@ fi
 
 # We depend on a container manager let's be sure we have it
 # First we use podman, else docker
-container_manager="podman"
-# Be sure we have a container manager to work with.
-if ! command -v podman >/dev/null; then
-	# If no podman, try docker.
-	container_manager="docker"
-	if ! command -v docker >/dev/null; then
-		# Error: we need at least one between docker or podman.
-		printf >&2 "Missing dependency: we need a container manager.\n"
-		printf >&2 "Please install one of podman or docker.\n"
-		printf >&2 "You can follow the documentation on:\n"
-		printf >&2 "\tman distrobox-compatibility\n"
-		printf >&2 "or:\n"
-		printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
-		exit 127
+case "${container_manager}" in
+autodetect)
+	if command -v podman >/dev/null; then
+		container_manager="podman"
+	elif command -v docker >/dev/null; then
+		container_manager="docker"
+	else
+		container_manager="not_found"
 	fi
+	;;
+podman)
+	container_manager="podman"
+	;;
+docker)
+	container_manager="docker"
+	;;
+*)
+	printf >&2 "Invalid input %s.\n" "${container_manager}"
+	printf >&2 "The available choices are: 'autodetect', 'podman', 'docker'\n"
+	container_manager="not_found"
+	;;
+esac
+
+# Be sure we have a container manager to work with.
+if ! command -v "${container_manager}" >/dev/null; then
+	# Error: we need at least one between docker or podman.
+	printf >&2 "Missing dependency: we need a container manager.\n"
+	printf >&2 "Please install one of podman or docker.\n"
+	printf >&2 "You can follow the documentation on:\n"
+	printf >&2 "\tman distrobox-compatibility\n"
+	printf >&2 "or:\n"
+	printf >&2 "\thttps://github.com/89luca89/distrobox/blob/main/docs/compatibility.md\n"
+	exit 127
 fi
 # add  verbose if -v is specified
 if [ "${verbose}" -ne 0 ]; then

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -20,9 +20,9 @@
 
 # POSIX
 # Optional env variables:
+#	DBX_CONTAINER_MANAGER
 #   DBX_CONTAINER_NAME
 #   DBX_NON_INTERACTIVE
-#	DBX_CONTAINER_MANAGER
 
 # Dont' run this command as sudo.
 if [ "$(id -u)" -eq 0 ]; then
@@ -109,9 +109,6 @@ while :; do
 		;;
 	esac
 done
-# Ensure the foundamental variables are set and not empty, we will not proceed if
-# they are not all set.
-[ -z "${container_name}" ] && printf "Error: Invalid arguments, missing container name\n" && exit 2
 
 set -o errexit
 set -o nounset

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ graphical apps (X11/Wayland), and audio.
   * [Inside the distrobox](#inside-the-distrobox)
     + [distrobox-export](usage/distrobox-export.md)
     + [distrobox-init](usage/distrobox-init.md)
+  * [Configure distrobox](#configure-distrobox) 
 - [Useful tips](useful_tips.md)
     + [Execute complex commands directly from distrobox-enter](useful_tips.md#execute-complex-commands-directly-from-distrobox-enter)
     + [Create a distrobox with a custom HOME directory](useful_tips.md#create-a-distrobox-with-a-custom-home-directory)
@@ -158,31 +159,6 @@ That said, it is in the works to implement some sort of decoupling with the host
 
 ---
 
-# Installation
-
-If you like to live your life dangerously, you can trust me and simply run this in your terminal:
-
-`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh`
-
-or if you want to select a custom directory to install without sudo:
-
-`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local`
-
-Else you can clone the project using `git clone` or using the latest release [HERE](https://github.com/89luca89/distrobox/releases/latest).
-
-Enter the directory and run `./install`, by default it will attempt to install in `~/.local` but if you run the script as root, it will default to `/usr/local`. You can specify a custom directory with the `--prefix` flag such as `./install --prefix ~/.distrobox`. 
-
-Prefix explained: main distrobox files get installed to `${prefix}/bin` whereas the manpages get installed to `${prefix}/share/man`.
-
-Or check the [Host Distros](compatibility.md#host-distros) compatibility list for distro-specific instructions.
-
-## Dependencies
-
-Distrobox depends on a container manager to work, you can choose to install either podman or docker.
-Please look in the [Compatibility Table](compatibility.md#host-distros) for your distribution notes.
-
----
-
 # Basic usage
 
 Create a new distrobox:
@@ -210,6 +186,58 @@ Remove a distrobox
 `distrobox rm test`
 
 You can check [HERE for more advanced usage](usage/usage.md) and check a [comprehensive list of useful tips HERE](useful_tips.md)
+
+# Configure Distrobox
+
+Configuration files can be placed in the following paths, from the least important
+to the most important:
+
+- /usr/share/distrobox/distrobox.conf
+- /etc/distrobox/distrobox.conf
+- ${HOME}/.config/distrobox/distrobox.conf
+- ${HOME}/.distroboxrc
+
+Example configuration file:
+
+```conf
+container_user_custom_home="/home/.local/share/container-home-test"
+container_image="registry.opensuse.org/opensuse/toolbox:latest"
+container_manager="docker"
+container_name="test-name-1"
+non_interactive="1"
+```
+
+Alternatively it is possible to specify preferences using ENV variables:
+
+- DBX_CONTAINER_MANAGER
+- DBX_CONTAINER_IMAGE
+- DBX_CONTAINER_NAME
+- DBX_NON_INTERACTIVE
+
+---
+
+# Installation
+
+If you like to live your life dangerously, you can trust me and simply run this in your terminal:
+
+`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh`
+
+or if you want to select a custom directory to install without sudo:
+
+`curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local`
+
+Else you can clone the project using `git clone` or using the latest release [HERE](https://github.com/89luca89/distrobox/releases/latest).
+
+Enter the directory and run `./install`, by default it will attempt to install in `~/.local` but if you run the script as root, it will default to `/usr/local`. You can specify a custom directory with the `--prefix` flag such as `./install --prefix ~/.distrobox`. 
+
+Prefix explained: main distrobox files get installed to `${prefix}/bin` whereas the manpages get installed to `${prefix}/share/man`.
+
+Or check the [Host Distros](compatibility.md#host-distros) compatibility list for distro-specific instructions.
+
+## Dependencies
+
+Distrobox depends on a container manager to work, you can choose to install either podman or docker.
+Please look in the [Compatibility Table](compatibility.md#host-distros) for your distribution notes.
 
 ---
 


### PR DESCRIPTION
Implement use of environment variables to change defaults like:

 - container manager
 - default image to use
 - default name to use
 - default custom home to use
 - interactivity

Variables will be respectively:

- DBX_CONTAINER_CUSTOM_HOME
- DBX_CONTAINER_MANAGER
- DBX_CONTAINER_IMAGE
- DBX_CONTAINER_NAME
- DBX_NON_INTERACTIVE

This work will open support for future configuration rc-style files,
which can be simply sourced.

For now this will ensure the possibility to alter the defaults using
environment files, lowering the need to use flags in normal use.

---

Simple use:

Add this to your ~/.profile

```sh
export DBX_CONTAINER_IMAGE="ubuntu:22.04"
export DBX_CONTAINER_MANAGER="docker"
export DBX_CONTAINER_NAME="test-env"
export DBX_CONTAINER_CUSTOM_HOME=/tmp/test-home
```

Now you can simply use:

- distrobox create
- distrobox enter
- distrobox rm
- distrobox stop

without having to specify your custom name or image, and all of them
will be automatically executed with docker, even if podman is present.

This work is an initial implementation for #193