### PR TITLE
Add yay and paru support to distrobox-init and distrobox-upgrade

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -452,6 +452,96 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 			mesa-vulkan-drivers \
 			vulkan || :
 
+	elif command -v yay; then
+		# If we need to upgrade, do it and exit, no further action required.
+		if [ "${upgrade}" -ne 0 ]; then
+			yay -Syyu --noconfirm
+			exit
+		fi
+		# In archlinux  official images, pacman is configured to ignore locale and docs
+		# This however, results in a rather poor out-of-the-box experience
+		# So, let's enable them.
+		sed -i "s|NoExtract.*||g" /etc/pacman.conf
+		sed -i "s|NoProgressBar.*||g" /etc/pacman.conf
+
+		# Check if shell_pkg is available in distro's repo. If not we
+		# fall back to bash, and we set the SHELL variable to bash so
+		# that it is set up correctly for the user.
+		yay --noconfirm -Syyu
+		if ! yay -Sy --noconfirm "${shell_pkg}"; then
+			shell_pkg="bash"
+		fi
+		yay -Sy --noconfirm \
+			"${shell_pkg}" \
+			bc \
+			curl \
+			diffutils \
+			findutils \
+			gnupg \
+			less \
+			lsof \
+			ncurses \
+			pinentry \
+			procps-ng \
+			shadow \
+			sudo \
+			time \
+			util-linux \
+			wget \
+			vte-common
+
+		# These are graphics drivers for 3d applications
+		yay -Sy --noconfirm \
+			mesa \
+			opengl-driver \
+			vulkan-intel \
+			vulkan-radeon
+
+	elif command -v paru; then
+		# If we need to upgrade, do it and exit, no further action required.
+		if [ "${upgrade}" -ne 0 ]; then
+			paru -Syyu --noconfirm
+			exit
+		fi
+		# In archlinux  official images, pacman is configured to ignore locale and docs
+		# This however, results in a rather poor out-of-the-box experience
+		# So, let's enable them.
+		sed -i "s|NoExtract.*||g" /etc/pacman.conf
+		sed -i "s|NoProgressBar.*||g" /etc/pacman.conf
+
+		# Check if shell_pkg is available in distro's repo. If not we
+		# fall back to bash, and we set the SHELL variable to bash so
+		# that it is set up correctly for the user.
+		paru --noconfirm -Syyu
+		if ! paru -Sy --noconfirm "${shell_pkg}"; then
+			shell_pkg="bash"
+		fi
+		paru -Sy --noconfirm \
+			"${shell_pkg}" \
+			bc \
+			curl \
+			diffutils \
+			findutils \
+			gnupg \
+			less \
+			lsof \
+			ncurses \
+			pinentry \
+			procps-ng \
+			shadow \
+			sudo \
+			time \
+			util-linux \
+			wget \
+			vte-common
+
+		# These are graphics drivers for 3d applications
+		paru -Sy --noconfirm \
+			mesa \
+			opengl-driver \
+			vulkan-intel \
+			vulkan-radeon
+
 	elif command -v pacman; then
 		# If we need to upgrade, do it and exit, no further action required.
 		if [ "${upgrade}" -ne 0 ]; then

--- a/distrobox-init
+++ b/distrobox-init
@@ -467,11 +467,12 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.
-		yay --noconfirm -Syyu
-		if ! yay -Sy --noconfirm "${shell_pkg}"; then
+		# Use Pacman instead of AUR helper for container init.
+		pacman --noconfirm -Syyu
+		if ! pacman -Sy --noconfirm "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi
-		yay -Sy --noconfirm \
+		pacman -Sy --noconfirm \
 			"${shell_pkg}" \
 			bc \
 			curl \
@@ -491,7 +492,7 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 			vte-common
 
 		# These are graphics drivers for 3d applications
-		yay -Sy --noconfirm \
+		pacman -Sy --noconfirm \
 			mesa \
 			opengl-driver \
 			vulkan-intel \
@@ -512,11 +513,12 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# Check if shell_pkg is available in distro's repo. If not we
 		# fall back to bash, and we set the SHELL variable to bash so
 		# that it is set up correctly for the user.
-		paru --noconfirm -Syyu
-		if ! paru -Sy --noconfirm "${shell_pkg}"; then
+		# Use Pacman instead of AUR helper for container init.
+		pacman --noconfirm -Syyu
+		if ! pacman -Sy --noconfirm "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi
-		paru -Sy --noconfirm \
+		pacman -Sy --noconfirm \
 			"${shell_pkg}" \
 			bc \
 			curl \
@@ -536,7 +538,7 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 			vte-common
 
 		# These are graphics drivers for 3d applications
-		paru -Sy --noconfirm \
+		pacman -Sy --noconfirm \
 			mesa \
 			opengl-driver \
 			vulkan-intel \

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -33,6 +33,7 @@ distrobox_path="$(dirname "$(realpath "${0}")")"
 distrobox_sudo_program="sudo"
 rootful=0
 verbose=0
