### PR TITLE
use --entrypoint to override entrypoint defined by image

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -622,8 +622,11 @@ generate_command() {
 	# inside the container is moved to distrobox-enter, in the start phase.
 	# This is done to make init, export and host-exec location independent from
 	# the host, and easier to upgrade.
-	result_command="${result_command} ${container_image}
-		/usr/bin/entrypoint -v --name \"${container_user_name}\"
+  #
+  # We set the entrypoint _before_ running the container image so that 
+  # we can override any user provided entrypoint if need be
+	result_command="${result_command} --entrypoint /usr/bin/entrypoint 
+    ${container_image} -v --name \"${container_user_name}\"
 		--user ${container_user_uid}
 		--group ${container_user_gid}
 		--home \"${container_user_custom_home:-"${container_user_home}"}\"

--- a/distrobox-create
+++ b/distrobox-create
@@ -622,11 +622,11 @@ generate_command() {
 	# inside the container is moved to distrobox-enter, in the start phase.
 	# This is done to make init, export and host-exec location independent from
 	# the host, and easier to upgrade.
-  #
-  # We set the entrypoint _before_ running the container image so that 
-  # we can override any user provided entrypoint if need be
-	result_command="${result_command} --entrypoint /usr/bin/entrypoint 
-    ${container_image} -v --name \"${container_user_name}\"
+	#
+	# We set the entrypoint _before_ running the container image so that
+	# we can override any user provided entrypoint if need be
+	result_command="${result_command} --entrypoint /usr/bin/entrypoint
+	${container_image} -v --name \"${container_user_name}\"
 		--user ${container_user_uid}
 		--group ${container_user_gid}
 		--home \"${container_user_custom_home:-"${container_user_home}"}\"


### PR DESCRIPTION
This is a small change but is helpful for users with specific images that have their own entry point defined for another purpose but building a distrobox using the same image would be helpful for debugging purposes. 

I've tested this on Ubuntu 22.04 running docker and I've checked that [podman-create](https://docs.podman.io/en/latest/markdown/podman-create.1.html) has the same option. 