### PR TITLE
Add init and pre-init hook defaults as supported config options

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -30,7 +30,7 @@ jobs:
       distrobox_changed: ${{ steps.check_file_changed.outputs.distrobox_changed }}
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2
@@ -55,7 +55,7 @@ jobs:
       github.event.inputs.run_always == 'True'
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Fetch from compatibility table all the distros supported
       - id: set-matrix
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run dash -n
         run: |
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run shfmt
         run: |
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Exclude from bashate the following rules:
       #   - SC2310 we don't want to exit if errors happen inside a check, that's why we have a check...
@@ -87,7 +87,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Exclude from bashate the following rules:
       #   - E002 we use tab indentation as suggested by shfmt.
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run markdownlint
         run: |

--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -21,7 +21,7 @@ jobs:
       distrobox_changed: ${{ steps.check_file_changed.outputs.distrobox_changed }}
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2
@@ -42,7 +42,7 @@ jobs:
     if: needs.check_changes.outputs.distrobox_changed == 'True'
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ done
   - `shfmt -d -s -ci -sr -kp`
 - use `bashate` to check the code:
   - install using `pip3 install bashate`
-  - `bashate -i E002,E003,E010,E011 --max-line-length 12`
+  - `bashate -i E002,E003,E010,E011 --max-line-length 120`
 - use `markdownlint`
   - install using `npm -i -g markdownlint-cli`
   - run `markdownlint $(find . -name '*.md' | grep -vF './.git')`

--- a/distrobox-create
+++ b/distrobox-create
@@ -616,11 +616,6 @@ generate_command() {
 	# Add additional flags
 	result_command="${result_command} ${container_manager_additional_flags}"
 
-	container_pre_init_hook_command_line=""
-	if [ -n "${container_pre_init_hook}" ]; then
-		container_pre_init_hook_command_line="--pre-init-hooks \"${container_pre_init_hook}\""
-	fi
-
 	# Now execute the entrypoint, refer to `distrobox-init -h` for instructions
 	#
 	# Be aware that entrypoint corresponds to distrobox-init, the copying of it
@@ -633,7 +628,7 @@ generate_command() {
 		--group ${container_user_gid}
 		--home \"${container_user_custom_home:-"${container_user_home}"}\"
 		--init \"${init}\"
-		${container_pre_init_hook_command_line}
+		--pre-init-hooks \"${container_pre_init_hook}\"
 		-- '${container_init_hook}'
 		"
 	# use container_user_custom_home if defined, else fallback to normal home.

--- a/distrobox-create
+++ b/distrobox-create
@@ -291,7 +291,7 @@ while :; do
 			;;
 		--pre-init-hooks)
 			if [ -n "$2" ]; then
-				container_pre_init_hook="--pre-init-hooks \"${2}\""
+				container_pre_init_hook="${2}"
 				shift
 				shift
 			fi
@@ -616,6 +616,11 @@ generate_command() {
 	# Add additional flags
 	result_command="${result_command} ${container_manager_additional_flags}"
 
+	container_pre_init_hook_command_line=""
+	if [ -n "${container_pre_init_hook}" ] ; then
+		container_pre_init_hook_command_line="--pre-init-hooks \"${container_pre_init_hook}\""
+	fi
+
 	# Now execute the entrypoint, refer to `distrobox-init -h` for instructions
 	#
 	# Be aware that entrypoint corresponds to distrobox-init, the copying of it
@@ -628,7 +633,7 @@ generate_command() {
 		--group ${container_user_gid}
 		--home \"${container_user_custom_home:-"${container_user_home}"}\"
 		--init \"${init}\"
-		${container_pre_init_hook}
+		${container_pre_init_hook_command_line}
 		-- '${container_init_hook}'
 		"
 	# use container_user_custom_home if defined, else fallback to normal home.

--- a/distrobox-create
+++ b/distrobox-create
@@ -617,7 +617,7 @@ generate_command() {
 	result_command="${result_command} ${container_manager_additional_flags}"
 
 	container_pre_init_hook_command_line=""
-	if [ -n "${container_pre_init_hook}" ] ; then
+	if [ -n "${container_pre_init_hook}" ]; then
 		container_pre_init_hook_command_line="--pre-init-hooks \"${container_pre_init_hook}\""
 	fi
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -122,6 +122,8 @@ while :; do
 				pre_init_hook="$2"
 				shift
 				shift
+			else
+				shift
 			fi
 			;;
 		--)

--- a/docs/README.md
+++ b/docs/README.md
@@ -273,6 +273,8 @@ container_image="registry.opensuse.org/opensuse/toolbox:latest"
 container_manager="docker"
 container_name="test-name-1"
 container_entry=0
+container_init_hook="~/.local/distrobox/a_custom_default_init_hook.sh"
+container_pre_init_hook="~/a_custom_default_pre_init_hook.sh"
 non_interactive="1"
 skip_workdir="0"
 ```


### PR DESCRIPTION
Since the `--init-hook` and `--pre-init-hook` are the current method for resolving custom TLS certificates being needed by corporate proxies (see #493), being able to configure fixed hooks that don't need to be manually added on the command-line each time are useful.  

The variables already existed and could be overridden by the config files (which are just sourced into the scripts), but the `--pre-init-hook` was processed strangely and was appending the arguments needed when calling docker at argument parsing-time instead (see #497).  The command-line options override the config file options already, so no changes were needed for that.

Unrelated, but there was a typo in the `bashate` command in the CONTRIBUTING guide as well. 


/closes #497