### PR TITLE
enter/export: handle quotes in arguments in a better way

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -179,7 +179,10 @@ while :; do
 			for arg in "$@"; do
 				if echo "${arg}" | grep -Eq "'|\""; then
 					container_command="${container_command} \
-						$(echo "${arg}" | sed "s|'|\\\'|g" | sed 's|"|\\\"|g')"
+						$(echo "${arg}" | sed 's|\\|\\\\|g' |
+						sed 's| |\\ |g' |
+						sed "s|'|\\\'|g" |
+						sed 's|"|\\\"|g')"
 				elif echo "${arg}" | grep -q '"'; then
 					container_command="${container_command}  '${arg}'"
 				else

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -181,6 +181,7 @@ while :; do
 					container_command="${container_command} \
 						$(echo "${arg}" | sed 's|\\|\\\\|g' |
 						sed 's| |\\ |g' |
+						sed 's|\$|\\\$|g' |
 						sed "s|'|\\\'|g" |
 						sed 's|"|\\\"|g')"
 				elif echo "${arg}" | grep -q '"'; then

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -184,10 +184,10 @@ while :; do
 						sed 's|\$|\\\$|g' |
 						sed "s|'|\\\'|g" |
 						sed 's|"|\\\"|g')"
-				elif echo "${arg}" | grep -q '"'; then
-					container_command="${container_command}  '${arg}'"
-				else
+				elif echo "${arg}" | grep -q "'"; then
 					container_command="${container_command}  \"${arg}\""
+				else
+					container_command="${container_command}  '${arg}'"
 				fi
 			done
 			break

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -177,7 +177,10 @@ while :; do
 			container_command="$1"
 			shift
 			for arg in "$@"; do
-				if echo "${arg}" | grep -q '"'; then
+				if echo "${arg}" | grep -Eq "'|\""; then
+					container_command="${container_command} \
+						$(echo "${arg}" | sed "s|'|\\\'|g" | sed 's|"|\\\"|g')"
+				elif echo "${arg}" | grep -q '"'; then
 					container_command="${container_command}  '${arg}'"
 				else
 					container_command="${container_command}  \"${arg}\""

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -302,7 +302,7 @@ generate_command() {
 	fi
 	result_command="${result_command}
 		--workdir=\"${workdir}\"
-		--env \"CONTAINER_ID=${container_id}\"
+		--env \"CONTAINER_ID=${container_name}\"
 		--env \"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
 	# Loop through all the environment vars
 	# and export them to the container.
@@ -391,11 +391,9 @@ if [ "${dryrun}" -ne 0 ]; then
 fi
 
 # Now inspect the container we're working with.
-container_id="unknown"
 container_status="unknown"
 eval "$(${container_manager} inspect --type container "${container_name}" --format \
-	'container_id={{.Id}};
-	container_status={{.State.Status}};
+	'container_status={{.State.Status}};
 	{{range .Config.Env}}{{if slice . 0 5 | eq "HOME="}}container_home={{slice . 5 | printf "%q"}};{{end}}{{end}}
 	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}')"
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -185,9 +185,9 @@ while :; do
 						sed "s|'|\\\'|g" |
 						sed 's|"|\\\"|g')"
 				elif echo "${arg}" | grep -q "'"; then
-					container_command="${container_command}  \"${arg}\""
+					container_command="${container_command} \"${arg}\""
 				else
-					container_command="${container_command}  '${arg}'"
+					container_command="${container_command} '${arg}'"
 				fi
 			done
 			break

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -173,7 +173,16 @@ while :; do
 			;;
 		-e | --exec | --)
 			shift
-			container_command=$*
+			# container_command=$*
+			container_command="$1"
+			shift
+			for arg in "$@"; do
+				if echo "$arg" | grep -q '"'; then
+					container_command="$container_command  '${arg}'"
+				else
+					container_command="$container_command  \"${arg}\""
+				fi
+			done
 			break
 			;;
 		-*) # Invalid options.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -177,10 +177,10 @@ while :; do
 			container_command="$1"
 			shift
 			for arg in "$@"; do
-				if echo "$arg" | grep -q '"'; then
-					container_command="$container_command  '${arg}'"
+				if echo "${arg}" | grep -q '"'; then
+					container_command="${container_command}  '${arg}'"
 				else
-					container_command="$container_command  \"${arg}\""
+					container_command="${container_command}  \"${arg}\""
 				fi
 			done
 			break

