### PR TITLE
Some openSUSE improvement

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -410,6 +410,17 @@ if ! command -v find || ! command -v mount || ! command -v passwd ||
 			vte-profile
 
 	elif command -v zypper; then
+		# In openSUSE official images, zypper is configured to ignore recommended
+		# packages (i.e., weak dependencies). This however, results in a rather
+		# poor out-of-the-box experience (e.g., when trying to run GUI apps).
+		# So, let's enable them. For the same reason, we make dure we install
+		# docs.
+		sed -i 's/.*solver.onlyRequires.*/solver.onlyRequires = false/g' /etc/zypp/zypp.conf
+		sed -i 's/.*rpm.install.excludedocs.*/rpm.install.excludedocs = no/g' /etc/zypp/zypp.conf
+		# With recommended packages, something might try to pull in
+		# parallel-printer-support which can't be installed in rootless podman.
+		# Since we very much likely never need it, just lock it
+		zypper al parallel-printer-support
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.

--- a/distrobox-init
+++ b/distrobox-init
@@ -427,6 +427,7 @@ if ! command -v find || ! command -v mount || ! command -v passwd ||
 			procps \
 			shadow \
 			sudo \
+			systemd \
 			util-linux
 
 	else


### PR DESCRIPTION
This pull request does the following:
1) fix openSUSE systemd (i.e., --init) enabled distrobox
2) customize openSUSE images during init, for enabling recommended packages
3) make it possible to keep recommended packages disabled --if one really wants that-- and do it in a way that is generic and can be used by other distroboxes and for other things

About 2 and 3, the first `enter` in a distrobox with is now quite a bit slower (because zypper is quite slow itself :-( ), but I think it's worth it. In fact, the resulting distrobox is now actually useful. E.g., GUI apps (but also non-GUI apps, as even just vim has problem withou recommended packages!) now works pretty much out of the box, once installed.

For comparison, I've created a Tumbleweed based distrobox, installed neofetch, vim and gedit, and it has ~600 packages. I've done the same on a rawhide one, and it has a little less than 500. So I think, all in all, it's fine, and well worth it.