### PR TITLE
Fix skel support

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1001,25 +1001,26 @@ printf "test -z \"\$USER\" && USER=\"\$(id -un 2> /dev/null)\"\n" > /etc/profile
 printf "test -z \"\$UID\"  && readonly  UID=\"\$(id -ur 2> /dev/null)\"\n" >> /etc/profile.d/distrobox_profile.sh
 printf "test -z \"\$EUID\" && readonly EUID=\"\$(id -u  2> /dev/null)\"\n" >> /etc/profile.d/distrobox_profile.sh
 if [ -n "${DISTROBOX_HOST_HOME:-}" ] && [ -d "/etc/skel" ]; then
-	skel_files="$(find /etc/skel/ -type f || :)"
-	for skel_file in ${skel_files}; do
-	        base_file_name=$(basename $skel_file)
-	        skel_file_path=${skel_file%$base_file_name}
-	        file_path_for_home=${skel_file_path#/etc/skel/}
+        skel_files="$(find /etc/skel/ -type f || :)"
+        for skel_file in ${skel_files}; do
+                base_file_name=$(basename $skel_file)
+                skel_file_path=${skel_file%$base_file_name}
+                file_path_for_home=${skel_file_path#/etc/skel/}
 
-	        if [ ! -z $file_path_for_home ] && 
-			[ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
-                		mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
-        	fi
+                if [ ! -z $file_path_for_home ] && 
+                        [ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
+                                mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
+                fi
 
-		if [ ! -f "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ] &&
-			[ ! -L "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ]; then
-				cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
-				chown "${container_user_uid}":"${container_user_gid}" \
-					"${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
-		fi
-	done
+                if [ ! -f "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}" ] &&
+                        [ ! -L "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}" ]; then
+                                cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}"
+                                chown "${container_user_uid}":"${container_user_gid}" \
+                                        "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}"
+                fi
+        done
 fi
+
 
 printf "distrobox: Executing init hooks...\n"
 # execute eventual init hooks if specified

--- a/distrobox-init
+++ b/distrobox-init
@@ -1003,22 +1003,20 @@ printf "test -z \"\$EUID\" && readonly EUID=\"\$(id -u  2> /dev/null)\"\n" >> /e
 if [ -n "${DISTROBOX_HOST_HOME:-}" ] && [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-        base_file_name=$(basename $skel_file)
-        skel_file_path=${skel_file%$base_file_name}
-        file_path_for_home=${skel_file_path#/etc/skel/}
+	        base_file_name=$(basename $skel_file)
+	        skel_file_path=${skel_file%$base_file_name}
+	        file_path_for_home=${skel_file_path#/etc/skel/}
 
-        if [ ! -z $file_path_for_home ] &&
-            [ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
-                mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
-        fi
+	        if [ ! -z $file_path_for_home ] && 
+			[ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
+                		mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
+        	fi
 
 		if [ ! -f "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ] &&
 			[ ! -L "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ]; then
-
-			cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
-			chown "${container_user_uid}":"${container_user_gid}" \
-				"${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
-
+				cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
+				chown "${container_user_uid}":"${container_user_gid}" \
+					"${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
 		fi
 	done
 fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -1003,12 +1003,21 @@ printf "test -z \"\$EUID\" && readonly EUID=\"\$(id -u  2> /dev/null)\"\n" >> /e
 if [ -n "${DISTROBOX_HOST_HOME:-}" ] && [ -d "/etc/skel" ]; then
 	skel_files="$(find /etc/skel/ -type f || :)"
 	for skel_file in ${skel_files}; do
-		if [ ! -f "${container_user_home}/$(basename "${skel_file}")" ] &&
-			[ ! -L "${container_user_home}/$(basename "${skel_file}")" ]; then
+        base_file_name=$(basename $skel_file)
+        skel_file_path=${skel_file%$base_file_name}
+        file_path_for_home=${skel_file_path#/etc/skel/}
 
-			cp "${skel_file}" "${container_user_home}"
+        if [ ! -z $file_path_for_home ] &&
+            [ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
+                mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
+        fi
+
+		if [ ! -f "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ] &&
+			[ ! -L "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}" ]; then
+
+			cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
 			chown "${container_user_uid}":"${container_user_gid}" \
-				"${container_user_home}/$(basename "${skel_file}")"
+				"${container_user_home}/${file_path_for_home:+$file_path_for_home/}${file_name}"
 
 		fi
 	done

--- a/distrobox-init
+++ b/distrobox-init
@@ -1000,27 +1000,26 @@ mkdir -p /etc/profile.d
 printf "test -z \"\$USER\" && USER=\"\$(id -un 2> /dev/null)\"\n" > /etc/profile.d/distrobox_profile.sh
 printf "test -z \"\$UID\"  && readonly  UID=\"\$(id -ur 2> /dev/null)\"\n" >> /etc/profile.d/distrobox_profile.sh
 printf "test -z \"\$EUID\" && readonly EUID=\"\$(id -u  2> /dev/null)\"\n" >> /etc/profile.d/distrobox_profile.sh
-if [ -n "${DISTROBOX_HOST_HOME:-}" ] && [ -d "/etc/skel" ]; then
-        skel_files="$(find /etc/skel/ -type f || :)"
-        for skel_file in ${skel_files}; do
-                base_file_name=$(basename $skel_file)
-                skel_file_path=${skel_file%$base_file_name}
-                file_path_for_home=${skel_file_path#/etc/skel/}
+if [ -n "${DISTROBOX_HOST_HOME-}"  ] && [ -d "/etc/skel" ]; then
+	skel_files="$(find /etc/skel/ -type f || :)"
+	for skel_file in ${skel_files}; do
+		base_file_name=$(basename "${skel_file}")
+		skel_file_path=$(dirname "${skel_file}")
+		file_path_for_home=${skel_file_path#/etc/skel}
 
-                if [ ! -z $file_path_for_home ] && 
-                        [ ! -d "${container_user_home}/${file_path_for_home:+$file_path_for_home}" ]; then
-                                mkdir -p "${container_user_home}/${file_path_for_home:+$file_path_for_home/}"
-                fi
+		if [ -n "${file_path_for_home}" ] &&
+			[ ! -d "${container_user_home}/${file_path_for_home:+"${file_path_for_home}"}" ]; then
+			mkdir -p "${container_user_home}/${file_path_for_home:+"${file_path_for_home}"/}"
+		fi
 
-                if [ ! -f "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}" ] &&
-                        [ ! -L "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}" ]; then
-                                cp "${skel_file}" "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}"
-                                chown "${container_user_uid}":"${container_user_gid}" \
-                                        "${container_user_home}/${file_path_for_home:+$file_path_for_home/}${base_file_name}"
-                fi
-        done
+		if [ ! -f "${container_user_home}/${file_path_for_home:+"${file_path_for_home}"/}${base_file_name}" ] &&
+			[ ! -L "${container_user_home}/${file_path_for_home:+"${file_path_for_home}"/}${base_file_name}" ]; then
+			cp "${skel_file}" "${container_user_home}/${file_path_for_home:+"${file_path_for_home}"/}${base_file_name}"
+			chown "${container_user_uid}":"${container_user_gid}" \
+				"${container_user_home}/${file_path_for_home:+"${file_path_for_home}"/}${base_file_name}"
+		fi
+	done
 fi
-
 
 printf "distrobox: Executing init hooks...\n"
 # execute eventual init hooks if specified


### PR DESCRIPTION
Hello, I started using Kali Linux over the distrobox soon. But every time I start the container, I noticed that the formation of Microsoft.PowerShell_profile.ps1 and prefs.xml files in my home directory. I noticed that there was a logical error on the code piece that formed the skel files in the distrobox-init file by researching the distrobox commands. In the Kali Linux /etc/skel folder, not only files. There are also folders. I threw PR to correct this problem.

Before:

![image](https://user-images.githubusercontent.com/62564400/209093279-6ee38aac-4532-4fd2-b19d-7d786aa08fc3.png)

After:

![image](https://user-images.githubusercontent.com/62564400/209094357-c956bba3-b1f3-4d9e-861d-b8bfab12d8e6.png)
