### PR TITLE
Add support for macOS

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -459,6 +459,14 @@ generate_command() {
 		result_command="${result_command}
 			--pid host"
 	fi
+
+	# Set a label so we can track the container and set
+	# environment variables for $SHELL and $HOME
+	result_command="${result_command}
+		--label \"manager=distrobox\"
+		--env \"SHELL=${SHELL:-"/bin/bash"}\"
+		--env \"HOME=${container_user_home}\""
+
 	# Mount useful stuff inside the container.
 	# We also mount host's root filesystem to /run/host, to be able to syphon
 	# dynamic configurations from the host.
@@ -469,18 +477,26 @@ generate_command() {
 	# Mount also the distrobox-init utility as the container entrypoint.
 	# Also mount in the container the distrobox-export and distrobox-host-exec
 	# utilities.
-	result_command="${result_command}
-		--label \"manager=distrobox\"
-		--env \"SHELL=${SHELL:-"/bin/bash"}\"
-		--env \"HOME=${container_user_home}\"
-		--volume /:/run/host:rslave
-		--volume /dev:/dev:rslave
-		--volume /sys:/sys:rslave
-		--volume /tmp:/tmp:rslave
-		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
-		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
-		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+	if [ "$(uname)" == "Darwin" ]; then
+		# Docker Desktop doesnt allow bind-propagation so we cant do rslave
+		# on mounts. Instead skip mounting /, /dev, /sys and /tmp and do a shared
+		# mount on the user's home directory
+		result_command="${result_command}
+      --volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
+      --volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
+      --volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
+      --volume \"${container_user_home}\":\"${container_user_home}\""
+	else
+		result_command="${result_command}
+      --volume /:/run/host:rslave
+      --volume /dev:/dev:rslave
+      --volume /sys:/sys:rslave
+      --volume /tmp:/tmp:rslave
+      --volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
+      --volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
+      --volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
+      --volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+	fi
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.

--- a/distrobox-create
+++ b/distrobox-create
@@ -482,20 +482,20 @@ generate_command() {
 		# on mounts. Instead skip mounting /, /dev, /sys and /tmp and do a shared
 		# mount on the user's home directory
 		result_command="${result_command}
-      --volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
-      --volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
-      --volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-      --volume \"${container_user_home}\":\"${container_user_home}\""
+			--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
+			--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
+			--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
+			--volume \"${container_user_home}\":\"${container_user_home}\""
 	else
 		result_command="${result_command}
-      --volume /:/run/host:rslave
-      --volume /dev:/dev:rslave
-      --volume /sys:/sys:rslave
-      --volume /tmp:/tmp:rslave
-      --volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
-      --volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
-      --volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-      --volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+			--volume /:/run/host:rslave
+			--volume /dev:/dev:rslave
+			--volume /sys:/sys:rslave
+			--volume /tmp:/tmp:rslave
+			--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
+			--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
+			--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
+			--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
 	fi
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory

--- a/install
+++ b/install
@@ -83,11 +83,11 @@ icon_dest_path="${prefix}/share/icons"
 completion_dest_path="${prefix}/share/bash-completion/completions/"
 
 install_command() {
-  if [ "$(uname)" == "Darwin" ]; then
-    ginstall $@
-  else
-    install $@
-  fi
+	if [ "$(uname)" == "Darwin" ]; then
+		ginstall $@
+	else
+		install $@
+	fi
 }
 
 set -o errexit

--- a/install
+++ b/install
@@ -82,6 +82,14 @@ man_dest_path="${prefix}/share/man/man1"
 icon_dest_path="${prefix}/share/icons"
 completion_dest_path="${prefix}/share/bash-completion/completions/"
 
+install_command() {
+  if [ "$(uname)" == "Darwin" ]; then
+    ginstall $@
+  else
+    install $@
+  fi
+}
+
 set -o errexit
 set -o nounset
 # set verbosity
@@ -97,23 +105,23 @@ cd "${curr_dir}" || exit 1
 # else download targz and uncompress it
 if [ -e "${curr_dir}/distrobox-enter" ]; then
 	for file in distrobox*; do
-		if ! install -D -m 0755 -t "${dest_path}" "${file}"; then
+		if ! install_command -D -m 0755 -t "${dest_path}" "${file}"; then
 			printf >&2 "Do you have permission to write to %s?\n" "${dest_path}"
 			exit 1
 		fi
 	done
 	if [ -e "man" ]; then
 		for file in man/man1/*; do
-			install -D -m 0644 -t "${man_dest_path}" "${file}"
+			install_command -D -m 0644 -t "${man_dest_path}" "${file}"
 		done
 	fi
 	if [ -e "completions" ]; then
 		for file in completions/*; do
-			install -D -m 0644 -t "${completion_dest_path}" "${file}"
+			install_command -D -m 0644 -t "${completion_dest_path}" "${file}"
 		done
 	fi
 	if [ -e terminal-distrobox-icon.png ]; then
-		install -D -m 0644 -t "${icon_dest_path}" terminal-distrobox-icon.png
+		install_command -D -m 0644 -t "${icon_dest_path}" terminal-distrobox-icon.png
 	fi
 else
 	printf >&2 "\033[1;31m Checking dependencies...\n\033[0m"
@@ -152,23 +160,23 @@ else
 	fi
 	# deploy our files
 	for file in "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')"/distrobox*; do
-		if ! install -D -m 0755 -t "${dest_path}" "${file}"; then
+		if ! install_command -D -m 0755 -t "${dest_path}" "${file}"; then
 			printf >&2 "Do you have permission to write to %s?\n" "${dest_path}"
 			exit 1
 		fi
 	done
 	if [ -e "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')/man/" ]; then
 		for file in "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')"/man/man1/*; do
-			install -D -m 0644 -t "${man_dest_path}" "${file}"
+			install_command -D -m 0644 -t "${man_dest_path}" "${file}"
 		done
 	fi
 	if [ -e "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')/completions/" ]; then
 		for file in "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')"/completions/*; do
-			install -D -m 0644 -t "${completion_dest_path}" "${file}"
+			install_command -D -m 0644 -t "${completion_dest_path}" "${file}"
 		done
 	fi
 	if [ -e "distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')"/terminal-distrobox-icon.png ]; then
-		install -D -m 0644 -t "${icon_dest_path}" \
+		install_command -D -m 0644 -t "${icon_dest_path}" \
 			"distrobox-$(echo "${release_name}" | sed 's/.tar.gz//g')"/terminal-distrobox-icon.png
 	fi
 


### PR DESCRIPTION
This gets the installer working on macos systems, you still need to `brew install coreutils` so we might want to add that to the README.md

This also changes mounting of volumes for macos only to skip `/, /dev, /tmp, /sys` and changes the user home mount to be a "regular" shared mount rather than rslave