### PR TITLE
init: fix sudoers spam (missing \" in check)

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -902,7 +902,7 @@ if ! grep -q 'Defaults !fqdn' /etc/sudoers.d/sudoers; then
 	printf "Defaults !fqdn\n" >> /etc/sudoers.d/sudoers
 fi
 # Ensure passwordless sudo is set up for user
-if ! grep -q "${container_user_name} ALL = (root) NOPASSWD:ALL" /etc/sudoers.d/sudoers; then
+if ! grep -q "\"${container_user_name}\" ALL = (root) NOPASSWD:ALL" /etc/sudoers.d/sudoers; then
 	printf "\"%s\" ALL = (root) NOPASSWD:ALL\n" "${container_user_name}" >> /etc/sudoers.d/sudoers
 fi
 


### PR DESCRIPTION
I noticed that `/etc/sudoers.d/sudoers` kept gaining a line every time the container started. I thus checked the init script and saw that the checked string doesn't match the printed string 😄 It prints `"user"` but only checks for `user` - this PR fixes that.

Thank you for creating and maintaining this!