### PR TITLE
Automatically create containers during 'distrobox-enter' (if they don't exist!)

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -87,6 +87,10 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# Fixup non_interactive=[true|false], in case we find it in the config file(s)
+[ "${non_interactive}" = "true" ] && non_interactive=1
+[ "${non_interactive}" = "false" ] && non_interactive=0
+
 [ -n "${DBX_CONTAINER_ALWAYS_PULL}" ] && container_always_pull="${DBX_CONTAINER_ALWAYS_PULL}"
 [ -n "${DBX_CONTAINER_CUSTOM_HOME}" ] && container_user_custom_home="${DBX_CONTAINER_CUSTOM_HOME}"
 [ -n "${DBX_CONTAINER_IMAGE}" ] && container_image="${DBX_CONTAINER_IMAGE}"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -364,24 +364,25 @@ if [ "${dryrun}" -ne 0 ]; then
 	exit 0
 fi
 
-# Inspect the container we're working with.
-container_status="unknown"
-eval "$(${container_manager} inspect --type container "${container_name}" --format \
-	'container_status={{.State.Status}};
-	{{range .Config.Env}}{{if slice . 0 5 | eq "HOME="}}container_home={{slice . 5 | printf "%q"}};{{end}}{{end}}
-	{{range .Config.Env}}{{if slice . 0 6 | eq "SHELL="}}container_shell={{slice . 6 | printf "%q"}};{{end}}{{end}}
-	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}')"
-container_exists="$?"
-# Set SHELL as a login shell
-container_shell="$(basename "${container_shell}") -l"
-# Does the container exists? check if inspect reported errors
-if [ "${container_exists}" -gt 0 ]; then
+# Check if the container is even there
+container_exists=$(${container_manager} ps -aq -f name=^"${container_name}"$)
+if [ "${container_exists}" = "" ]; then
 	# If not, prompt to create it first
 	printf >&2 "Cannot find container %s, does it exist?\n" "${container_name}"
 	printf >&2 "\nTry running first:\n"
 	printf >&2 "\tdistrobox-create <name-of-container> --image <remote>/<docker>:<tag>\n"
 	exit 1
 fi
+
+# Now inspect the container we're working with.
+container_status="unknown"
+eval "$(${container_manager} inspect --type container "${container_name}" --format \
+	'container_status={{.State.Status}};
+	{{range .Config.Env}}{{if slice . 0 5 | eq "HOME="}}container_home={{slice . 5 | printf "%q"}};{{end}}{{end}}
+	{{range .Config.Env}}{{if slice . 0 6 | eq "SHELL="}}container_shell={{slice . 6 | printf "%q"}};{{end}}{{end}}
+	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}')"
+# Set SHELL as a login shell
+container_shell="$(basename "${container_shell}") -l"
 
 # If the container is not already running, we need to start if first
 if [ "${container_status}" != "running" ]; then

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -77,6 +77,10 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# Fixup non_interactive=[true|false], in case we find it in the config file(s)
+[ "${non_interactive}" = "true" ] && non_interactive=1
+[ "${non_interactive}" = "false" ] && non_interactive=0
+
 [ -n "${DBX_CONTAINER_IMAGE}" ] && container_image="${DBX_CONTAINER_IMAGE}"
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -45,9 +45,12 @@ container_shell="${SHELL:-"bash"}"
 # For example in hosts that do not follow FHS, like NixOS or for shells in custom
 # exotic paths.
 container_shell="$(basename "${container_shell}") -l"
+container_image=""
+container_image_default="registry.fedoraproject.org/fedora-toolbox:36"
 container_manager="autodetect"
 container_name="my-distrobox"
 container_manager_additional_flags=""
+non_interactive=0
 
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
@@ -74,9 +77,11 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+[ -n "${DBX_CONTAINER_IMAGE}" ] && container_image="${DBX_CONTAINER_IMAGE}"
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 [ -n "${DBX_SKIP_WORKDIR}" ] && skip_workdir="${DBX_SKIP_WORKDIR}"
+[ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
 
 # Print usage to stdout.
 # Arguments:
@@ -156,6 +161,10 @@ while :; do
 				shift
 				shift
 			fi
+			;;
+		-Y | --yes)
+			non_interactive=1
+			shift
 			;;
 		-e | --exec | --)
 			shift
@@ -368,10 +377,40 @@ fi
 container_exists=$(${container_manager} ps -aq -f name=^"${container_name}"$)
 if [ "${container_exists}" = "" ]; then
 	# If not, prompt to create it first
-	printf >&2 "Cannot find container %s, does it exist?\n" "${container_name}"
-	printf >&2 "\nTry running first:\n"
-	printf >&2 "\tdistrobox-create <name-of-container> --image <remote>/<docker>:<tag>\n"
-	exit 1
+	printf >&2 "Cannot find container %s\n" "${container_name}"
+	if [ -z "${container_image}" ]; then
+		container_image="${container_image_default}"
+	fi
+	# If we're not-interactive, just don't ask questions
+	if [ "${non_interactive}" -eq 1 ]; then
+		response="yes"
+	else
+		printf >&2 "Create it now, out of image %s? [Y/n]: " "${container_image}"
+		read -r response
+		response="${response:-"Y"}"
+	fi
+
+	# Accept only y,Y,Yes,yes,n,N,No,no.
+	case "${response}" in
+		y | Y | Yes | yes | YES)
+			# Ok, let's create the container with just 'distrobox create $container_name
+			printf >&2 "Creating the container with command:\n"
+			printf >&2 "  distrobox create -i %s %s\n" "${container_image}" "${container_name}"
+			if [ "${dryrun}" -ne 1 ]; then
+				distrobox-create -i "${container_image}" -n "${container_name}"
+			fi
+			;;
+		n | N | No | no | NO)
+			printf >&2 "Ok. For creating it, run this command:\n"
+			printf >&2 "\tdistrobox-create <name-of-container> --image <remote>/<docker>:<tag>\n"
+			exit 0
+			;;
+		*) # Default case: If no more options then break out of the loop.
+			printf >&2 "Invalid input.\n"
+			printf >&2 "The available choices are: y,Y,Yes,yes,YES or n,N,No,no,NO.\nExiting.\n"
+			exit 1
+			;;
+	esac
 fi
 
 # Now inspect the container we're working with.

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -54,6 +54,10 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# Fixup non_interactive=[true|false], in case we find it in the config file(s)
+[ "${non_interactive}" = "true" ] && non_interactive=1
+[ "${non_interactive}" = "false" ] && non_interactive=0
+
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -53,6 +53,10 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# Fixup non_interactive=[true|false], in case we find it in the config file(s)
+[ "${non_interactive}" = "true" ] && non_interactive=1
+[ "${non_interactive}" = "false" ] && non_interactive=0
+
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"


### PR DESCRIPTION
When someone tries to enter a container that does not exist, let's offer the option of just creating it ourselves. The main (only?) issue is whether to accept and, if yes, how to handle 'distrobox-create' options in 'distrobox-enter'.

As a first step, let's ingore the problem entirely and just invoke 'distrobox-create $container_name', in this case.

An improvement could be making 'distrobox-enter' support all distrobox-create parameter. Of course, that would be "just" the parsing of them, to stash them somewhere and, if we get to creating the container, pass them to 'distrobox-create'. That's easy enough to do, but it then means that every time we add/remove/modify a parameter of 'distrobox-create', we also need to do the same change in 'distrobox-enter' parsing code, which is not really nice...