### PR TITLE
An implementation of the suggestion from issue #362 "Add a flag to distrobox-host-exec to skip the flatpak-spawn prompt"

### DIFF
--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -22,9 +22,9 @@ trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
 host_command=""
-install_host_spawn=""
+non_interactive=0
 distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
-host_spawn_version="1.0.3"
+host_spawn_version="1.1.0"
 verbose=0
 version="1.3.2"
 
@@ -51,9 +51,9 @@ Options:
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
-    --no-confirm/-nc:   skip prompt so the host-spawn will be installed
-                        on guest system automatically, if neither
-                        flatpak-build or host-spawn are detected
+    --yes/-Y:      Automatically answer yes to prompt: 
+                        host-spawn will be installed on the guest system
+                        if neither flatpak-build or host-spawn are detected
 EOF
 }
 
@@ -79,10 +79,10 @@ if [ -z "${host_command}" ]; then
 				printf "distrobox: %s\n" "${version}"
 				exit 0
 				;;
-			-nc | --no-confirm) 
-			install_host_spawn="yes"
-			shift
-			;;
+		    -Y | --yes)
+			    non_interactive=1
+			    shift
+			    ;;
 			--) # End of all options.
 				shift
 				;;
@@ -125,16 +125,19 @@ if ! command -v flatpak-spawn > /dev/null; then
 	if ! command -v host-spawn > /dev/null ||
 		[ "$(host-spawn --version)" != "${host_spawn_version}" ]; then
 
-        # if host spawn flag hasn't been set
-        if ! [ "$install_host_spawn" = "yes" ]; then   
+        # if non-interactive flag flag hasn't been set
+        if [ "${non_interactive}" -eq 0 ]; then
+	        # Prompt to download it.
 		    printf "Distrobox Warning: no flatpak-spawn nor host-spawn found!\n"
 		    printf "View distrobox-host-exec docs on Github for more details.\n"
 		    printf "Do you want to install host-spawn utility? [Y/n] "
 		    read -r response
-		    install_host_spawn=${response:-"Y"}
+		    response=${response:-"Y"}
+        else
+        	response="yes"
         fi
 		# Accept only y,Y,Yes,yes,n,N,No,no.
-		case "${install_host_spawn}" in
+		case "${response}" in
 			y | Y | Yes | yes | YES)
 				# Download matching version with current distrobox
 				if ! curl -L \

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -127,8 +127,8 @@ if ! command -v flatpak-spawn > /dev/null; then
 
         # if host spawn flag hasn't been set
         if ! [ "$install_host_spawn" = "yes" ]; then   
-		    printf "Distrobox Warning: no flatpak-spawn nor host-spawn found!\n"
-		    printf "View distrobox-host-exec docs on Github for more details"
+		    printf "Distrobox Warning: no flatpak-spawn or host-spawn found!\n"
+		    printf "View distrobox-host-exec docs on Github for more details."
 		    printf "Do you want to install host-spawn utility? [Y/n] "
 		    read -r response
 		    install_host_spawn=${response:-"Y"}

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -127,8 +127,8 @@ if ! command -v flatpak-spawn > /dev/null; then
 
         # if host spawn flag hasn't been set
         if ! [ "$install_host_spawn" = "yes" ]; then   
-		    printf "Distrobox Warning: no flatpak-spawn or host-spawn found!\n"
-		    printf "View distrobox-host-exec docs on Github for more details."
+		    printf "Distrobox Warning: no flatpak-spawn nor host-spawn found!\n"
+		    printf "View distrobox-host-exec docs on Github for more details.\n"
 		    printf "Do you want to install host-spawn utility? [Y/n] "
 		    read -r response
 		    install_host_spawn=${response:-"Y"}

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -50,6 +50,7 @@ Options:
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
+    --host-spawn:     execute the command inside a host-spawn sandbox instead of the default flatpak sandbox
 EOF
 }
 
@@ -74,6 +75,9 @@ if [ -z "${host_command}" ]; then
 			-V | --version)
 				printf "distrobox: %s\n" "${version}"
 				exit 0
+				;;
+			--) # End of all options.
+				shift
 				;;
 			--) # End of all options.
 				shift

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -52,8 +52,8 @@ Options:
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
     --yes/-Y:      Automatically answer yes to prompt: 
