### PR TITLE
compatibility: add gentoo docker image

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -379,10 +379,20 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		fi
 
 	elif command -v emerge; then
+		# Check if the container we are using has a ::gentoo repo defined,
+		# if it is defined and it is empty, then synchroznize it.
+		gentoo_repo="$(portageq get_repo_path / gentoo)"
+		if [ -n "${gentoo_repo}" ] && [ ! -e "${gentoo_repo}" ] ; then
+			emerge-webrsync
+		fi
+		# If we need to upgrade, do it and exit, no further action required.
+		if [ "${upgrade}" -ne 0 ] ; then
+			emerge --sync
+			exit
+		fi
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.
-		emerge --sync --quiet
 		if ! emerge --ask=n --autounmask-continue --noreplace --quiet-build "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -382,11 +382,11 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# Check if the container we are using has a ::gentoo repo defined,
 		# if it is defined and it is empty, then synchroznize it.
 		gentoo_repo="$(portageq get_repo_path / gentoo)"
-		if [ -n "${gentoo_repo}" ] && [ ! -e "${gentoo_repo}" ] ; then
+		if [ -n "${gentoo_repo}" ] && [ ! -e "${gentoo_repo}" ]; then
 			emerge-webrsync
 		fi
 		# If we need to upgrade, do it and exit, no further action required.
-		if [ "${upgrade}" -ne 0 ] ; then
+		if [ "${upgrade}" -ne 0 ]; then
 			emerge --sync
 			exit
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -388,16 +388,18 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		fi
 		emerge --ask=n --autounmask-continue --noreplace --quiet-build \
 			"${shell_pkg}" \
+			app-crypt/gnupg \
 			bc \
-			net-misc/curl \
 			diffutils \
 			findutils \
 			less \
 			ncurses \
+			net-misc/curl \
 			pinentry \
 			procps \
 			shadow \
 			sudo \
+			sys-process/lsof \
 			util-linux \
 			wget
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -382,7 +382,7 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.
-		emerge --sync
+		emerge --sync --quiet
 		if ! emerge --ask=n --autounmask-continue --noreplace --quiet-build "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -382,6 +382,7 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.
+		emerge --sync
 		if ! emerge --ask=n --autounmask-continue --noreplace --quiet-build "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi
@@ -398,8 +399,7 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 			shadow \
 			sudo \
 			util-linux \
-			wget \
-			x11-libs/vte
+			wget
 
 	elif command -v microdnf; then
 		# If we need to upgrade, do it and exit, no further action required.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -154,7 +154,7 @@ Distrobox guests tested successfully with the following container images:
 | Debian | Testing    | docker.io/library/debian:testing  <br>  docker.io/library/debian:testing-backports    |
 | Debian | Unstable | docker.io/library/debian:unstable    |
 | Fedora | 35 <br> 36 <br> 37 <br> Rawhide | registry.fedoraproject.org/fedora-toolbox:35 <br> quay.io/fedora/fedora:35 <br> quay.io/fedora/fedora:36 <br> registry.fedoraproject.org/fedora:37 <br> quay.io/fedora/fedora:rawhide    |
-| Gentoo Linux | rolling | You will have to [Build your own](distrobox_gentoo.md) to have a complete Gentoo docker image |
+| Gentoo Linux | rolling | docker.io/gentoo/stage3:latest |
 | Kali Linux | rolling | docker.io/kalilinux/kali-rolling:latest |
 | Mageia | 8 | docker.io/library/mageia |
 | Neurodebian | nd100 | docker.io/library/neurodebian:nd100 |


### PR DESCRIPTION
Turns out that we can use the `stage3` image as a normal container. This (with the addition of `emerge --sync`) can solve the problem of providing and testing gentoo in the CI.

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>