### PR TITLE
Complete rewrite of exec argument handling to handle spaces in quoted args.

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -39,7 +39,6 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Defaults
-container_command=""
 container_image=""
 container_image_default="registry.fedoraproject.org/fedora-toolbox:36"
 container_manager="autodetect"
@@ -173,7 +172,8 @@ while :; do
 			;;
 		-e | --exec | --)
 			shift
-			container_command=$*
+			# Do nothing except consume the argument and break. We will
+			# use "$@" to preserve spaces in the remaining args.
 			break
 			;;
 		-*) # Invalid options.
@@ -244,125 +244,6 @@ fi
 if [ "${rootful}" -ne 0 ]; then
 	container_manager="${distrobox_sudo_program} ${container_manager}"
 fi
-
-# Generate Podman or Docker command to execute.
-# Arguments:
-#   None
-# Outputs:
-#   prints the podman or docker command to enter the distrobox container
-generate_command() {
-	result_command="${container_manager} exec"
-	result_command="${result_command}
-		--interactive
-		--user=\"${USER}\""
-
-	# For some usage, like use in service, or launched by non-terminal
-	# eg. from desktop files, TTY can fail to instantiate, and fail to enter
-	# the container.
-	# To work around this, --headless let's you skip the --tty flag and make it
-	# work in tty-less situations.
-	# Disable tty also if we're NOT in a tty (test -t 0).
-	if [ "${headless}" -eq 0 ] && [ -t 0 ]; then
-		result_command="${result_command}
-			--tty"
-	fi
-
-	# Entering container using our user and workdir.
-	# Start container from working directory. Else default to home. Else do /.
-	# Since we are entering from host, drop at workdir through '/run/host'
-	# which represents host's root inside container. Any directory on host
-	# even if not explicitly mounted is bound to exist under /run/host.
-	# Since user $HOME is very likely present in container, enter there directly
-	# to avoid confusing the user about shifted paths.
-	# pass distrobox-enter path, it will be used in the distrobox-export tool.
-	if [ "${skip_workdir}" -eq 0 ]; then
-		workdir="$(echo "${PWD:-${container_home:-"/"}}" | sed -e 's/"/\\\"/g')"
-		if [ -n "${workdir##*"${container_home}"*}" ]; then
-			workdir="/run/host${workdir}"
-		fi
-	else
-		# Skipping workdir we just enter $HOME of the container.
-		workdir="${container_home}"
-	fi
-	result_command="${result_command}
-		--workdir=\"${workdir}\"
-		--env \"CONTAINER_ID=${container_id}\"
-		--env \"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
-	# Loop through all the environment vars
-	# and export them to the container.
-	set +o xtrace
-	# disable logging fot this snippet, or it will be too talkative.
-	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
-		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|SHELL|XDG_.*_DIRS|^_)'); do
-		# We filter the environment so that we do not have strange variables,
-		# multiline or containing spaces.
-		# We also NEED to ignore the HOME variable, as this is set at create time
-		# and needs to stay that way to use custom home dirs.
-		result_command="${result_command} --env \"${i}\""
-	done
-
-	# Start with the $PATH set in the container's config
-	container_paths="${container_path:-""}"
-	# Ensure the standard FHS program paths are in PATH environment
-	standard_paths="/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin"
-	# add to the PATH after the existing paths, and only if not already present
-	for standard_path in ${standard_paths}; do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
-			container_paths="${container_paths}:${standard_path}"
-		fi
-	done
-	# Ensure the $PATH entries from the host are appended as well
-	for standard_path in $(echo "${PATH}" | tr ':' ' '); do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
-			container_paths="${container_paths}:${standard_path}"
-		fi
-	done
-	result_command="${result_command} --env \"PATH=${container_paths}\""
-
-	# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment
-	standard_paths="/usr/local/share /usr/share"
-	container_paths="${XDG_DATA_DIRS:=}"
-	# add to the XDG_DATA_DIRS only after the host's paths, and only if not already present.
-	for standard_path in ${standard_paths}; do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
-			container_paths="${container_paths}:${standard_path}"
-		fi
-	done
-	result_command="${result_command} --env \"XDG_DATA_DIRS=${container_paths}\""
-
-	# Ensure the standard FHS program paths are in XDG_CONFIG_DIRS environment
-	standard_paths="/etc/xdg"
-	container_paths="${XDG_CONFIG_DIRS:=}"
-	# add to the XDG_CONFIG_DIRS only after the host's paths, and only if not already present.
-	for standard_path in ${standard_paths}; do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
-			container_paths="${container_paths}:${standard_path}"
-		fi
-	done
-	result_command="${result_command} --env \"XDG_CONFIG_DIRS=${container_paths}\""
-
-	# re-enable logging if it was enabled previously.
-	if [ "${verbose}" -ne 0 ]; then
-		set -o xtrace
-	fi
-
-	# Add additional flags
-	result_command="${result_command} ${container_manager_additional_flags}"
-
-	# Run selected container with specified command.
-	result_command="${result_command} ${container_name}"
-
-	if [ -n "${container_command}" ]; then
-		result_command="${result_command} ${container_command}"
-	else
-		# if no command was specified, let's execute a command that will find
-		# and run the default shell for the user
-		result_command="${result_command} sh -c \"\\\$(getent passwd ${USER} | cut -f 7 -d :) -l"\"
-	fi
-
-	# Return generated command.
-	printf "%s" "${result_command}"
-}
 
 container_home="${HOME}"
 container_path="${PATH}"
@@ -498,7 +379,109 @@ if [ "${container_status}" != "running" ]; then
 	printf >&2 "\nContainer Setup Complete!\n"
 fi
 
