### PR TITLE
create: add --no-entry

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -28,6 +28,7 @@
 #	DBX_CONTAINER_IMAGE
 #	DBX_CONTAINER_MANAGER
 #	DBX_CONTAINER_NAME
+#	DBX_CONTAINER_NO_ENTRY
 #	DBX_NON_INTERACTIVE
 #	DBX_SUDO_PROGRAM
 
@@ -49,6 +50,7 @@ container_image_default="registry.fedoraproject.org/fedora-toolbox:36"
 container_init_hook=""
 container_manager="autodetect"
 container_manager_additional_flags=""
+container_no_entry=0
 container_name=""
 container_pre_init_hook=""
 container_user_custom_home=""
@@ -89,6 +91,7 @@ done
 [ -n "${DBX_CONTAINER_IMAGE}" ] && container_image="${DBX_CONTAINER_IMAGE}"
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
+[ -n "${DBX_CONTAINER_NO_ENTRY}" ] && container_no_entry="${DBX_CONTAINER_NO_ENTRY}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
 [ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
@@ -134,6 +137,7 @@ Options:
 	--init/-I		use init system (like systemd) inside the container.
 				this will make host's processes not visible from within the container.
 	--help/-h:		show this message
+	--no-entry:		do not generate a container entry in the application list
 	--dry-run/-d:		only print the container manager command generated
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -161,6 +165,10 @@ while :; do
 		-V | --version)
 			printf "distrobox: %s\n" "${version}"
 			exit 0
+			;;
+		--no-entry)
+			shift
+			container_no_entry=1
 			;;
 		-d | --dry-run)
 			shift
@@ -633,7 +641,9 @@ if eval ${cmd} > /dev/null; then
 
 	# We've created the box, let's also create the entry
 	if [ "${rootful}" -eq 0 ]; then
-		"$(dirname "$(realpath "${0}")")/distrobox-generate-entry" "${container_name}"
+		if [ "${container_no_entry}" -eq 0 ]; then
+			"$(dirname "$(realpath "${0}")")/distrobox-generate-entry" "${container_name}"
+		fi
 	fi
 	exit $?
 fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -270,6 +270,7 @@ container_user_custom_home="/home/.local/share/container-home-test"
 container_image="registry.opensuse.org/opensuse/toolbox:latest"
 container_manager="docker"
 container_name="test-name-1"
+container_no_entry=0
 non_interactive="1"
 skip_workdir="0"
 ```
@@ -281,6 +282,7 @@ Alternatively it is possible to specify preferences using ENV variables:
 - DBX_CONTAINER_IMAGE
 - DBX_CONTAINER_MANAGER
 - DBX_CONTAINER_NAME
+- DBX_CONTAINER_NO_ENTRY
 - DBX_NON_INTERACTIVE
 - DBX_SKIP_WORKDIR
 

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -33,6 +33,7 @@ graphical apps (X11/Wayland), and audio.
 	--init/-I		use init system (like systemd) inside the container.
 				this will make host's processes not visible from within the container.
 	--help/-h:		show this message
+	--no-entry:             do not generate a container entry in the application list
 	--dry-run/-d:		only print the container manager command generated
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version


### PR DESCRIPTION
I have found myself not always needing the automatic application entry generation so I implemented a way to disable it