### PR TITLE
Install reflector(1) in arch containers

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -471,6 +471,16 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		if ! pacman -Sy --noconfirm "${shell_pkg}"; then
 			shell_pkg="bash"
 		fi
+
+		# Install reflector(1) and make it sort the 40 most recently
+        # synchronized http/https mirrors by speed and overwrite the mirrorlist
+        # This greatly increases the download speed of installed packages
+        if ! pacman -Sy --noconfirm reflector; then
+			pacman -Sy --noconfirm reflector
+	        reflector --latest 40 --protocol http,https --sort rate --save /etc/pacman.d/mirrorlist
+		fi
+
+
 		pacman -Sy --noconfirm \
 			"${shell_pkg}" \
 			bc \


### PR DESCRIPTION
This installs reflector(1) in arch containers (if found in the repos) and runs a sort on the 40 latest synchronized http/https mirrors to make sure that the rest of the container setup is way faster