-                        host-spawn will be installed on the guest system
-                        if neither flatpak-build or host-spawn are detected
+                                host-spawn will be installed on the guest system
+                                if neither flatpak-build or host-spawn are detected
 EOF
 }
 

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -128,7 +128,7 @@ if ! command -v flatpak-spawn > /dev/null; then
         # if non-interactive flag flag hasn't been set
         if [ "${non_interactive}" -eq 0 ]; then
 	        # Prompt to download it.
-		    printf "Distrobox Warning: no flatpak-spawn nor host-spawn found!\n"
+		    printf "Distrobox Warning: no flatpak-spawn or host-spawn found!\n"
 		    printf "View distrobox-host-exec docs on Github for more details.\n"
 		    printf "Do you want to install host-spawn utility? [Y/n] "
 		    read -r response

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -22,6 +22,7 @@ trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
 host_command=""
+host_spawn=""
 distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
 host_spawn_version="1.0.2"
 verbose=0
@@ -76,9 +77,10 @@ if [ -z "${host_command}" ]; then
 				printf "distrobox: %s\n" "${version}"
 				exit 0
 				;;
-			--) # End of all options.
-				shift
-				;;
+			--hs | --host-spawn) 
+			host_spawn="host_spawn"
+			shift
+			;;
 			--) # End of all options.
 				shift
 				;;

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -22,9 +22,9 @@ trap '[ "$?" -ne 0 ] && printf "\nAn error occurred\n"' EXIT
 
 # Defaults
 host_command=""
-host_spawn=""
+install_host_spawn=""
 distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
-host_spawn_version="1.0.2"
+host_spawn_version="1.0.3"
 verbose=0
 version="1.3.2"
 
@@ -51,7 +51,9 @@ Options:
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
-    --host-spawn:     execute the command inside a host-spawn sandbox instead of the default flatpak sandbox
+    --no-confirm/-nc:   skip prompt so the host-spawn will be installed
+                        on guest system automatically, if neither
+                        flatpak-build or host-spawn are detected
 EOF
 }
 
@@ -77,8 +79,8 @@ if [ -z "${host_command}" ]; then
 				printf "distrobox: %s\n" "${version}"
 				exit 0
 				;;
-			--hs | --host-spawn) 
-			host_spawn="host_spawn"
+			-nc | --no-confirm) 
+			install_host_spawn="yes"
 			shift
 			;;
 			--) # End of all options.
@@ -123,13 +125,16 @@ if ! command -v flatpak-spawn > /dev/null; then
 	if ! command -v host-spawn > /dev/null ||
 		[ "$(host-spawn --version)" != "${host_spawn_version}" ]; then
 
-		printf "Warning: no flatpak-spawn nor host-spawn found!\n"
-		printf "Do you want to install host-spawn utility? [Y/n] "
-		read -r response
-		response=${response:-"Y"}
-
+        # if host spawn flag hasn't been set
+        if ! [ "$install_host_spawn" = "yes" ]; then   
+		    printf "Distrobox Warning: no flatpak-spawn nor host-spawn found!\n"
+		    printf "View distrobox-host-exec docs on Github for more details"
+		    printf "Do you want to install host-spawn utility? [Y/n] "
+		    read -r response
+		    install_host_spawn=${response:-"Y"}
+        fi
 		# Accept only y,Y,Yes,yes,n,N,No,no.
-		case "${response}" in
+		case "${install_host_spawn}" in
 			y | Y | Yes | yes | YES)
 				# Download matching version with current distrobox
 				if ! curl -L \


### PR DESCRIPTION
See more details of the suggestion here. https://github.com/89luca89/distrobox/issues/362

Add a flag to distrobox-host-exec to skip the flatpak-spawn prompt. 

I've tried to keep the code high quality, and confirming to distrobox's conventions with comments and submitted a pull request with the changes. 
I added a --no-confirm/-nc flag. it doesn't force using host-spawn it just skips the prompt and tries to install host-spawn if flatpak and host-spawn are not installed.

I've made some minor changes to the wording of the prompt, including a line that directs people to the docs and added information about new flag to the options listed by the --help flag.