### PR TITLE
docs: fix a mistake for gentoo dockerfile

### DIFF
--- a/docs/distrobox_gentoo.md
+++ b/docs/distrobox_gentoo.md
@@ -11,7 +11,7 @@ You need to build your own image. The official resource is [here](https://github
 but here is a simple Dockerfile:
 
 ``` Dockerfile
-FROM registry.hub.docker.com/gentoo/portage:latest
+FROM registry.hub.docker.com/gentoo/portage:latest as portage
 FROM registry.hub.docker.com/gentoo/stage3:systemd
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 ```


### PR DESCRIPTION
There is an error message when using current dockerfile of gentoo.

> invalid from flag value portage: pull access denied for portage, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

Obviously, the "portage" in the last line doesn't exist. Indicate gentoo/portage as portage to fix it.