### PR TITLE
host-exec: replace chroot with host-spawn

### DIFF
--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -21,8 +21,9 @@
 trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
-distrobox_host_exec_default_command="/bin/sh"
-
+host_command=""
+distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
+host_spawn_version="1.0.1"
 verbose=0
 version="1.3.2"
 
@@ -52,40 +53,46 @@ Options:
 EOF
 }
 
+# If we're a symlink to a command, use that as command to exec, and skip arg parsing.
+if [ "$(basename "${0}")" != "distrobox-host-exec" ]; then
+	host_command="$(basename "${0}")"
+fi
 # Parse arguments
-while :; do
-	case $1 in
-		-h | --help)
-			# Call a "show_help" function to display a synopsis, then exit.
-			show_help
-			exit 0
-			;;
-		-v | --verbose)
-			verbose=1
-			shift
-			;;
-		-V | --version)
-			printf "distrobox: %s\n" "${version}"
-			exit 0
-			;;
-		--) # End of all options.
-			shift
-			;;
-		-*) # Invalid options.
-			printf >&2 "ERROR: Invalid flag '%s'\n\n" "$1"
-			show_help
-			exit 1
-			;;
-		*)
-			command=${distrobox_host_exec_default_command}
-			if [ -n "$1" ]; then
-				command=$1
+if [ -z "${host_command}" ]; then
+	# Skip argument parsing if we're a symlink
+	while :; do
+		case $1 in
+			-h | --help)
+				# Call a "show_help" function to display a synopsis, then exit.
+				show_help
+				exit 0
+				;;
+			-v | --verbose)
+				verbose=1
 				shift
-			fi
-			break
-			;;
-	esac
-done
+				;;
+			-V | --version)
+				printf "distrobox: %s\n" "${version}"
+				exit 0
+				;;
+			--) # End of all options.
+				shift
+				;;
+			-*) # Invalid options.
+				printf >&2 "ERROR: Invalid flag '%s'\n\n" "$1"
+				show_help
+				exit 1
+				;;
+			*)
+				if [ -n "$1" ]; then
+					host_command=$1
+					shift
+				fi
+				break
+				;;
+		esac
+	done
+fi
 
 set -o errexit
 set -o nounset
@@ -100,44 +107,53 @@ if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
 	exit 126
 fi
 
-mode=flatpak
-result_command="flatpak-spawn --host --forward-fd=1 --forward-fd=2 "
-
-if ! command -v flatpak-spawn > /dev/null; then
-	printf "WARNING: flatpak-spawn not found!\n"
-	printf "We recommend installing it and then trying distrobox-host-exec again.\n\n"
-	printf "Alternatively, we can try an different (chroot-based) approach, but please\n"
-	printf "be aware that it has severe limitations and some commands will not work!\n\n"
-	printf "Do you really want to continue without installing flatpak-spawn? [y/N] "
-	read -r response
-	response=${response:-"N"}
-
-	# Accept only y,Y,Yes,yes,n,N,No,no.
-	case "${response}" in
-		y | Y | Yes | yes | YES)
-			mode=chroot
-			result_command="sudo -E chroot --userspec=$(id -u):$(id -g) /run/host/ /usr/bin/env "
-			;;
-		n | N | No | no | NO)
-			printf "Good choice! Go get flatpak-spawn.\n"
-			exit 0
-			;;
-		*) # Default case: If no more options then break out of the loop.
-			printf >&2 "Invalid input.\n"
-			printf >&2 "The available choices are: y,Y,Yes,yes,YES or n,N,No,no,NO.\nExiting.\n"
-			exit 1
-			;;
-	esac
+if [ -z "${host_command}" ]; then
+	host_command="${distrobox_host_exec_default_command}"
 fi
 
-# Let's also pass back the environment
-for i in $(printenv | grep "=" | grep -Ev ' |"' | grep -Ev "^(_)"); do
-	if [ "${mode}" = "chroot" ]; then
-		result_command="${result_command} ${i}"
-	else
-		result_command="${result_command} --env=${i} "
-	fi
-done
+# If flatpak-spawn is not present, let's use host-spawn utility
+if ! command -v flatpak-spawn > /dev/null; then
+	# Setup host-spawn as a way to execute commands back on the host
+	if [ ! -e /usr/bin/host-spawn ] || [ "$(/usr/bin/host-spawn --version)" != "${host_spawn_version}" ]; then
+		printf "Warning: no flatpak-spawn nor host-spawn found!\n"
+		printf "Do you want to install host-spawn utility? [Y/n] "
+		read -r response
+		response=${response:-"Y"}
 
-# Eval the generated command.
-exec ${result_command} sh -c " cd ${PWD} && ${command} $* "
+		# Accept only y,Y,Yes,yes,n,N,No,no.
+		case "${response}" in
+			y | Y | Yes | yes | YES)
+				# Download matching version with current distrobox
+				if ! curl -L "https://github.com/1player/host-spawn/releases/download/${host_spawn_version}/host-spawn-$(uname -m)" \
+					-o /tmp/host-spawn; then
+
+					printf "Error: Cannot download /usr/bin/host-spawn\n"
+					exit 1
+				fi
+				if [ -e /tmp/host-spawn ]; then
+					sudo mv /tmp/host-spawn /usr/bin/
+					sudo chmod +x /usr/bin/host-spawn
+				fi
+				;;
+			n | N | No | no | NO)
+				printf "Installation aborted, either install host-spawn or flatpak-spawn.\n"
+				exit 0
+				;;
+			*) # Default case: If no more options then break out of the loop.
+				printf >&2 "Invalid input.\n"
+				printf >&2 "The available choices are: y,Y,Yes,yes,YES or n,N,No,no,NO.\nExiting.\n"
+				exit 1
+				;;
+		esac
+
+	fi
+	host-spawn "${host_command}" "$@"
+	# Exit here, we don't continue execution
+	exit $?
+fi
+
+# Use flatpak-spawn if we have it
+flatpak-spawn --host \
+	--forward-fd=1 --forward-fd=2 \
+	--env=TERM="${TERM}" \
+	"${host_command}" "$@"


### PR DESCRIPTION
Thanks to @1player, we now have a single-binary solution to replace
flatpak-spawn when not present.

Right now the solution is to ask to download the matching-version binary
from github releases.


This PR also implements the use of symlinks to make `distrobox-host-exec` execute as that command:

```console
~$: ln -s /usr/bin/distrobox-host-exec /usr/local/bin/podman
~$: ls -l /usr/local/bin/podman
lrwxrwxrwx. 1 root root 51 Jul 11 19:26 /usr/local/bin/podman -> /usr/bin/distrobox-host-exec
~$: podman version
...this is executed on host...
```

Fix #321

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>