### PR TITLE
init: Allow all package manager checks to run

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -464,9 +464,11 @@ if [ -d "/usr/lib/rpm/macros.d/" ]; then
 %_netsharedpath ${net_mounts}
 EOF
 
+fi
+
 # In case of an DEB distro, we can specify that our bind_mount directories
 # have to be ignored. This prevents conflicts during package installations.
-elif [ -d "/etc/dpkg/dpkg.cfg.d/" ]; then
+if [ -d "/etc/dpkg/dpkg.cfg.d/" ]; then
 	# Loop through all the environment vars
 	# and export them to the container.
 	set +o xtrace
@@ -487,7 +489,9 @@ DPkg::Pre-Invoke {"if mountpoint /var/log/journal; then umount /var/log/journal;
 DPkg::Post-Invoke {"if [ -e /run/host/var/log/journal ]; then mount --rbind -o ro /run/host/var/log/journal /var/log/journal; fi";};
 EOF
 	fi
-elif [ -d "/usr/share/libalpm/scripts" ]; then
+fi
+
+if [ -d "/usr/share/libalpm/scripts" ]; then
 	set +o xtrace
 	printf "#!/bin/sh\n" > /usr/share/libalpm/scripts/00_distrobox_pre_hook.sh
 	printf "#!/bin/sh\n" > /usr/share/libalpm/scripts/00_distrobox_post_hook.sh


### PR DESCRIPTION


The problem is that a user might have the first two directories on Arch
Linux if they have installed the `rpm` and `dpkg` commands respectively.
While that seems odd on the surface, these tools are useful for building
packages for `rpm` or `dpkg`-based distributions on Arch Linux, such as the
Linux kernel, which has `bindeb-pkg` and `binrpm-pkg` targets to build a
`.deb` and `.rpm` package respectively, which does not require a Debian or
Fedora host.

As a result of the `rpm` and `dpkg` directories being checked first, the
third else if clause never gets executed in the scenario described
above. Move the libalpm check to the beginning so that `pacman`-based
images benefit from the new change regardless of `rpm` and `dpkg` being
installed. While here, add a comment similar to the other checks.

`distrobox-init` checks for three directories to make decisions based on
what package manager is being used in the following order:

```
/usr/lib/rpm/macros.d
/etc/dpkg/dpkg.cfg.d
/usr/share/libalpm/scripts
```

The problem is that a user might have the first two directories on Arch
Linux if they have installed the `rpm-tools` and `dpkg` packages
respectively.  While that seems odd on the surface, these tools are
useful for building packages for `rpm` or `dpkg`-based distributions on
Arch Linux, such as the Linux kernel, which has `bindeb-pkg` and
`binrpm-pkg` targets to build a `.deb` and `.rpm` package respectively,
which does not require a Debian or Fedora host. As a result of the `rpm`
and `dpkg` directories being checked first, the third else if clause
never gets executed in the scenario described above.

Instead of making all these if statements mutually exclusive, allow them
all to be run, which should not impact anything during runtime, as only
one package manager will actually be used within the container. Arch
Linux explicitly notes this when installing the `dpkg` and `rpm-tools`
packages:

https://github.com/archlinux/svntogit-community/blob/55c1554978e24cdc5c53d1265a211e5c9dc72a0b/trunk/dpkg.install
https://github.com/archlinux/svntogit-community/blob/13188cb24c4c2ee318f1efad3281e44c6516fde1/trunk/rpm-tools.install

While here, add a comment similar to the other checks.