### PR TITLE
Fix distrobox-export --bin error handling

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -28,6 +28,7 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
+dest_path=""
 export_action=""
 exported_app=""
 exported_app_label=""


### PR DESCRIPTION
The check that `--export-path` is also passed fails because the
`dest_path` variable used to store the argument does not have a
default value.

Fixes #274

```shell
distrobox on  fix-export-bin [!]
⬢ [fedora-toolbox:36] ❯ distrobox-export --bin /usr/bin/fedpkg
/usr/bin/distrobox-export: line 205: dest_path: unbound variable

An error occurred
```

```shell
distrobox on  fix-export-bin [!]
⬢ [fedora-toolbox:36] ❯ distrobox-export --bin /usr/bin/fedpkg
Error: Missing argument export-path.

An error occurred

distrobox on  fix-export-bin [!]
⬢ [fedora-toolbox:36] ❯ distrobox-export --bin /usr/bin/fedpkg --export-path ~/bin
/usr/bin/fedpkg from f36-packaging exported successfully in /home/michel/bin.
OK!

```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>