### PR TITLE
Use separate `XDG_RUNTIME_DIR` when init system is used

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -133,6 +133,7 @@ Options:
 	--pre-init-hooks:	additional commands to execute prior to container initialization
 	--init/-I:		use init system (like systemd) inside the container.
 				this will make host's processes not visible from within the container.
+				`XDG_RUNTIME_DIR` and session bus will also be unshared.
 	--help/-h:		show this message
 	--no-entry:		do not generate a container entry in the application list
 	--dry-run/-d:		only print the container manager command generated

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -192,7 +192,7 @@ This will ensure SSH X-Forwarding will work when SSH-ing inside the distrobox:
 
 By default distrobox will integrate with host's flatpak directory and session bus if present:
 - `/var/lib/flatpak`
-- `$HOME` and by implication `$HOME/.local/share/flatpak`
+- `$HOME` and by implication `$HOME/.local/share/flatpak` / `$HOME/.var/app`
 - `$XDG_RUNTIME_DIR`
 
 If you want to have a separate system remote between host and container,
@@ -201,12 +201,14 @@ you can create your distrobox with the following command:
 
 ```sh
 distrobox create --name test --image your-chosen-image:tag \
+                        --home "/your/custom/home" \
                         --init \
                         --init-hooks 'umount /var/lib/flatpak'
                         ...
 ```
 
 - Specifically `--init` and `init-hooks` are required
+- `--home` can be used to separate host user's flatpak directory from container one
 
 Within container you need to start user session bus manually by executing:
 

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -190,15 +190,28 @@ This will ensure SSH X-Forwarding will work when SSH-ing inside the distrobox:
 
 ## Use distrobox to install different flatpaks from the host
 
-By default distrobox will integrate with host's flatpak directory if present:
-`/var/lib/flatpak` and obviously with the $HOME one.
+By default distrobox will integrate with host's flatpak directory and session bus if present:
+- `/var/lib/flatpak`
+- `$HOME` and by implication `$HOME/.local/share/flatpak`
+- `$XDG_RUNTIME_DIR`
 
 If you want to have a separate system remote between host and container,
-you can create your distrobox with the followint init-hook:
+and to make sure container's `xdg-desktop-portal` does not conflict with host's one,
+you can create your distrobox with the following command:
 
 ```sh
 distrobox create --name test --image your-chosen-image:tag \
-                        --init-hooks 'umount /var/lib/flatpak'`
+                        --init \
+                        --init-hooks 'umount /var/lib/flatpak'
+                        ...
+```
+
+- Specifically `--init` and `init-hooks` are required
+
+Within container you need to start user session bus manually by executing:
+
+```bash
+sudo systemctl start "user@$(id -u).service"
 ```
 
 After that you'll be able to have separate flatpaks between host and distrobox.

--- a/lib/create-command
+++ b/lib/create-command
@@ -172,10 +172,15 @@ generate_create_command() {
 			--volume \"/var/home/${container_user_name}\":\"/var/home/${container_user_name}\":rslave"
 	fi
 
-	# Mount also the XDG_RUNTIME_DIR to ensure functionality of the apps.
-	if [ -d "/run/user/${container_user_uid}" ]; then
+	if [ "${init}" -eq 0 ]; then
+		# Mount also the XDG_RUNTIME_DIR to ensure functionality of the apps.
+		if [ -d "/run/user/${container_user_uid}" ]; then
+			result_command="${result_command}
+				--volume /run/user/${container_user_uid}:/run/user/${container_user_uid}:rslave"
+		fi
+	else
 		result_command="${result_command}
-			--volume /run/user/${container_user_uid}:/run/user/${container_user_uid}:rslave"
+				--tmpfs /run/user"
 	fi
 
 	# These are dynamic configs needed by the container to function properly


### PR DESCRIPTION
Closes https://github.com/89luca89/distrobox/issues/523.

A very simple change to use a separate `XDG_RUNTIME_DIR` when `--init` flag is used.

This is marked as draft, you should decide if this is the way you want to do it.

---

`#524` / https://github.com/89luca89/distrobox/pull/525