### PR TITLE
fix: use container's $PATH when entering

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -243,11 +243,21 @@ generate_command() {
 		result_command="${result_command} --env=\"${i}\""
 	done
 
+	# Start with the $PATH set in the container's config
+	container_paths="${container_PATH}"
 	# Ensure the standard FHS program paths are in PATH environment
 	standard_paths="/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin"
-	container_paths="${PATH}"
-	# add to the PATH only after the host's paths, and only if not already present.
+	# add to the PATH after the existing paths, and only if not already present
 	for standard_path in ${standard_paths}; do
+		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+			container_paths="${container_paths}:${standard_path}"
+		fi
+	done
+	# Ensure the $PATH entries from the host are appended as well
+	for standard_path in $(
+		IFS=:
+		for p in ${PATH}; do echo "${p}"; done
+	); do
 		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
@@ -300,8 +310,11 @@ if [ "${dryrun}" -ne 0 ]; then
 fi
 
 # Inspect the container we're working with.
-container_status="$(${container_manager} inspect --type container \
-	"${container_name}" --format '{{.State.Status}}')"
+container_status=unknown
+container_PATH="${PATH}"
+eval "$(${container_manager} inspect --type container "${container_name}" --format \
+	'container_status={{.State.Status}};
+	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_PATH={{slice . 5 | printf "%q"}}{{end}}{{end}}')"
 container_exists="$?"
 # Does the container exists? check if inspect reported errors
 if [ "${container_exists}" -gt 0 ]; then


### PR DESCRIPTION
The PATH fixes in 6b60c73999c5147f732a1f9933d0b52d7d090161 use the
host's $PATH instead of the $PATH defined in the container.  This
change fixes that by inspecting the container and parsing $PATH
out of its environment.  The inspect was already being done so
this shouldn't be a signficiant performance impact.  Future
features may desire further information out of the inspect
invocation and the parsing method can be extended.

The container's $PATH is merged with the host $PATH and the
standard set of binary paths as the existing logic uses.