### PR TITLE
remove deprecated path feature

### DIFF
--- a/install
+++ b/install
@@ -33,7 +33,6 @@ install --prefix /usr/local
 
 Options:
 	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
-	--path/-p:		(DEPRECATED) path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
 EOF
@@ -50,13 +49,6 @@ while :; do
 		-v | --verbose)
 			shift
 			verbose=1
-			;;
-		-p | --path)
-			if [ -n "$2" ]; then
-				dest_path="$2"
-				shift
-				shift
-			fi
 			;;
 		-N | --next)
 			if [ -n "$2" ]; then
@@ -76,12 +68,7 @@ while :; do
 	esac
 done
 
-if [ -n "${dest_path}" ] && [ -n "${prefix}" ]; then
-	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
-	exit 1
-fi
 
-if [ -z "${dest_path}" ]; then
 	if [ -z "${prefix}" ]; then
 		prefix="/usr/local"
 		# in case we're not root, just default to the home directory
@@ -91,11 +78,6 @@ if [ -z "${dest_path}" ]; then
 	fi
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
-else
-	printf >&2 "Warning: -p/--path is deprecated. Please refer to the documentation and switch to -P/--prefix.\n"
-	# dest_path is already set
-	man_dest_path="${dest_path}/../share/man/man1"
-fi
 
 set -o errexit
 set -o nounset

--- a/install
+++ b/install
@@ -145,5 +145,8 @@ else
 	fi
 fi
 
+[ ! -w "${dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${dest_path}" && exit 1
+[ ! -w "${man_dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${man_dest_path}" && exit 1
+
 printf >&2 "Successfully installed to %s.\n" "${dest_path}"
 printf >&2 "Be sure that %s is in your \$PATH environment variable for it to work.\n" "${dest_path}"

--- a/install
+++ b/install
@@ -68,16 +68,15 @@ while :; do
 	esac
 done
 
-
-	if [ -z "${prefix}" ]; then
-		prefix="/usr/local"
-		# in case we're not root, just default to the home directory
-		if [ "$(id -u)" -ne 0 ]; then
-			prefix="${HOME}/.local"
-		fi
+if  [ -z "${prefix}" ]; then
+	prefix="/usr/local"
+	# in case we're not root, just default to the home directory
+	if [ "$(id -u)" -ne 0 ]; then
+		prefix="${HOME}/.local"
 	fi
-	dest_path="${prefix}/bin"
-	man_dest_path="${prefix}/share/man/man1"
+fi
+dest_path="${prefix}/bin"
+man_dest_path="${prefix}/share/man/man1"
 
 set -o errexit
 set -o nounset

--- a/uninstall
+++ b/uninstall
@@ -86,6 +86,9 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 # uninstall
+for file in "${dest_path}/distrobox"*; do
+	[ -e "${file}" ] && rm "${file}"
+done
 for file in "${man_dest_path}/distrobox"*; do
 	[ -e "${file}" ] && rm "${file}"
 done

--- a/uninstall
+++ b/uninstall
@@ -85,6 +85,9 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
+[ ! -w "${dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${dest_path}" && exit 1
+[ ! -w "${man_dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${man_dest_path}" && exit 1
+
 # uninstall
 for file in "${dest_path}/distrobox"*; do
 	[ -e "${file}" ] && rm "${file}"

--- a/uninstall
+++ b/uninstall
@@ -68,15 +68,15 @@ while :; do
 	esac
 done
 
-	if [ -z "${prefix}" ]; then
-		prefix="/usr/local"
-		# in case we're not root, just default to the home directory
-		if [ "$(id -u)" -ne 0 ]; then
-			prefix="${HOME}/.local"
-		fi
+if  [ -z "${prefix}" ]; then
+	prefix="/usr/local"
+	# in case we're not root, just default to the home directory
+	if [ "$(id -u)" -ne 0 ]; then
+		prefix="${HOME}/.local"
 	fi
-	dest_path="${prefix}/bin"
-	man_dest_path="${prefix}/share/man/man1"
+fi
+dest_path="${prefix}/bin"
+man_dest_path="${prefix}/share/man/man1"
 
 set -o errexit
 set -o nounset

--- a/uninstall
+++ b/uninstall
@@ -32,7 +32,6 @@ uninstall --prefix /usr/local
 
 Options:
 	--prefix/-P:		base bath where all files will be deployed (default /usr/local if root, ~/.local if not)
-	--path/-p:		(DEPRECATED) path where to deploy the files (default /usr/local/bin if root, ~/.local/bin if not)
 	--help/-h:		show this message
 	-v:			show more verbosity
 EOF
@@ -69,12 +68,6 @@ while :; do
 	esac
 done
 
-if [ -n "${dest_path}" ] && [ -n "${prefix}" ]; then
-	printf >&2 "Both -p and -P are set. Cannot continue. Exiting.\n"
-	exit 1
-fi
-
-if [ -z "${dest_path}" ]; then
 	if [ -z "${prefix}" ]; then
 		prefix="/usr/local"
 		# in case we're not root, just default to the home directory
@@ -84,11 +77,6 @@ if [ -z "${dest_path}" ]; then
 	fi
 	dest_path="${prefix}/bin"
 	man_dest_path="${prefix}/share/man/man1"
-else
-	printf >&2 "Warning: -p/--path is deprecated. Please refer to the documentation and switch to -P/--prefix.\n"
-	# dest_path is already set
-	man_dest_path="${dest_path}/../share/man/man1"
-fi
 
 set -o errexit
 set -o nounset
@@ -97,14 +85,7 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
-# Ensure the foundamental variables are set and not empty, we will not proceed if
-# they are not all set.
-[ ! -w "${dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${dest_path}/bin" && exit 1
-
 # uninstall
-for file in "${dest_path}/distrobox"*; do
-	[ -e "${file}" ] && rm "${file}"
-done
 for file in "${man_dest_path}/distrobox"*; do
 	[ -e "${file}" ] && rm "${file}"
 done


### PR DESCRIPTION
Ever since `--prefix` was introduced in #190 (version 1.2.14), `--path` has been deprecated. 5 months have passed since, is it finally time to remove this relic of the past?