### PR TITLE
Update handler function to support bash scripts

### DIFF
--- a/docs/posts/execute_commands_on_host.md
+++ b/docs/posts/execute_commands_on_host.md
@@ -82,7 +82,7 @@ command_not_found_handle() {
   
   distrobox-host-exec "${@}"
 }
-if [ -n "${ZSH_VERSION-}${BASH_VERSION-}" ]; then
+if [ -n "${ZSH_VERSION-}" ]; then
   command_not_found_handler() {
     command_not_found_handle "$@"
  }

--- a/docs/posts/execute_commands_on_host.md
+++ b/docs/posts/execute_commands_on_host.md
@@ -82,12 +82,14 @@ command_not_found_handle() {
   
   distrobox-host-exec "${@}"
 }
-if [ -n "${ZSH_VERSION-}" ]; then
+if [ -n "${ZSH_VERSION-}${BASH_VERSION-}" ]; then
   command_not_found_handler() {
     command_not_found_handle "$@"
  }
 fi
 ```
+
+And then, run `source ~/.profile` to reload `.profile` in the current session.
 
 ## fish
 


### PR DESCRIPTION
`command_not_found_handler` only checks for `$ZSH_VERSION` environment variable. To support bash as well, we need to check for `$BASH_VERSION` environment variable.

Plus, give a tip to ensure that the change has an effect as we do in the `fish` section.