### PR TITLE
distrobox-host-exec: new tool for host command execution

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -60,10 +60,12 @@ non_interactive=0
 # management.
 distrobox_entrypoint_path="$(cd "$(dirname "${0}")" && pwd)/distrobox-init"
 distrobox_export_path="$(cd "$(dirname "${0}")" && pwd)/distrobox-export"
+distrobox_hostexec_path="$(cd "$(dirname "${0}")" && pwd)/distrobox-host-exec"
 # In case init or export are not in the same path as create, let's search
 # in PATH for them.
 [ ! -e "${distrobox_entrypoint_path}" ] && distrobox_entrypoint_path="$(command -v distrobox-init)"
 [ ! -e "${distrobox_export_path}" ] && distrobox_export_path="$(command -v distrobox-export)"
+[ ! -e "${distrobox_hostexec_path}" ] && distrobox_hostexec_path="$(command -v distrobox-hostexec)"
 dryrun=0
 init=0
 rootful=0
@@ -407,6 +409,7 @@ generate_command() {
 		--volume \"${container_user_home}\":\"${container_user_home}\":rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
+		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
 		--volume /:/run/host:rslave
 		--volume /dev:/dev:rslave
 		--volume /sys:/sys:rslave

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -1,0 +1,142 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project:
+#    https://github.com/89luca89/distrobox
+#
+# Copyright (C) 2022 distrobox contributors
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
+trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
+
+# Defaults
+distrobox_host_exec_default_command="/bin/sh"
+
+verbose=0
+version="1.2.16"
+
+# Print usage to stdout.
+# Arguments:
+#   None
+# Outputs:
+#   print usage with examples.
+show_help() {
+	cat << EOF
+distrobox version: ${version}
+
+Usage:
+
+	distrobox-host-exec [command [arguments]]
+	distrobox-host-exec ls
+	distrobox-host-exec bash -l
+	distrobox-host-exec flatpak run org.mozilla.firefox
+	distrobox-host-exec podman ps -a
+
+
+Options:
+
+	--help/-h:		show this message
+	--verbose/-v:		show more verbosity
+	--version/-V:		show version
+EOF
+}
+
+# Parse arguments
+while :; do
+	case $1 in
+		-h | --help)
+			# Call a "show_help" function to display a synopsis, then exit.
+			show_help
+			exit 0
+			;;
+		-v | --verbose)
+			verbose=1
+			shift
+			;;
+		-V | --version)
+			printf "distrobox: %s\n" "${version}"
+			exit 0
+			;;
+		--) # End of all options.
+			shift
+			;;
+		-*) # Invalid options.
+			printf >&2 "ERROR: Invalid flag '%s'\n\n" "$1"
+			show_help
+			exit 1
+			;;
+		*)
+			command=${distrobox_host_exec_default_command}
+			if [ -n "$1" ]; then
+				command=$1
+				shift
+			fi
+			break
+			;;
+	esac
+done
+
+set -o errexit
+set -o nounset
+# set verbosity
+if [ "${verbose}" -ne 0 ]; then
+	set -o xtrace
+fi
+
+# Check we're running inside a container and not on the host
+if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
+	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
+	exit 126
+fi
+
+mode=flatpak
+result_command="flatpak-spawn --host --forward-fd=1 --forward-fd=2 "
+
+if ! command -v flatpak-spawn > /dev/null; then
+	printf "WARNING: flatpak-spawn not found!\n"
+	printf "We recommend installing it and then trying distrobox-host-exec again.\n\n"
+	printf "Alternatively, we can try an different (chroot-based) approach, but please\n"
+	printf "be aware that it has severe limitations and some commands will not work!\n\n"
+	printf "Do you really want to continue without installing flatpak-spawn? [N/y] "
+	read -r response
+	response=${response:-"N"}
+
+	# Accept only y,Y,Yes,yes,n,N,No,no.
+	case "${response}" in
+		y | Y | Yes | yes | YES)
+			mode=chroot
+			result_command="sudo -E chroot --userspec=$(id -u):$(id -g) /run/host/ /usr/bin/env "
+			;;
+		n | N | No | no | NO)
+			printf "Good choice! Go get flatpak-spawn.\n"
+			exit 0
+			;;
+		*) # Default case: If no more options then break out of the loop.
+			printf >&2 "Invalid input.\n"
+			printf >&2 "The available choices are: y,Y,Yes,yes,YES or n,N,No,no,NO.\nExiting.\n"
+			exit 1
+			;;
+	esac
+fi
+
+# Let's also pass back the environment
+for i in $(printenv | grep "=" | grep -Ev ' |"' | grep -Ev "^(_)"); do
+	if [ "${mode}" = "chroot" ]; then
+		result_command="${result_command} ${i}"
+	else
+		result_command="${result_command} --env=${i} "
+	fi
+done
+
+exec ${result_command} sh -c " cd ${PWD} && ${command} $* "

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ graphical apps (X11/Wayland), and audio.
     - [distrobox-stop](usage/distrobox-stop.md)
   - [Inside the distrobox](usage/usage.md#inside-the-distrobox)
     - [distrobox-export](usage/distrobox-export.md)
+    - [distrobox-host-exec](usage/distrobox-host-exec.md)
     - [distrobox-init](usage/distrobox-init.md)
   - [Configure distrobox](#configure-distrobox)
 - [Useful tips](useful_tips.md)
@@ -122,6 +123,8 @@ It is divided into 7 commands:
 - `distrobox-init`   - the entrypoint of the container (not meant to be used manually)
 - `distrobox-export` - it is meant to be used inside the container,
   useful to export apps and services from the container to the host
+- `distrobox-host-exec` - to run commands/programs from the host, while inside
+ of the container
 
 It also includes a little wrapper to launch commands with `distrobox COMMAND`
 instead of calling the single files.

--- a/docs/posts/execute_commands_on_host.md
+++ b/docs/posts/execute_commands_on_host.md
@@ -1,7 +1,9 @@
 - [Distrobox](../README.md)
   - [Execute a command on the Host](execute_commands_on_host.md)
-    - [The easy one](#the-easy-one)
-    - [The not so easy one](#the-not-so-easy-one)
+    - [With distrobox-host-exec](#distrobox-host-exec)
+    - [Manually](#manually)
+      - [The easy one](#the-easy-one)
+      - [The not so easy one](#the-not-so-easy-one)
   - [Integrate host with container seamlessly](#integrate-host-with-container-seamlessly)
 
 ---
@@ -13,7 +15,15 @@ archive manager, a container manager and so on.
 
 Here are a couple of solutions.
 
-## The easy one
+## With distrobox-host-exec
+
+distrobox offers the `distrobox-host-exec` helper, that can be used exactly for this.
+
+See [distrobox-host-exec](../usage/distrobox-host-exec.md).
+
+## Manually
+
+### The easy one
 
 Install `flatpak-spawn` inside the container, this example is running on a
 Fedora Distrobox:
@@ -31,7 +41,7 @@ user@fedora-distrobox:~$ flatpak-spawn --host bash -l
 ~$  # We're back on host!
 ```
 
-## The not so easy one
+### The not so easy one
 
 Alternatively you may don't have `flatpak-spawn` in the repository of your container,
 or simply want an alternative.

--- a/docs/usage/distrobox-host-exec.md
+++ b/docs/usage/distrobox-host-exec.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD010 -->
+# Host Command Execution
+
+distrobox-host-exec lets one execute command on the host, while inside of a container.
+
+If "flatpak-spawn" is installed in the container, this is what is used, and it is the
+most powerful and recommended method. If, instead, "flatpak-spawn" can't be found, it
+still try to get the job done with "chroot" (but beware that not all commands/programs
+will work well in this mode).
+
+Just pass to "distrobox-host-exec" any command and all its arguments, if any.
+
+	distrobox-host-exec [command [arguments]]
+
+If no command is provided, it will execute "/bin/sh".
+
+Example usage:
+
+	distrobox-host-exec ls
+	distrobox-host-exec bash -l
+	distrobox-host-exec flatpak run org.mozilla.firefox
+	distrobox-host-exec podman ps -a
+
+Options:
+
+	--help/-h:		show this message
+	--verbose/-v:		show more verbosity
+	--version/-V:		show version


### PR DESCRIPTION
Executing commands on the host, while inside of a container, can be done
either with flatpak-spawn, of playing tricks with chroot. Let's provide
a new script, which will be available inside of the container, that does
exactly that.

This tries to improve (although maybe not completely fix):
https://github.com/89luca89/distrobox/issues/177

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>