### PR TITLE
Remove quote marks in fish tutorial

### DIFF
--- a/docs/posts/execute_commands_on_host.md
+++ b/docs/posts/execute_commands_on_host.md
@@ -97,7 +97,7 @@ Place this snippet in a new fish function file (`~/.config/fish/functions/fish_c
 function fish_command_not_found
     # "In a container" check
     if test -e /run/.containerenv -o -e /.dockerenv
-        distrobox-host-exec "$argv"
+        distrobox-host-exec $argv
     else
         __fish_default_command_not_found_handler $argv
     end


### PR DESCRIPTION
this works:

```fish
> distrobox-host-exec podman version
Client:       Podman Engine
Version:      4.2.0
API Version:  4.2.0
Go Version:   go1.18.4
Built:        Thu Aug 11 22:42:17 2022
OS/Arch:      linux/amd64
```

this doesn't:

```fish
> distrobox-host-exec "podman version"
Failed to start command: Failed to execute child process “podman version” (No such file or directory)
```

Quote marks need to be removed in order for the integration to work.