### PR TITLE
Fix using --home with space in path.

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -503,7 +503,7 @@ generate_command() {
 		result_command="${result_command}
 			--env \"HOME=${container_user_custom_home}\"
 			--env \"DISTROBOX_HOST_HOME=${container_user_home}\"
-			--volume ${container_user_custom_home}:${container_user_custom_home}:rslave"
+			--volume \"${container_user_custom_home}:${container_user_custom_home}:rslave\""
 	fi
 
 	# Mount also the /var/home dir on ostree based systems


### PR DESCRIPTION
When you try to use `distrobox-create --home` with a home directory that has a space in it, it errors out. This fixes that.