### PR TITLE
Fix compatibility with init containers

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -58,7 +58,15 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox create --yes -i "${image}" --name "${container_name}"
+          case "$CURRENT_DIR" in
+            *init*)
+              echo "SYSTEMD DETECTED: creating container with --init..."
+              ./distrobox create --yes -i "${image}" --name "${container_name}" --init
+              ;;
+            *)
+              ./distrobox create --yes -i "${image}" --name "${container_name}"
+              ;;
+          esac
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - init
@@ -66,7 +74,14 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter --name "${container_name}" -- whoami
+          case "$CURRENT_DIR" in
+            *init*)
+              echo "SYSTEMD DETECTED: performing systemctl check..."
+              ./distrobox enter --name "${container_name}" -- systemctl status
+              ;;
+            *)
+              ./distrobox enter --name "${container_name}" -- whoami
+              ;;
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - user

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          case "$CURRENT_DIR" in
+          case "${container_name}" in
             *init*)
               echo "SYSTEMD DETECTED: creating container with --init..."
               ./distrobox create --yes -i "${image}" --name "${container_name}" --init
@@ -74,7 +74,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          case "$CURRENT_DIR" in
+          case "${container_name}" in
             *init*)
               echo "SYSTEMD DETECTED: performing systemctl check..."
               ./distrobox enter --name "${container_name}" -- systemctl status
@@ -82,6 +82,7 @@ jobs:
             *)
               ./distrobox enter --name "${container_name}" -- whoami
               ;;
+          esac
 
       # Ensure distrobox enter and init works:
       - name: Distrobox enter - user

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -77,7 +77,7 @@ jobs:
           case "${container_name}" in
             *init*)
               echo "SYSTEMD DETECTED: performing systemctl check..."
-              ./distrobox enter --name "${container_name}" -- systemctl status
+              ./distrobox enter --name "${container_name}" -- systemctl status --no-pager
               ;;
             *)
               ./distrobox enter --name "${container_name}" -- whoami
@@ -118,10 +118,10 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path /tmp/
+          ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path ${HOME}/
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(/tmp/uname -n | tr -d '\r' | tr -d '^@')"
+          command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -133,10 +133,10 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path /tmp/
+          ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path ${HOME}/
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(/tmp/uname -n | tr -d '\r' | tr -d '^@')"
+          command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1

--- a/distrobox-create
+++ b/distrobox-create
@@ -470,6 +470,10 @@ generate_command() {
 		--ulimit host
 		--annotation run.oci.keep_original_groups=1
 		--mount type=devpts,destination=/dev/pts"
+		if [ "${init}" -eq 1 ]; then
+			result_command="${result_command}
+				--systemd=always"
+		fi
 	fi
 
 	# Add additional flags


### PR DESCRIPTION
Fix #215

Right now systemd integration works only on docker, on podman it will
fail.
This is because docker daemon, running as root, has access to
/sys/fs/cgroup, while podman (rootless) does not.
Podman has a functionality to set up cgroups so that they work in
rootless mode as explained here: https://www.redhat.com/sysadmin/improved-systemd-podman

Right now the system is not triggered because it only checks if
entrypoint are `/sbin/init` or `/usr/bin/systemd`.

To fix this, let's force the use of systemd mode on podman if we're
using `--init`.

This problem went also undetected on the new CI as the `init` images are
tested as normal images. Let's also fix this and test create/enter on
init images using systemd commands.