### PR TITLE
Small clarifications

### DIFF
--- a/docs/posts/run_latest_gnome_kde_on_distrobox.md
+++ b/docs/posts/run_latest_gnome_kde_on_distrobox.md
@@ -49,6 +49,8 @@ user@fedora-rawhide:~$ sudo ln -s /run/host/run/systemd/system /run/systemd
 user@fedora-rawhide:~$ sudo ln -s /run/host/run/dbus/system_bus_socket /run/dbus/
 ```
 
+If you get an error message, you might have to manually create the folders `/run/systemd` and `/run/dbus` with `sudo mkdir`.
+
 Then we can proceed to install GNOME in the container:
 
 ```shell
@@ -70,7 +72,7 @@ container so we need to change the ownership from `root` to `$USER` each time.
 Let's add:
 
 ```shell
-chown -R $USER:$USER /tmp/.X11-unix
+chown -f -R $USER:$USER /tmp/.X11-unix
 ```
 
 to `/etc/profile.d/fix_tmp.sh` file.
@@ -78,7 +80,7 @@ to `/etc/profile.d/fix_tmp.sh` file.
 This is needed for the XWayland session to work properly which right now is
 necessary to run gnome-shell even on wayland.
 
-Then we need to add a desktop file for the session on the host's file system,
+Then we need to add a desktop file for the session on the **host's** file system,
 so that it appears on your login manager (Be it SSDM or GDM)
 
 ```shell
@@ -92,6 +94,7 @@ X-GDM-SessionRegisters=true
 ```
 
 This file should be placed under `/usr/local/share/wayland-sessions/distrobox-gnome.desktop`
+(If it doesn't show up, you can place it under `/usr/share/xsessions/distrobox-gnome.desktop`)
 
 Let's log out and voilá!
 
@@ -123,7 +126,7 @@ user@fedora-rawhide:~$ sudo dnf groupinstall KDE
 
 ### Generate session file - Plasma
 
-We need to add a desktop file for the session on the host's file system,
+We need to add a desktop file for the session on the **host's** file system,
 so that it appears on your login manager (Be it SSDM or GDM)
 
 ```shell
@@ -135,6 +138,7 @@ X-KDE-PluginInfo-Version=5.23.3
 ```
 
 This file should be placed under `/usr/local/share/wayland-sessions/distrobox-plasma.desktop`
+(If it doesn't show up, you can place it under `/usr/share/xsessions/distrobox-plasma.desktop`)
 
 ### Add a couple of fixes
 
@@ -148,7 +152,7 @@ container so we need to change the ownership from `root` to `$USER` each time.
 Let's add:
 
 ```shell
-chown -R $USER:$USER /tmp/.X11-unix
+chown -f -R $USER:$USER /tmp/.X11-unix
 ```
 
 to `/etc/profile.d/fix_tmp.sh` file.


### PR DESCRIPTION
When trying the GNOME instructions (on Debian 11 Stable) I had to:
- manually create the folder /run/dbus in fedora-rawhide.
- add the flag -f to chown (otherwise it gave an `Operation not permitted` error) in fedora-rawhide.
- add the .desktop file to `/usr/share/xsessions` instead of `/usr/local/share/wayland-sessions/` for it to show in the login window. 

I also made the word host bold when talking about adding the .desktop entry, even if that should be obvious. Since all other instructions are inside fedora-rawhide, one might forget to exit before that step.

(Written from GNOME 43 on Fedora-Rawhide on Debian 11 Stable)