### PR TITLE
enter: fix unbound variable with --dry-run

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -333,6 +333,7 @@ generate_command() {
 	printf "%s" "${result_command}"
 }
 
+container_path="${PATH}"
 # dry run mode, just generate the command and print it. No execution.
 if [ "${dryrun}" -ne 0 ]; then
 	cmd="$(generate_command)"
@@ -343,7 +344,6 @@ fi
 
 # Inspect the container we're working with.
 container_status="unknown"
-container_path="${PATH}"
 eval "$(${container_manager} inspect --type container "${container_name}" --format \
 	'container_status={{.State.Status}};
 	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}')"


### PR DESCRIPTION
The --dry-run switch for enter command fails with

```
DISTROBOX_ENTER_PATH=/usr/bin/distrobox-enter"'
++ set +o xtrace
/usr/bin/distrobox-enter: line 279: container_PATH: unbound variable
```

generate_command expects container_PATH to be declared, so move the
variable declaration slightly upper fixes the problem.