+aur=0
 version="1.4.2.1"
 
 # Source configuration files, this is done in an hierarchy so local files have

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -80,6 +80,7 @@ Options:
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
+	--aur/-u:		Needed to run yay and paru with distrobox-upgrade
 EOF
 }
 
@@ -111,6 +112,10 @@ while :; do
 		-r | --root)
 			shift
 			rootful=1
+			;;
+		-u | --aur)
+			shift
+			aur=1
 			;;
 		--) # End of all options.
 			shift
@@ -207,6 +212,10 @@ for container in ${container_name}; do
 	if [ "${rootful}" -ne 0 ]; then
 		# shellcheck disable=SC2086
 		"${distrobox_path}"/distrobox-enter --root ${container} -- sudo /usr/bin/entrypoint --upgrade
+	elif [ "${rootful}" -ne 0 && "${aur}" -ne 0 ]; then
+		"${distrobox_path}"/distrobox-enter --root ${container} -- /usr/bin/entrypoint --upgrade
+	elif [ "${aur}" -ne 0 ]; then
+		"${distrobox_path}"/distrobox-enter ${container} -- /usr/bin/entrypoint --upgrade
 	else
 		# shellcheck disable=SC2086
 		"${distrobox_path}"/distrobox-enter ${container} -- sudo /usr/bin/entrypoint --upgrade

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -214,9 +214,21 @@ for container in ${container_name}; do
 		# shellcheck disable=SC2086
 		"${distrobox_path}"/distrobox-enter --root ${container} -- sudo /usr/bin/entrypoint --upgrade
 	elif [ "${rootful}" -ne 0 ] && [ "${aur}" -ne 0 ]; then
-		"${distrobox_path}"/distrobox-enter --root ${container} -- /usr/bin/entrypoint --upgrade
+		if [ $("${distrobox_path}"/distrobox-enter --root ${container} -- ls /usr/bin | grep -ow "yay") ]; then
+			"${distrobox_path}"/distrobox-enter --root ${container} -- /usr/bin/entrypoint --upgrade
+		elif [ $("${distrobox_path}"/distrobox-enter --root ${container} -- ls /usr/bin | grep -ow "paru") ]; then
+			"${distrobox_path}"/distrobox-enter --root ${container} -- /usr/bin/entrypoint --upgrade
+		else
+			"${distrobox_path}"/distrobox-enter --root ${container} -- sudo /usr/bin/entrypoint --upgrade
+		fi
 	elif [ "${aur}" -ne 0 ]; then
-		"${distrobox_path}"/distrobox-enter ${container} -- /usr/bin/entrypoint --upgrade
+		if [ $("${distrobox_path}"/distrobox-enter ${container} -- ls /usr/bin | grep -ow "yay") ]; then
+			"${distrobox_path}"/distrobox-enter ${container} -- /usr/bin/entrypoint --upgrade
+		elif [ $("${distrobox_path}"/distrobox-enter ${container} -- ls /usr/bin | grep -ow "paru") ]; then
+			"${distrobox_path}"/distrobox-enter ${container} -- /usr/bin/entrypoint --upgrade
+		else
+			"${distrobox_path}"/distrobox-enter ${container} -- sudo /usr/bin/entrypoint --upgrade
+		fi
 	else
 		# shellcheck disable=SC2086
 		"${distrobox_path}"/distrobox-enter ${container} -- sudo /usr/bin/entrypoint --upgrade

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -212,7 +212,7 @@ for container in ${container_name}; do
 	if [ "${rootful}" -ne 0 ]; then
 		# shellcheck disable=SC2086
 		"${distrobox_path}"/distrobox-enter --root ${container} -- sudo /usr/bin/entrypoint --upgrade
-	elif [ "${rootful}" -ne 0 && "${aur}" -ne 0 ]; then
+	elif [ "${rootful}" -ne 0 ] && [ "${aur}" -ne 0 ]; then
 		"${distrobox_path}"/distrobox-enter --root ${container} -- /usr/bin/entrypoint --upgrade
 	elif [ "${aur}" -ne 0 ]; then
 		"${distrobox_path}"/distrobox-enter ${container} -- /usr/bin/entrypoint --upgrade


### PR DESCRIPTION
This PR adds the paru and yay AUR helpers to distrobox-init to be preferred over pacman when they exist on the container.

 I've added a `--aur` argument to `distrobox-upgrade` which will check for either `yay` or `paru`, and if detected will run the entrypoint without sudo.  `distrobox-upgrade --all --aur` will also handle containers using standard package managers along with arch containers with yay or paru installed. These checks are needed as makepkg disallows itself to run as root.

Please let me know if there are any issues and I'll try my best to resolve ASAP.