-# Generate the exec command and run it
-cmd="$(generate_command)"
-# shellcheck disable=SC2086
-eval ${cmd}
+# Time to generate the command.
+
+command_prefix="${container_manager} exec"
+command_prefix="${command_prefix} --interactive --user=\"${USER}\""
+
+# For some usage, like use in service, or launched by non-terminal
+# eg. from desktop files, TTY can fail to instantiate, and fail to enter
+# the container.
+# To work around this, --headless let's you skip the --tty flag and make it
+# work in tty-less situations.
+# Disable tty also if we're NOT in a tty (test -t 0).
+if [ "${headless}" -eq 0 ] && [ -t 0 ]; then
+	command_prefix="${command_prefix} --tty"
+fi
+
+# Entering container using our user and workdir.
+# Start container from working directory. Else default to home. Else do /.
+# Since we are entering from host, drop at workdir through '/run/host'
+# which represents host's root inside container. Any directory on host
+# even if not explicitly mounted is bound to exist under /run/host.
+# Since user $HOME is very likely present in container, enter there directly
+# to avoid confusing the user about shifted paths.
+# pass distrobox-enter path, it will be used in the distrobox-export tool.
+if [ "${skip_workdir}" -eq 0 ]; then
+	workdir="$(echo "${PWD:-${container_home:-"/"}}" | sed -e 's/"/\\\"/g')"
+	if [ -n "${workdir##*"${container_home}"*}" ]; then
+		workdir="/run/host${workdir}"
+	fi
+else
+	# Skipping workdir we just enter $HOME of the container.
+	workdir="${container_home}"
+fi
+command_prefix="${command_prefix} --workdir=\"${workdir}\" --env \"CONTAINER_ID=${container_id}\" --env \"DISTROBOX_ENTER_PATH=${distrobox_enter_path}\""
+# Loop through all the environment vars
+# and export them to the container.
+set +o xtrace
+# disable logging fot this snippet, or it will be too talkative.
+for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
+	grep -Ev '^(HOST|HOSTNAME|HOME|PATH|SHELL|XDG_.*_DIRS|^_)'); do
+	# We filter the environment so that we do not have strange variables,
+	# multiline or containing spaces.
+	# We also NEED to ignore the HOME variable, as this is set at create time
+	# and needs to stay that way to use custom home dirs.
+	command_prefix="${command_prefix} --env \"${i}\""
+done
+
+# Start with the $PATH set in the container's config
+container_paths="${container_path:-""}"
+# Ensure the standard FHS program paths are in PATH environment
+standard_paths="/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin"
+# add to the PATH after the existing paths, and only if not already present
+for standard_path in ${standard_paths}; do
+	if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+		container_paths="${container_paths}:${standard_path}"
+	fi
+done
+# Ensure the $PATH entries from the host are appended as well
+for standard_path in $(echo "${PATH}" | tr ':' ' '); do
+	if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+		container_paths="${container_paths}:${standard_path}"
+	fi
+done
+command_prefix="${command_prefix} --env \"PATH=${container_paths}\""
+
+# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment
+standard_paths="/usr/local/share /usr/share"
+container_paths="${XDG_DATA_DIRS:=}"
+# add to the XDG_DATA_DIRS only after the host's paths, and only if not already present.
+for standard_path in ${standard_paths}; do
+	if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+		container_paths="${container_paths}:${standard_path}"
+	fi
+done
+command_prefix="${command_prefix} --env \"XDG_DATA_DIRS=${container_paths}\""
+
+# Ensure the standard FHS program paths are in XDG_CONFIG_DIRS environment
+standard_paths="/etc/xdg"
+container_paths="${XDG_CONFIG_DIRS:=}"
+# add to the XDG_CONFIG_DIRS only after the host's paths, and only if not already present.
+for standard_path in ${standard_paths}; do
+	if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+		container_paths="${container_paths}:${standard_path}"
+	fi
+done
+command_prefix="${command_prefix} --env \"XDG_CONFIG_DIRS=${container_paths}\""
+
+# re-enable logging if it was enabled previously.
+if [ "${verbose}" -ne 0 ]; then
+	set -o xtrace
+fi
+
+# Add additional flags
+command_prefix="${command_prefix} ${container_manager_additional_flags}"
+
+# Run selected container with specified command.
+command_prefix="${command_prefix} ${container_name}"
+
+if ! [ "${1:-}" ]; then
+	# if no command was specified, let's execute a command that will find
+	# and run the default shell for the user
+	set -- "$(getent passwd "${USER}" | cut -f 7 -d :)" "-l"
+fi
+
+eval "set -- ${command_prefix} \"\$@\""
+
+exec "$@"


### PR DESCRIPTION
Fixes #439. Probably also fixes some other things, too; I consistently got errors after entering distrobox environments, and now I don't anymore.

* Moves the entirety of the `generate_command` function out of a function, and over to the only place where it is actually called.
* Completely drops the `container_command` variable, and instead relies on `$@` for preserving spaces.
* Renames `result_command` to `command_prefix`.
* Moving it out of a function means no more `printf` into stdout into command substitution; that was redundant and possibly harmful.
* Uses `eval` to interpret manual quoting inside the `command_prefix` variable when prepending it to `$@`.
* Drops the newlines and tabs from the variable assignments because newlines in `eval` mean "command args are over, here is a new command"
* Simplifies looking up the shell from `/etc/passwd` as a fallback command.

Simple test case for #439:

```
echo 'hiya!' > "/tmp/with-spaces"
distrobox enter $your_fave_container -- cat "/tmp/with spaces"
```

Without this fix, it tries to cat two separate files: "/tmp/with" and "spaces". With this fix, quoting and spacing is preserved. You can call your `distrobox enter` commands naturally, as you would with any other command, without any additional quoting or spacing acrobatics.