### PR TITLE
Add AlmaLinux 9 to tested containers distros

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -106,7 +106,7 @@ Distrobox guests tested successfully with the following container images:
 
 |    Distro  |    Version | Images    |
 | --- | --- | --- |
-| AlmaLinux | 8     | docker.io/library/almalinux:8    |
+| AlmaLinux | 8 <br> 9 | docker.io/library/almalinux:8 <br> docker.io/library/almalinux:9 |
 | AlmaLinux (UBI) | 8     | docker.io/almalinux/8-base <br> docker.io/almalinux/8-init    |
 | Alpine Linux    | 3.14 <br> 3.15 | docker.io/library/alpine:latest    |
 | AmazonLinux | 2  | docker.io/library/amazonlinux:2.0.20211005.0    |

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -293,10 +293,14 @@ the shell you use on the host is not available in the default repos (e.g.
 
 Use the pre-initialization hooks for this:
 
-```bash
+```shell
 distrobox create -i docker.io/almalinux/8-init --init --name test --pre-init-hooks "dnf config-manager --enable powertools && dnf -y install epel-release"
 ```
 
-```bash
+```shell
+distrobox create -i docker.io/library/almalinux:9 -n alma9 --pre-init-hooks "dnf -y install dnf-plugins-core && dnf config-manager --enable crb && dnf -y install epel-release"
+```
+
+```shell
 distrobox create -i quay.io/centos/centos:stream8 c8s --pre-init-hooks "dnf config-manager --enable powertools && dnf -y install epel-next-release"
 ```


### PR DESCRIPTION
Tested and worked fine. I had to install `dnf-plugins-core` which is
installed out of the box on AlmaLinux 8, but that's not a distrobox
issue.

```shell
distrobox on  main
❯ ./distrobox create -i docker.io/library/almalinux:9 -n alma9 --pre-init-hooks "dnf -y install dnf-plugins-core && dnf config-manager --enable crb && dnf -y install epel-release"
39a00b6fdacdbd22217fba9ff9c08a2468c8a57747f0df6e501ff057231899eb
Distrobox 'alma9' successfully created.
To enter, run:

distrobox-enter alma9

distrobox on  main
❯ ./distrobox enter alma9
Container alma9 is not running.
Starting container alma9
run this command to follow along:

 podman logs -f alma9

 Starting container...                  	[ OK ]
 Executing pre-init hooks...            	[ OK ]
 Installing basic packages...           	[ OK ]
 Setting up read-only mounts...         	[ OK ]
 Setting up read-write mounts...        	[ OK ]
 Setting up host's sockets integration...	[ OK ]
 Integrating host's themes, icons, fonts...	[ OK ]
 Setting up package manager exceptions...	[ OK ]
 Setting up sudo...                     	[ OK ]
 Setting up groups...                   	[ OK ]
 Setting up users...                    	[ OK ]
 Executing init hooks...                	[ OK ]

Container Setup Complete!
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish

distrobox on  main
⬢ [almalinux:9] ❯
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>