### PR TITLE
feat: Replace call to 'rev | cut' with 'grep'

### DIFF
--- a/install
+++ b/install
@@ -132,7 +132,7 @@ else
 	if [ "${next}" -eq 0 ]; then
 		release_ver=$(curl -L https://github.com/89luca89/distrobox/releases/latest |
 			grep 'refs/tags' | tail -1 | cut -d'"' -f2)
-		release_name=$(echo "${release_ver}" | rev | cut -d'/' -f1 | rev)
+		release_name=$(echo "${release_ver}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$')
 	else
 		release_ver="89luca89/distrobox/archive/refs/heads/main.tar.gz"
 		release_name="main"


### PR DESCRIPTION
This modifies the parsing of $release_name from $release_ver by
grepping for a semantic version with a '.tar.gz' extension.

The prior method used 'rev | cut | rev' to isolate $release_name
as the last field of $release_ver. The rev tool is not installed
by default on some machines.