### PR TITLE
Add --network option

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -58,6 +58,8 @@ container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"
 container_user_uid="$(id -ru)"
+container_network=""
+container_network_default="host"
 distrobox_sudo_program="sudo"
 dryrun=0
 init=0
@@ -143,6 +145,7 @@ Options:
 				of the same environment.
 	--home/-H:		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume:		additional volumes to add to the container
+	--network:		select a network namespace for the container
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--init-hooks:		additional commands to execute during container initialization
 	--pre-init-hooks:	additional commands to execute prior to container initialization
@@ -258,6 +261,13 @@ while :; do
 				shift
 			fi
 			;;
+		--network)
+			if [ -n "$2" ]; then
+				container_network="${2}"
+				shift
+				shift
+			fi
+			;;
 		--) # End of all options.
 			shift
 			break
@@ -311,6 +321,10 @@ fi
 #	ghcr.io/void-linux/void-linux:latest-full-x86_64 -> void-linux-latest-full-x86_64
 if [ -z "${container_name}" ]; then
 	container_name="$(basename "${container_image}" | sed -E 's/[:.]/-/g')"
+fi
+
+if [ -z "${container_network}" ]; then
+	container_network="${container_network_default}"
 fi
 
 # We depend on a container manager let's be sure we have it
@@ -411,7 +425,7 @@ generate_command() {
 		--hostname \"${container_name}.$(uname -n)\"
 		--ipc host
 		--name \"${container_name}\"
-		--network host
+		--network ${container_network}
 		--privileged
 		--security-opt label=disable
 		--user root:root"
@@ -530,9 +544,13 @@ generate_command() {
 	# This is the bare minimum to ensure connectivity inside the container.
 	# These files, will then be kept updated by the main loop every 15 seconds.
 	result_command="${result_command}
-		--volume /etc/hosts:/etc/hosts:ro
-		--volume /etc/localtime:/etc/localtime:ro
-		--volume /etc/resolv.conf:/etc/resolv.conf:ro"
+		--volume /etc/localtime:/etc/localtime:ro"
+
+	if [ "${container_network}" = "${container_network_default}" ]; then
+		result_command="${result_command}
+			--volume /etc/hosts:/etc/hosts:ro
+			--volume /etc/resolv.conf:/etc/resolv.conf:ro"
+	fi
 
 	# These flags are not supported by docker, so we use them only if our
 	# container manager is podman.

--- a/distrobox-create
+++ b/distrobox-create
@@ -327,7 +327,7 @@ fi
 if [ -z "${container_network}" ]; then
 	container_network="${container_network_default}"
 elif [ "${container_network}" != "${container_network_default}" ]; then
-	printf "\--network does not work without --init. Enabling"
+	printf "The --network option does not work without --init. Enabling\n\n"
 	init=1
 fi
 

--- a/distrobox-create
+++ b/distrobox-create
@@ -145,7 +145,7 @@ Options:
 				of the same environment.
 	--home/-H:		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume:		additional volumes to add to the container
-	--network		select a custom network for the container, as accepted by
+	--network		(EXPERIMENTAL) select a custom network for the container, as accepted by
 				podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)	default: host
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--init-hooks:		additional commands to execute during container initialization
@@ -264,6 +264,7 @@ while :; do
 			;;
 		--network)
 			if [ -n "$2" ]; then
+				printf "Warning: --network is currently experimental and may not work in some configurations\n\n"
 				container_network="${2}"
 				shift
 				shift

--- a/distrobox-create
+++ b/distrobox-create
@@ -145,7 +145,8 @@ Options:
 				of the same environment.
 	--home/-H:		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume:		additional volumes to add to the container
-	--network:		select a network namespace for the container
+	--network		select a custom network for the container, as accepted by
+				podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)	default: host
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--init-hooks:		additional commands to execute during container initialization
 	--pre-init-hooks:	additional commands to execute prior to container initialization