--- a/distrobox-export
+++ b/distrobox-export
@@ -247,8 +247,17 @@ generate_script() {
 # distrobox_binary
 # name: ${container_name}
 if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
-    ${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
-${is_sudo} ${exported_bin} ${extra_flags} "\$@"
+    command="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
+${is_sudo} ${exported_bin} ${extra_flags} "
+
+	for arg in "\$@"; do
+		if echo "\${arg}" | grep -q '"'; then
+			command="\${command}  '\${arg}'"
+		else
+			command="\${command}  \"\${arg}\""
+		fi
+	done
+	eval "\${command}"
 else
     ${exported_bin} "\$@"
 fi

--- a/distrobox-export
+++ b/distrobox-export
@@ -240,14 +240,14 @@ fi
 # Arguments:
 #	none it will use the ones set up globally
 # Outputs:
-#   print generated script.
+#	print generated script.
 generate_script() {
 	cat << EOF
 #!/bin/sh
 # distrobox_binary
 # name: ${container_name}
 if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
-    command="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
+	command="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
 ${is_sudo} ${exported_bin} ${extra_flags} "
 
 	for arg in "\$@"; do
@@ -259,14 +259,14 @@ ${is_sudo} ${exported_bin} ${extra_flags} "
 				sed "s|'|\\\\\'|g" |
 				sed 's|"|\\\\\"|g')"
 		elif echo "\${arg}" | grep -q "'"; then
-			command="\${command}  \"\${arg}\""
+			command="\${command} \"\${arg}\""
 		else
-			command="\${command}  '\${arg}'"
+			command="\${command} '\${arg}'"
 		fi
 	done
 	exec \${command}
 else
-    ${exported_bin} "\$@"
+	${exported_bin} "\$@"
 fi
 EOF
 	return $?

--- a/distrobox-export
+++ b/distrobox-export
@@ -251,7 +251,13 @@ if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
 ${is_sudo} ${exported_bin} ${extra_flags} "
 
 	for arg in "\$@"; do
-		if echo "\${arg}" | grep -q '"'; then
+		if echo "\${arg}" | grep -Eq "'|\""; then
+			command="\${command} \\
+				\$(echo "\${arg}" | sed 's|\\\|\\\\\\\|g' |
+				sed 's| |\\\ |g' |
+				sed "s|'|\\\\\'|g" |
+				sed 's|"|\\\\\"|g')"
+		elif echo "\${arg}" | grep -q '"'; then
 			command="\${command}  '\${arg}'"
 		else
 			command="\${command}  \"\${arg}\""

--- a/distrobox-export
+++ b/distrobox-export
@@ -255,6 +255,7 @@ ${is_sudo} ${exported_bin} ${extra_flags} "
 			command="\${command} \\
 				\$(echo "\${arg}" | sed 's|\\\|\\\\\\\|g' |
 				sed 's| |\\\ |g' |
+				sed 's|\\$|\\\\\\$|g' |
 				sed "s|'|\\\\\'|g" |
 				sed 's|"|\\\\\"|g')"
 		elif echo "\${arg}" | grep -q '"'; then

--- a/distrobox-export
+++ b/distrobox-export
@@ -231,7 +231,7 @@ if [ -z "${container_name}" ]; then
 fi
 
 # Prefix to add to an existing command to work throught the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- '${is_sudo} "
+container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- ${is_sudo} "
 if [ -z "${exported_app_label}" ]; then
 	exported_app_label=" (on ${container_name})"
 fi
@@ -264,7 +264,7 @@ ${is_sudo} ${exported_bin} ${extra_flags} "
 			command="\${command} '\${arg}'"
 		fi
 	done
-	exec \${command}
+	eval \${command}
 else
 	${exported_bin} "\$@"
 fi
@@ -435,7 +435,6 @@ export_application() {
 		# throught the container separation
 		sed "s|^Exec=|Exec=${container_command_prefix} |g" "${desktop_file}" |
 			sed "s|\(%.*\)|${extra_flags} \1|g" |
-			sed "s|^Exec=.*|&'|g" |
 			sed "/^TryExec=.*/d" |
 			sed "/^DBusActivatable=true/d" |
 			sed "s|Name.*|& ${exported_app_label}|g" \
@@ -534,8 +533,7 @@ export_service() {
 			# Add extra flags
 			# Add closing quote
 			sed "s|^${exec_cmd}=|${exec_cmd}=${container_command_prefix}|g" "${temp_file}" |
-				sed "s|^${exec_cmd}=.*|& ${extra_flags}|g" |
-				sed "s|^${exec_cmd}=.*|&'|g" > "${exported_service_fullpath}"
+				sed "s|^${exec_cmd}=.*|& ${extra_flags}|g" > "${exported_service_fullpath}"
 			# in the end we add the final quote we've opened in the "container_command_prefix"
 		fi
 	done

--- a/distrobox-export
+++ b/distrobox-export
@@ -258,13 +258,13 @@ ${is_sudo} ${exported_bin} ${extra_flags} "
 				sed 's|\\$|\\\\\\$|g' |
 				sed "s|'|\\\\\'|g" |
 				sed 's|"|\\\\\"|g')"
-		elif echo "\${arg}" | grep -q '"'; then
-			command="\${command}  '\${arg}'"
-		else
+		elif echo "\${arg}" | grep -q "'"; then
 			command="\${command}  \"\${arg}\""
+		else
+			command="\${command}  '\${arg}'"
 		fi
 	done
-	eval "\${command}"
+	exec \${command}
 else
     ${exported_bin} "\$@"
 fi

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -1,5 +1,4 @@
 - [Distrobox](README.md)
-  - [Execute complex commands directly from distrobox enter](#execute-complex-commands-directly-from-distrobox-enter)
   - [Create a distrobox with a custom HOME directory](#create-a-distrobox-with-a-custom-home-directory)
   - [Mount additional volumes in a distrobox](#mount-additional-volumes-in-a-distrobox)
   - [Use a different shell than the host](#use-a-different-shell-than-the-host)
@@ -36,20 +35,6 @@ For containers generated with older versions, you can use:
 To delete it:
 
 `distrobox generate-entry you-container-name --delete`
-
-## Execute complex commands directly from distrobox enter
-
-Sometimes it is necessary to execure complex commands from a distrobox enter,
-like multiple concatenated commands using variables declared **inside** the container.
-
-For example:
-
-`distrobox enter test -- bash -l -c '"echo \$HOME && whoami"'`
-
-Note the use of **single quotes around double quotes**, this is necessary so that
-quotes are preserved inside the arguments. Also note the **dollar escaping** needed
-so that $HOME is not evaluated at the time of the command launch, but directly
-inside the container.
 
 ## Create a distrobox with a custom HOME directory
 


### PR DESCRIPTION
This enables the use of spaced arguments, quotes and special chars handling in both enter and export

Fix #439

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>