### PR TITLE
Remove shebangs from bash completions

### DIFF
--- a/completions/distrobox
+++ b/completions/distrobox
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 _generate_from_help() {

--- a/completions/distrobox-create
+++ b/completions/distrobox-create
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-enter
+++ b/completions/distrobox-enter
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-ephemeral
+++ b/completions/distrobox-ephemeral
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-generate-entry
+++ b/completions/distrobox-generate-entry
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-list
+++ b/completions/distrobox-list
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-rm
+++ b/completions/distrobox-rm
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-stop
+++ b/completions/distrobox-stop
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then

--- a/completions/distrobox-upgrade
+++ b/completions/distrobox-upgrade
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=all
 
 if [ -e /usr/share/bash-completion/completions/distrobox ]; then


### PR DESCRIPTION
These files start with the #! sequence that marks interpreted scripts, but they are bash completion scripts that is merely intended to be sourced.

See https://lintian.debian.org/tags/bash-completion-with-hashbang

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>