--- a/distrobox-create
+++ b/distrobox-create
@@ -326,7 +326,7 @@ fi
 
 if [ -z "${container_network}" ]; then
 	container_network="${container_network_default}"
-else
+elif [ "${container_network}" != "${container_network_default}" ]; then
 	printf "\--network does not work without --init. Enabling"
 	init=1
 fi

--- a/distrobox-create
+++ b/distrobox-create
@@ -325,6 +325,9 @@ fi
 
 if [ -z "${container_network}" ]; then
 	container_network="${container_network_default}"
+else
+	printf "\--network does not work without --init. Enabling"
+	init=1
 fi
 
 # We depend on a container manager let's be sure we have it

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -27,7 +27,7 @@ graphical apps (X11/Wayland), and audio.
 				of the same environment.
 	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume		additional volumes to add to the container
-	--network		select a custom network for the container, as accepted by
+	--network		(EXPERIMENTAL) select a custom network for the container, as accepted by
 				podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)	default: host
 
 	--additional-flags/-a:	additional flags to pass to the container manager command

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -27,7 +27,8 @@ graphical apps (X11/Wayland), and audio.
 				of the same environment.
 	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume		additional volumes to add to the container
-	--network		select a network namespace for the container
+	--network		select a custom network for the container, as accepted by
+				podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)	default: host
 
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--init-hooks		additional commands to execute during container initialization

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -27,6 +27,8 @@ graphical apps (X11/Wayland), and audio.
 				of the same environment.
 	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
 	--volume		additional volumes to add to the container
+	--network		select a network namespace for the container
+
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--init-hooks		additional commands to execute during container initialization
 	--pre-init-hooks	additional commands to execute prior to container initialization

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -49,7 +49,8 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
---network       select a network namespace for the container
+--network       select a custom network for the container, as accepted by
+                podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)  default: host
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization
 --pre-init-hooks    additional commands to execute prior to container initialization

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -49,6 +49,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
+--network       select a network namespace for the container
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization
 --pre-init-hooks    additional commands to execute prior to container initialization

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -49,7 +49,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
---network       select a custom network for the container, as accepted by
+--network       (EXPERIMENTAL) select a custom network for the container, as accepted by
                 podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)  default: host
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -358,7 +358,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
---network       select a custom network for the container, as accepted by
+--network       (EXPERIMENTAL) select a custom network for the container, as accepted by
                 podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)  default: host
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -358,6 +358,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
+--network       select a network namespace for the container
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization
 --pre-init-hooks    additional commands to execute prior to container initialization

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -358,7 +358,8 @@ usb devices and graphical apps (X11/Wayland), and audio.
             of the same environment.
 --home/-H       select a custom HOME directory for the container. Useful to avoid host\[aq]s home littering with temp files.
 --volume        additional volumes to add to the container
---network       select a network namespace for the container
+--network       select a custom network for the container, as accepted by
+                podman or docker's --network option. Useful for per-container split tunneling of VPNs (implies --init)  default: host
 --additional-flags/-a:  additional flags to pass to the container manager command
 --init-hooks        additional commands to execute during container initialization
 --pre-init-hooks    additional commands to execute prior to container initialization


### PR DESCRIPTION
This patch experimentally implements the --network option to use custom networking other than the default "host". This generally works fine for networks created using "podman network create".

It's otherwise a relatively crude, experimental implementation, with limitations:

* There is no bash completion yet. The obvious solution is to check for docker or podman in the completion script itself and print the output of `podman network ls --format "{{.Name}}"`, but I wasn't sure about it.
* It requires --init. I could not get it to work properly without --init. The container has no Internet access after setup, probably because /etc/resolv.conf and /etc/hosts are mounted. I wasn't able to find a clean way to not mount those when --init is absent.

I have not tested this with rootful containers, and other networking modes such as "bridge" and "ns:". For the latter, I'd expect those to work fine.