### PR TITLE
Do not open manpager automatically

### DIFF
--- a/distrobox
+++ b/distrobox
@@ -89,10 +89,6 @@ case "${distrobox_command}" in
 		exit 0
 		;;
 	help | --help | -h)
-		if command -v man > /dev/null; then
-			man distrobox || show_help
-			exit 0
-		fi
 		show_help
 		exit 0
 		;;


### PR DESCRIPTION
`distrobox --help` checks if man is present and acts as if `man distrobox` was executed by the user. Other commands do not exhibit this behaviour and I believe the wrapper should not be an outlier.
My belief is if a user wanted to open a manpage they would have called `man` themselves.