### PR TITLE
install: Stop calling git

### DIFF
--- a/install
+++ b/install
@@ -104,10 +104,6 @@ cd "${curr_dir}" || exit 1
 # if files are available, install files in dest directory
 # else download targz and uncompress it
 if [ -e "${curr_dir}/distrobox-enter" ]; then
-	release_ver="github-zip-$(date +%F)"
-	if [ -d "${curr_dir}/.git" ] && command -v git > /dev/null; then
-		release_ver="git-$(git rev-parse HEAD)"
-	fi
 	for file in distrobox*; do
 		if ! install -D -m 0755 -t "${dest_path}" "${file}"; then
 			printf >&2 "Do you have permission to write to %s?\n" "${dest_path}"


### PR DESCRIPTION
As pointed out by Mišo Barišić in #260, this call might fail when
running `sudo ./install` because of the fix for CVE-2022-24765, which is
present in git 2.36.0 and certain maintenence releases from 2.30 to
2.35. This variable has been unused in this block since 68df9d2, where a
proper version value was used, rather than being dynamically updated by
`./install`.

Link: https://lore.kernel.org/xmqqv8veb5i6.fsf@gitster.g/
