### PR TITLE
Allow root user to run Distrobox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ for file in $(find . -type f -not -path "*.git*"); do
       echo "### Checking file $file..."
       dash -n $file
       result=$(( result + $? ))
+      echo "Result: $result"
     fi
 done
 ```

--- a/distrobox-create
+++ b/distrobox-create
@@ -33,11 +33,15 @@
 #	DBX_NON_INTERACTIVE
 #	DBX_SUDO_PROGRAM
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
@@ -59,7 +63,6 @@ container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"
 container_user_uid="$(id -ru)"
-distrobox_sudo_program="sudo"
 dryrun=0
 init=0
 non_interactive=0
@@ -75,7 +78,9 @@ distrobox_hostexec_path="$(cd "$(dirname "${0}")" && pwd)/distrobox-host-exec"
 [ ! -e "${distrobox_entrypoint_path}" ] && distrobox_entrypoint_path="$(command -v distrobox-init)"
 [ ! -e "${distrobox_export_path}" ] && distrobox_export_path="$(command -v distrobox-export)"
 [ ! -e "${distrobox_hostexec_path}" ] && distrobox_hostexec_path="$(command -v distrobox-hostexec)"
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "${container_user_uid}" -eq 0 ] && rootful=1 || rootful=0
 verbose=0
 version="1.4.2.1"
 
@@ -95,6 +100,15 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root -- as in logged in in the shell as root
+# user, and not via SUDO/DOAS --, we don't need to set distrobox_sudo_program
+# as it's meaningless for this use case.
+if [ "${container_user_uid}" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 # Fixup non_interactive=[true|false], in case we find it in the config file(s)
 [ "${non_interactive}" = "true" ] && non_interactive=1
 [ "${non_interactive}" = "false" ] && non_interactive=0
@@ -107,7 +121,6 @@ done
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 [ -n "${DBX_container_generate_entry}" ] && container_generate_entry="${DBX_container_generate_entry}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
-[ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
 # Print usage to stdout.
 # Arguments:
@@ -392,7 +405,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program} ${container_manager}"
+	container_manager="${distrobox_sudo_program:-} ${container_manager}"
 fi
 
 # Clone a container as a snapshot.
@@ -664,10 +677,12 @@ fi
 if ${container_manager} inspect --type container "${container_name}" > /dev/null 2>&1; then
 	printf "Distrobox named '%s' already exists.\n" "${container_name}"
 	printf "To enter, run:\n\n"
-	if [ "${rootful}" -ne 0 ]; then
-		printf "distrobox-enter --root %s\n\n" "${container_name}"
-	else
-		printf "distrobox-enter %s\n\n" "${container_name}"
+	# If it's a rootful container AND user is not logged as root.
+	if [ "${rootful}" -eq 1 ] && [ "${container_user_uid}" -ne 0 ]; then
+		printf "distrobox enter --root %s\n\n" "${container_name}"
+	# If user is logged as root OR it's a rootless container.
+	elif [ "${container_user_uid}" -eq 0 ] || [ "${rootful}" -eq 0 ]; then
+		printf "distrobox enter %s\n\n" "${container_name}"
 	fi
 	exit 0
 fi
@@ -720,9 +735,11 @@ cmd="$(generate_command)"
 if eval ${cmd} > /dev/null; then
 	printf >&2 "\033[32m [ OK ]\n\033[0mDistrobox '%s' successfully created.\n" "${container_name}"
 	printf >&2 "To enter, run:\n\n"
-	if [ "${rootful}" -ne 0 ]; then
+	# If it's a rootful container AND user is not logged as root.
+	if [ "${rootful}" -eq 1 ] && [ "${container_user_uid}" -ne 0 ]; then
 		printf "distrobox enter --root %s\n\n" "${container_name}"
-	else
+	# If user is logged as root OR it's a rootless container.
+	elif [ "${container_user_uid}" -eq 0 ] || [ "${rootful}" -eq 0 ]; then
 		printf "distrobox enter %s\n\n" "${container_name}"
 	fi
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -28,13 +28,17 @@
 #	DBX_SKIP_WORKDIR
 #	DBX_SUDO_PROGRAM
 
-trap 'rm -f $HOME/.cache/.*.fifo $HOME/.cache/.*.status' EXIT
+trap 'rm -f ${HOME}/.cache/.*.fifo ${HOME}/.cache/.*.status' EXIT
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
@@ -46,7 +50,6 @@ container_manager_additional_flags=""
 container_name=""
 container_name_default="my-distrobox"
 non_interactive=0
-distrobox_sudo_program="sudo"
 
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
@@ -55,7 +58,9 @@ distrobox_sudo_program="sudo"
 distrobox_enter_path="$(cd "$(dirname "$0")" && pwd)/distrobox-enter"
 dryrun=0
 headless=0
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 skip_workdir=0
 verbose=0
 version="1.4.2.1"
@@ -76,6 +81,15 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root -- as in, logged in in the shell as root
+# user, and not via SUDO/DOAS --, we don't need to set distrobox_sudo_program
+# as it's meaningless for thi use case.
+if [ "$(id -ru)" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 # Fixup non_interactive=[true|false], in case we find it in the config file(s)
 [ "${non_interactive}" = "true" ] && non_interactive=1
 [ "${non_interactive}" = "false" ] && non_interactive=0
@@ -84,7 +98,6 @@ done
 [ -n "${DBX_CONTAINER_NAME}" ] && container_name="${DBX_CONTAINER_NAME}"
 [ -n "${DBX_SKIP_WORKDIR}" ] && skip_workdir="${DBX_SKIP_WORKDIR}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
-[ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
 # Print usage to stdout.
 # Arguments:
@@ -261,7 +274,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program} ${container_manager}"
+	container_manager="${distrobox_sudo_program:-} ${container_manager}"
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-ephemeral
+++ b/distrobox-ephemeral
@@ -25,11 +25,15 @@
 #   DBX_NON_INTERACTIVE
 #	DBX_SUDO_PROGRAM
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
@@ -37,7 +41,9 @@ container_command=""
 create_flags=""
 distrobox_path="$(dirname "${0}")"
 extra_flags=""
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 verbose=0
 version="1.4.2.1"
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -910,15 +910,19 @@ EOF
 fi
 ###############################################################################
 
-printf "distrobox: Setting up sudo...\n"
-mkdir -p /etc/sudoers.d
-# Do not check fqdn when doing sudo, it will not work anyways
-if ! grep -q 'Defaults !fqdn' /etc/sudoers.d/sudoers; then
-	printf "Defaults !fqdn\n" >> /etc/sudoers.d/sudoers
-fi
-# Ensure passwordless sudo is set up for user
-if ! grep -q "\"${container_user_name}\" ALL = (root) NOPASSWD:ALL" /etc/sudoers.d/sudoers; then
-	printf "\"%s\" ALL = (root) NOPASSWD:ALL\n" "${container_user_name}" >> /etc/sudoers.d/sudoers
+# If we're running this script as root in a login shell (sudoless), we don't
+# have to bother setting up sudo.
+if [ "${container_user_uid}" -ne 0 ]; then
+	printf "distrobox: Setting up sudo...\n"
+	mkdir -p /etc/sudoers.d
+	# Do not check fqdn when doing sudo, it will not work anyways
+	if ! grep -q 'Defaults !fqdn' /etc/sudoers.d/sudoers; then
+		printf "Defaults !fqdn\n" >> /etc/sudoers.d/sudoers
+	fi
+	# Ensure passwordless sudo is set up for user
+	if ! grep -q "\"${container_user_name}\" ALL = (root) NOPASSWD:ALL" /etc/sudoers.d/sudoers; then
+		printf "\"%s\" ALL = (root) NOPASSWD:ALL\n" "${container_user_name}" >> /etc/sudoers.d/sudoers
+	fi
 fi
 
 printf "distrobox: Setting up groups...\n"

--- a/distrobox-list
+++ b/distrobox-list
@@ -23,21 +23,26 @@
 #	DBX_CONTAINER_MANAGER
 #	DBX_SUDO_PROGRAM
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
 # Defaults
 no_color=0
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 verbose=0
 version="1.4.2.1"
 container_manager="autodetect"
-distrobox_sudo_program="sudo"
 
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
@@ -55,8 +60,16 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root -- as in logged in in the shell as root
+# user, and not via SUDO/DOAS --, we don't need to set distrobox_sudo_program
+# as it's meaningless for this use case.
+if [ "$(id -ru)" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
-[ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
 # Print usage to stdout.
 # Arguments:
@@ -168,7 +181,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program} ${container_manager}"
+	container_manager="${distrobox_sudo_program:-} ${container_manager}"
 fi
 
 # List containers using custom format that inclused MOUNTS

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -26,11 +26,15 @@
 #   DBX_NON_INTERACTIVE
 #	DBX_SUDO_PROGRAM
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
@@ -38,10 +42,11 @@ fi
 container_manager="autodetect"
 force=0
 non_interactive=0
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 verbose=0
 rm_home=0
-distrobox_sudo_program="sudo"
 version="1.4.2.1"
 
 # Source configuration files, this is done in an hierarchy so local files have
@@ -60,6 +65,15 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root - as in logged in in the shell as root
+# user, and not via SUDO/DOAS -, we don't need to set distrobox_sudo_program
+# as it's meaningless for this use case.
+if [ "$(id -ru)" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 # Fixup non_interactive=[true|false], in case we find it in the config file(s)
 [ "${non_interactive}" = "true" ] && non_interactive=1
 [ "${non_interactive}" = "false" ] && non_interactive=0
@@ -67,7 +81,6 @@ done
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 [ -n "${DBX_CONTAINER_RM_CUSTOM_HOME}" ] && rm_home="${DBX_CONTAINER_RM_CUSTOM_HOME}"
 [ -n "${DBX_NON_INTERACTIVE}" ] && non_interactive="${DBX_NON_INTERACTIVE}"
-[ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
 # Declare it AFTER config sourcing because we do not want a default name set for rm.
 container_name=""
@@ -200,7 +213,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program} ${container_manager}"
+	container_manager="${distrobox_sudo_program:-} ${container_manager}"
 fi
 
 # check if we have containers to delete

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -25,11 +25,15 @@
 #   DBX_NON_INTERACTIVE
 #	DBX_SUDO_PROGRAM
 
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
@@ -37,9 +41,10 @@ fi
 container_manager="autodetect"
 container_name_default="my-distrobox"
 non_interactive=0
-rootful=0
+# If the user runs this script as root in a login shell, set rootful=1.
+# There's no need for them to pass the --root flag option in such cases.
+[ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 verbose=0
-distrobox_sudo_program="sudo"
 version="1.4.2.1"
 
 # Source configuration files, this is done in an hierarchy so local files have
@@ -58,6 +63,15 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root - as in logged in in the shell as root
+# user, and not via SUDO/DOAS -, we don't need to set distrobox_sudo_program
+# as it's meaningless for this use case.
+if [ "$(id -ru)" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 # Fixup non_interactive=[true|false], in case we find it in the config file(s)
 [ "${non_interactive}" = "true" ] && non_interactive=1
 [ "${non_interactive}" = "false" ] && non_interactive=0
@@ -198,7 +212,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program} ${container_manager}"
+	container_manager="${distrobox_sudo_program:-} ${container_manager}"
 fi
 
 # Inspect the container we're working with.

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -18,19 +18,21 @@
 # You should have received a copy of the GNU General Public License
 # along with distrobox; if not, see <http://www.gnu.org/licenses/>.
 
-# POSIX
-# Dont' run this command as sudo.
-if [ "$(id -u)" -eq 0 ]; then
-	printf >&2 "Running %s as sudo is not supported.\n" "$(basename "${0}")"
-	printf >&2 " try instead running:\n"
-	printf >&2 "	%s --root %s\n" "$(basename "${0}")" "$*"
+# Despite of running this script via SUDO/DOAS being not supported (the
+# script itself will call the appropriate tool when necessary), we still want
+# to allow people to run it as root, logged in in a shell, and create rootful
+# containers.
+#
+# SUDO_USER is a variable set by SUDO and can be used to check whether the script was called by it. Same thing for DOAS_USER, set by DOAS.
+if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
+	printf >&2 "Running %s via SUDO/DOAS is not supported. Instead, please try running:\n" "$(basename "${0}")"
+	printf >&2 "  %s --root %s\n" "$(basename "${0}")" "$*"
 	exit 1
 fi
 
 all=0
 container_manager="autodetect"
 distrobox_path="$(dirname "$(realpath "${0}")")"
-distrobox_sudo_program="sudo"
 rootful=0
 verbose=0
 version="1.4.2.1"
@@ -51,8 +53,16 @@ for config_file in ${config_files}; do
 	# shellcheck disable=SC1090
 	[ -e "${config_file}" ] && . "${config_file}"
 done
+# If we're running this script as root - as in logged in in the shell as root
+# user, and not via SUDO/DOAS -, we don't need to set distrobox_sudo_program
+# as it's meaningless for this use case.
+if [ "$(id -ru)" -ne 0 ]; then
+	# If the DBX_SUDO_PROGRAM/distrobox_sudo_program variable was set by the
+	# user, use its value instead of "sudo". But only if not runnig the script
+	# as root (UID 0).
+	distrobox_sudo_program=${DBX_SUDO_PROGRAM:-${distrobox_sudo_program:-"sudo"}}
+fi
 [ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
-[ -n "${DBX_SUDO_PROGRAM}" ] && distrobox_sudo_program="${DBX_SUDO_PROGRAM}"
 
 # Declare it AFTER config sourcing because we do not want a default name set.
 container_name=""

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -82,6 +82,22 @@ with your `$USER`.
 
 `distrobox create --name test --image your-chosen-image:tag --root`
 
+Another use case, what if you want or need to run distrobox with the root user, in a login
+shell?
+
+Before the 1.4.3 release, it wasn't possible. We couldn't make a distinction between someone
+running distrobox vi `sudo` from someone logged in as the root user in a shell. Now things are
+as easy as it would be if you were creating a rootless container:
+
+`# distrobox create --name your-container --pull --image your-chosen-image:tag`
+
+And:
+
+`# distrobox enter your-container`
+
+We trust you already know the implications of running distrobox, as well as anything else,
+with the root user and that with great power comes great responsibilities.
+
 ## Using a command other than sudo to run a rootful container
 
 When using the `--root` option with Distrobox, internally, it uses `sudo` to be able to


### PR DESCRIPTION
Up until now, we weren't able to distinguish between normal users (running the scripts via `sudo`) and **root** user (running the script in a login shell). This intruduces a check for the **SUDO_USER** variable (created in unmodified environments, by `sudo`), among other mechanisms, to allow the **root** user to manage _rootful_ containers.

This fixes #575.