### PR TITLE
distrobox-export: add login shell option

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -405,7 +405,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program:-} ${container_manager}"
+	container_manager="${distrobox_sudo_program-} ${container_manager}"
 fi
 
 # Clone a container as a snapshot.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -274,7 +274,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program:-} ${container_manager}"
+	container_manager="${distrobox_sudo_program-} ${container_manager}"
 fi
 
 # Generate Podman or Docker command to execute.

--- a/distrobox-export
+++ b/distrobox-export
@@ -38,7 +38,9 @@ extra_flags=""
 #	DBX_HOST_HOME is set in case container is created
 #	with custom --home directory
 host_home="${DISTROBOX_HOST_HOME:-"${HOME}"}"
-is_sudo=""
+start_shell=""
+is_login=0
+is_sudo=0
 rootful=""
 verbose=0
 version="1.4.2.1"
@@ -77,6 +79,7 @@ Options:
 				Defaults to (on \$container_name)
 	--export-path/-ep:	path where to export the binary
 	--extra-flags/-ef:	extra flags to add to the command
+    --login/-l      run the exported item in a login shell
 	--sudo/-S:		specify if the exported item should be run as sudo
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
@@ -124,8 +127,12 @@ while :; do
 				shift
 			fi
 			;;
+        -l | --login)
+            is_login=1
+            shift
+            ;;
 		-S | --sudo)
-			is_sudo="sudo"
+			is_sudo=1
 			shift
 			;;
 		-el | --export-label)
@@ -228,8 +235,17 @@ if [ -z "${container_name}" ]; then
 	container_name=$(uname -n | cut -d'.' -f1)
 fi
 
+#
+if [ $is_login -ne 0 ] && [ $is_sudo -ne 0 ]; then
+    start_shell="sudo -i"
+elif [ $is_login -ne 0 ]; then
+    start_shell="sh -l -c"
+else
+    start_shell=""
+fi
+
 # Prefix to add to an existing command to work throught the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- ${is_sudo} "
+container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- ${start_shell} "
 if [ -z "${exported_app_label}" ]; then
 	exported_app_label=" (on ${container_name})"
 fi
@@ -246,7 +262,7 @@ generate_script() {
 # name: ${container_name}
 if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
 	command="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
-${is_sudo} ${exported_bin} ${extra_flags} "
+${start_shell} ${exported_bin} ${extra_flags} "
 
 	for arg in "\$@"; do
 		if echo "\${arg}" | grep -Eq "'|\""; then

--- a/distrobox-export
+++ b/distrobox-export
@@ -127,10 +127,10 @@ while :; do
 				shift
 			fi
 			;;
-        -l | --login)
-            is_login=1
-            shift
-            ;;
+		-l |     --login)
+			is_login=1
+			shift
+			;;
 		-S | --sudo)
 			is_sudo=1
 			shift
@@ -237,11 +237,11 @@ fi
 
 #
 if [ $is_login -ne 0 ] && [ $is_sudo -ne 0 ]; then
-    start_shell="sudo -i"
+	start_shell="sudo -i"
 elif [ $is_login -ne 0 ]; then
-    start_shell="sh -l -c"
+	start_shell="sh -l -c"
 else
-    start_shell=""
+	start_shell=""
 fi
 
 # Prefix to add to an existing command to work throught the container

--- a/distrobox-export
+++ b/distrobox-export
@@ -79,7 +79,7 @@ Options:
 				Defaults to (on \$container_name)
 	--export-path/-ep:	path where to export the binary
 	--extra-flags/-ef:	extra flags to add to the command
-    --login/-l      run the exported item in a login shell
+	--login/-l		run the exported item in a login shell
 	--sudo/-S:		specify if the exported item should be run as sudo
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
@@ -127,7 +127,7 @@ while :; do
 				shift
 			fi
 			;;
-		-l |     --login)
+		-l | --login)
 			is_login=1
 			shift
 			;;
@@ -236,9 +236,9 @@ if [ -z "${container_name}" ]; then
 fi
 
 #
-if [ $is_login -ne 0 ] && [ $is_sudo -ne 0 ]; then
+if [ "${is_login}" -ne 0 ] && [ "${is_sudo}" -ne 0 ]; then
 	start_shell="sudo -i"
-elif [ $is_login -ne 0 ]; then
+elif [ "${is_login}" -ne 0 ]; then
 	start_shell="sh -l -c"
 else
 	start_shell=""

--- a/distrobox-list
+++ b/distrobox-list
@@ -181,7 +181,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program:-} ${container_manager}"
+	container_manager="${distrobox_sudo_program-} ${container_manager}"
 fi
 
 # List containers using custom format that inclused MOUNTS

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -213,7 +213,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program:-} ${container_manager}"
+	container_manager="${distrobox_sudo_program-} ${container_manager}"
 fi
 
 # check if we have containers to delete

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -212,7 +212,7 @@ fi
 
 # prepend sudo (or the specified sudo program) if we want podman or docker to be rootful
 if [ "${rootful}" -ne 0 ]; then
-	container_manager="${distrobox_sudo_program:-} ${container_manager}"
+	container_manager="${distrobox_sudo_program-} ${container_manager}"
 fi
 
 # Inspect the container we're working with.

--- a/docs/usage/distrobox-export.md
+++ b/docs/usage/distrobox-export.md
@@ -26,6 +26,7 @@ automatically be launched from the container it is exported from.
 				Defaults to (on \$container_name)
 	--export-path/-ep:	path where to export the binary
 	--extra-flags/-ef:	extra flags to add to the command
+    --login/-l      run the exported item in a login shell
 	--sudo/-S:		specify if the exported item should be run as sudo
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
@@ -103,6 +104,11 @@ The option "--delete" will un-export an app, binary, or service.
 **Run as root in the container**
 
 The option "--sudo" will launch the exported item as root inside the distrobox.
+
+**Run inside a login shell**
+
+The option "--login" will launch the exported item inside a login shell, allowing access to
+variables sourced at login in the container (e.g: /etc/profile).
 
 **Exporting apps from rootful containers**
 


### PR DESCRIPTION
Add the option (`-l` or `--login`) to `distrobox-export` so that the exported command runs inside a login shell, giving it access to the variables sourced during login (e.g: /etc/profile).
If `--sudo` is also specified, then care has been taken so that it also runs in a login shell (via -i).

Fixes #639 