### PR TITLE
Fix typo and incorrect key for generated desktop entry `Categories`

### DIFF
--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -274,7 +274,7 @@ cat << EOF > "${HOME}/.local/share/applications/${container_name}.desktop"
 Name=${entry_name}
 GenericName=Terminal entering ${entry_name}
 Comment=Terminal entering ${entry_name}
-Category=Distrobox;System;Utility"
+Categories=Distrobox;System;Utility
 Exec=${distrobox_path}/distrobox enter ${container_name}
 Icon=${icon}
 Keywords=distrobox;


### PR DESCRIPTION
The proper key is "Categories", per https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

The trailing quote seems to just be a copy-paste error from moving the lines around in 5d77405e5ffc89479cdc8e9b2d482e018c469885

I hope it's okay, I didn't open an issue for this as the fix seemed trivial I wasn't sure it was worth filing separately.