### PR TITLE
init: Fix init hooks after 039c4adae54ab

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -120,11 +120,9 @@ while :; do
 		--pre-init-hooks)
 			if [ -n "$2" ]; then
 				pre_init_hook="$2"
-				shift
-				shift
-			else
-				shift
 			fi
+			shift
+			shift
 			;;
 		--)
 			shift


### PR DESCRIPTION
After 039c4adae54ab, my init hook to ensure I can start accelerated VMs
by making sure that the container's user is part of a group with the
same group ID as the kvm group on the host no longer works.

Before:

```
  $ distrobox create --init-hooks ...
  $ distrobox enter ... -- groups
  ...
  pi render
```

After:

```
  $ distrobox create --init-hooks ...
  $ distrobox enter ... -- groups
  ...
  pi
```

This is due to the fact that `distrobox-init`'s new handling of
`--pre-init-hooks` is incorrect. It assumes that `--pre-init-hook` may
be passed with an empty value so it just shifts once when the next
argument is empty. Unfortunately, the empty value is still in the
arguments array so it will just be handled by the main loop on the next
iteration. As a result, the case will fall through to the default
case and silently stop processing the rest of the arguments, which
includes any init hooks requested by the user.

Always shift twice for `--pre-init-hooks`, as there will always be two
values passed.
