### PR TITLE
Fix cni_plugin_dirs

### DIFF
--- a/extras/install-podman
+++ b/extras/install-podman
@@ -161,7 +161,6 @@ exit_command_delay = 10
 # can be runc, crun
 runtime = "crun"
 stop_timeout = 5
-cni_plugin_dirs = [ "${dest_path}/lib/cni" ]
 conmon_path=[ "${dest_path}/lib/podman/conmon" ]
 helper_binaries_dir = [ "${dest_path}/lib/podman" ]
 static_dir = "${dest_path}/share/podman/libpod"
@@ -169,6 +168,8 @@ volume_path = "${dest_path}/share/podman/volume"
 [engine.runtimes]
 crun = [ "${dest_path}/bin/crun" ]
 runc = [ "${dest_path}/bin/runc" ]
+[network]
+cni_plugin_dirs = [ "${dest_path}/lib/cni" ]
 EOF
 
 # Same for mouning programs


### PR DESCRIPTION
I was having an issue with networking and found the configuration for cni_plugin_dirs wasn't being referenced. The configuration document suggests it needed to be in the [network] section. After moving it there, cni was able to find the plugins it said were missing.

https://github.com/containers/common/blob/main/docs/containers.conf.5.md#network-table