### PR TITLE
Redundant "else" in readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -307,7 +307,7 @@ Here is a list of alternative ways to install distrobox
 
 ### Curl
 
-Else, if you like to live your life dangerously, or you want the latest release,
+If you like to live your life dangerously, or you want the latest release,
 you can trust me and simply run this in your terminal:
 
 ```sh


### PR DESCRIPTION
The placement of `else` does not make sense with the flow of the chapters. `Alternative methods` does not contain a prior statement which should be "else-d".