### PR TITLE
[DRAFT] Don't mount host $HOME if custom home specified

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -379,8 +379,6 @@ generate_command() {
 	# Mount also the distrobox-init utility as the container entrypoint.
 	result_command="${result_command}
 		--env \"SHELL=${SHELL:-"/bin/bash"}\"
-		--env \"HOME=${container_user_home}\"
-		--volume \"${container_user_home}\":\"${container_user_home}\":rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
 		--volume /:/run/host:rslave
@@ -421,13 +419,17 @@ generate_command() {
 
 	# If we have a custom home to use,
 	#	1- override the HOME env variable
-	#	2- expor the DISTROBOX_HOST_HOME env variable pointing to original HOME
-	# 	3- mount the custom home inside the container.
+	# 	2- mount the custom home inside the container.
 	if [ -n "${container_user_custom_home}" ]; then
 		result_command="${result_command}
 		--env \"HOME=${container_user_custom_home}\"
 		--env \"DISTROBOX_HOST_HOME=${container_user_home}\"
 		--volume ${container_user_custom_home}:${container_user_custom_home}:rslave"
+	else
+		# No custom home -> mount original home dir from host
+		result_command="${result_command}
+		--env \"HOME=${container_user_home}\"
+		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
 	fi
 
 	# Mount also the /var/home dir on ostree based systems

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -251,11 +251,23 @@ generate_command() {
 	# Since we are entering from host, drop at workdir through '/run/host'
 	# which represents host's root inside container. Any directory on host
 	# even if not explicitly mounted is bound to exist under /run/host.
-	# Since user $HOME is very likely present in container, enter there directly
-	# to avoid confusing the user about shifted paths.
+	# $HOME variable is very likely present in container.  It is either equal
+	# to the user's normal $HOME on host, or a custom dir specified when the
+	# container was created.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
-	workdir="$(echo "${PWD:-${HOME:-"/"}}" | sed -e 's/"/\\\"/g')"
-	if [ -n "${workdir##*"${HOME}"*}" ]; then
+
+	# Find $HOME as it is defined in the container (could be a custom home)
+	local home=$(${container_manager} inspect --type container --format='{{.Config.Env}}' "${container_name}" \
+		| sed 's/ /\n/g' | awk '/^HOME=/' | cut -d= -f 2)
+
+	# Custom home specified?  Let's then start there.
+	if [ "$home" != "$HOME" ] ; then
+		workdir="$(echo "$home" | sed -e 's/"/\\\"/g')"
+	else
+		workdir="$(echo "${PWD:-${home:-"/"}}" | sed -e 's/"/\\\"/g')"
+	fi
+
+	if [ -n "${workdir##*"${home}"*}" ]; then
 		workdir="/run/host/${workdir}"
 	fi
 	result_command="${result_command}


### PR DESCRIPTION
This is more of a discussion item still but I felt some code might be easier to discuss around.  Let me know if you want a discussion Issue instead.

----

I prefer that $HOME isn't mounted if a custom home was specified.

[Choosing the --workdir seems not perfect](https://github.com/89luca89/distrobox/blob/bf7c0ba556f244c33d8d81156c54e1e0d8f79b39/distrobox-enter#L249) (in both **main**, and in this PR), but in my view it should at least not be host $HOME by default, if another HOME has been specified...

Ref: 
- https://github.com/89luca89/distrobox/issues/70

...noted one of the problems that can still appear, that --[workdir set to a non-existing location will cause an error](https://github.com/89luca89/distrobox/issues/70#issuecomment-1002889436).

Sandboxing apps and isolating them from personal files in $HOME is actually my main reason for trying out distrobox, but it's [not the primary direction of the project](https://github.com/89luca89/distrobox#aims). 

I feel would be good to protect the host's `$HOME` dir from applications in the container **_if_** a custom home was selected.  Not mounting it at `/home/<user>` is [a good start](https://github.com/gunnarx/distrobox/blob/b532d4f4f1ae569cf2138d2fbbbe617d14d59a08/distrobox-create#L423), but of course not ultimately secure since it is still at `/run/host/home/<user>` as things stand now.

Ultimately, this is only a step towards Sandbox implementation which is an open issue, but I wonder if you also think changing to this behavior now is logical.

This behavior is at least what I expected, and the modification is what I use now.   There's more tweaking possible probably so consider this a draft PR for discussion?

Ref:  
- https://github.com/89luca89/distrobox/issues/28