### PR TITLE
host-exec: bump host-spawn to 1.4.1 and do proper version comparison

### DIFF
--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -124,8 +124,8 @@ fi
 
 # Setup host-spawn as a way to execute commands back on the host
 if  ! command -v host-spawn > /dev/null ||
-	[ "$(printf "%s\n%s\n" "${host_spawn_version}" "$(host-spawn --version)" \
-		| sort -V | head -n 1)" != "${host_spawn_version}" ]; then
+	[ "$(printf "%s\n%s\n" "${host_spawn_version}" "$(host-spawn --version)" |
+		sort -V | head -n 1)" != "${host_spawn_version}" ]; then
 
 	# if non-interactive flag flag hasn't been set
 	if [ "${non_interactive}" -eq 0 ]; then

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -26,7 +26,7 @@ if [ ! -t 1 ]; then
 	non_interactive=1
 fi
 distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
-host_spawn_version="1.2.1"
+host_spawn_version="1.4.1"
 verbose=0
 version="1.4.2.1"
 
@@ -124,7 +124,8 @@ fi
 
 # Setup host-spawn as a way to execute commands back on the host
 if  ! command -v host-spawn > /dev/null ||
-	[ "$(host-spawn --version)" != "${host_spawn_version}" ]; then
+	[ "$(printf "%s\n%s\n" "${host_spawn_version}" "$(host-spawn --version)" \
+		| sort -V | head -n 1)" != "${host_spawn_version}" ]; then
 
 	# if non-interactive flag flag hasn't been set
 	if [ "${non_interactive}" -eq 0 ]; then


### PR DESCRIPTION
Download `host-spawn` only if it is missing or when the installed version is actually older.

Prior to this change `distrobox-host-exec` will download `host-spawn` even when the locally installed version is greater than expected.

For example `distrobox-host-exec` expected `host-spawn` version `1.2.1` and I have version `1.4.1` installed locally. Every time I call `distrobox-host-exec` it won't work unless I download the version `1.2.1`.

This shouldn't be happenning, considering that `distrobox-host-exec` prints that my version is older, when it is actually newer.