### PR TITLE
init: add nvidia integration

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -144,6 +144,7 @@ Usage:
 	distrobox create --image registry.fedoraproject.org/fedora-toolbox:35 --name fedora-toolbox-35
 	distrobox create --pull --image centos:stream9 --home ~/distrobox/centos9
 	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim"
+	distrobox create --image ubuntu:22.04 --name ubuntu-nvidia --nvidia
 
 	DBX_NON_INTERACTIVE=1 DBX_CONTAINER_NAME=test-alpine DBX_CONTAINER_IMAGE=alpine distrobox-create
 

--- a/distrobox-create
+++ b/distrobox-create
@@ -64,6 +64,7 @@ container_user_gid="$(id -rg)"
 container_user_home="${HOME:-"/"}"
 container_user_name="${USER}"
 container_user_uid="$(id -ru)"
+nvidia=0
 dryrun=0
 init=0
 non_interactive=0
@@ -166,6 +167,7 @@ Options:
 	--pre-init-hooks:	additional commands to execute prior to container initialization
 	--init/-I:		use init system (like systemd) inside the container.
 				this will make host's processes not visible from within the container.
+	--nvidia:		try to integrate host's nVidia drivers in the guest
 	--compatibility/-C:	show list of compatible images
 	--help/-h:		show this message
 	--no-entry:		do not generate a container entry in the application list
@@ -280,6 +282,10 @@ while :; do
 		-p | --pull)
 			container_always_pull=1
 			shift
+			;;
+		--nvidia)
+			shift
+			nvidia=1
 			;;
 		-Y | --yes)
 			non_interactive=1
@@ -660,6 +666,7 @@ generate_command() {
 		--group ${container_user_gid}
 		--home \"${container_user_custom_home:-"${container_user_home}"}\"
 		--init \"${init}\"
+		--nvidia \"${nvidia}\"
 		--pre-init-hooks \"${container_pre_init_hook}\"
 		--additional-packages \"${container_additional_packages}\"
 		-- '${container_init_hook}'

--- a/distrobox-init
+++ b/distrobox-init
@@ -269,32 +269,6 @@ mount_bind() (
 	return 0
 )
 
-# Extract soft path from full host library path
-# Arguments:
-#   source_dir
-# Outputs:
-#   Path in the guest container where to put the lib
-get_nvidia_lib_path() {
-	source_dir="$1"
-
-	# Some Debian based systems use this type of path
-	if [ -e "/run/host/usr/lib/x86_64-linux-gnu/" ]; then
-		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib/x86_64-linux-gnu||g')"
-		echo "${dest_dir}"
-		return
-	# /usr/lib64 is quite popular on rpm based distros
-	elif [ -e "/run/host/usr/lib64" ]; then
-		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib64||g')"
-		echo "${dest_dir}"
-		return
-	# Fallback to /usr/lib if none of the previous are present
-	else
-		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib||g')"
-		echo "${dest_dir}"
-		return
-	fi
-}
-
 if [ -n "${pre_init_hook}" ]; then
 	printf "distrobox: Executing pre-init hooks...\n"
 	# execute pre-init hooks if specified
@@ -970,20 +944,25 @@ if [ "${nvidia}" -eq 1 ]; then
 	done
 
 	# Then we find all the ".so" libraries, there are searched separately
-	# because we need to use get_nvidia_lib_path to mount them in the
+	# because we need to extract the relative path to mount them in the
 	# correct path based on the guest's setup
 	NVIDIA_LIBS="$(find /run/host/usr/lib* -type f -iname "*nvidia*.so*")"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
+		dest_file="$(printf "%s" "${nvidia_lib}" |
+			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |
+			sed 's|/run/host/usr/lib64/||g' |
+			sed 's|/run/host/usr/lib/||g')"
+
 		# In the guest we need to adjust the destination path, so if we're on
 		# debian based containers, we need to target /usr/lib/x86_64-linux-gnu/
 		if [ -e "/usr/lib/x86_64-linux-gnu/" ]; then
-			mount_bind "${nvidia_lib}" "/usr/lib/x86_64-linux-gnu/$(get_nvidia_lib_path "${nvidia_lib}")" ro
-		# /usr/lib64 is common in rpm based distros
+			mount_bind "${nvidia_lib}" "/usr/lib/x86_64-linux-gnu/${dest_file}" ro
+			# /usr/lib64 is common in rpm based distros
 		elif [ -e "/usr/lib64" ]; then
-			mount_bind "${nvidia_lib}" "/usr/lib64/$(get_nvidia_lib_path "${nvidia_lib}")" ro
-		# fallback to /usr/lib if none of the previous
+			mount_bind "${nvidia_lib}" "/usr/lib64/${dest_file}" ro
+			# fallback to /usr/lib if none of the previous
 		else
-			mount_bind "${nvidia_lib}" "/usr/lib/$(get_nvidia_lib_path "${nvidia_lib}")" ro
+			mount_bind "${nvidia_lib}" "/usr/lib/${dest_file}" ro
 		fi
 	done
 fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -947,6 +947,7 @@ for host_socket in ${host_sockets}; do
 	fi
 done
 ###############################################################################
+printf "distrobox: Setting up host's nvidia drivers integration...\n"
 
 # If --nvidia, we try to integrate host's nvidia drivers in to the guest
 if [ "${nvidia}" -eq 1 ]; then
@@ -963,7 +964,7 @@ if [ "${nvidia}" -eq 1 ]; then
 		-a -not -path "/run/host/usr/src*")"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
-		mount_bind "${nvidia_file}" "${dest_file}"
+		mount_bind "${nvidia_file}" "${dest_file}" ro
 	done
 
 	# Then we find all the ".so" libraries, there are searched separately
@@ -1032,7 +1033,6 @@ fi
 ###############################################################################
 
 ###############################################################################
-printf "distrobox: Setting up host's nvidia drivers integration...\n"
 # In case of an DEB distro, we can specify that our bind_mount directories
 # have to be ignored. This prevents conflicts during package installations.
 if [ -d "/etc/dpkg/dpkg.cfg.d/" ]; then

--- a/distrobox-init
+++ b/distrobox-init
@@ -1032,6 +1032,7 @@ fi
 ###############################################################################
 
 ###############################################################################
+printf "distrobox: Setting up host's nvidia drivers integration...\n"
 # In case of an DEB distro, we can specify that our bind_mount directories
 # have to be ignored. This prevents conflicts during package installations.
 if [ -d "/etc/dpkg/dpkg.cfg.d/" ]; then

--- a/distrobox-init
+++ b/distrobox-init
@@ -246,7 +246,7 @@ mount_bind() (
 	# if instead it's a file, create it with touch
 	elif [ -f "${source_dir}" ]; then
 		# exit if not successful
-		if ! mkdir -p "$(dirname "${source_dir}")"; then
+		if ! mkdir -p "$(dirname "${target_dir}")"; then
 			printf "Warning: cannot create mount target directory: %s\n" "${target_dir}"
 			return 1
 		fi
@@ -956,12 +956,14 @@ if [ "${nvidia}" -eq 1 ]; then
 	#	- confs
 	#	- icd files
 	#	- egl files
-	NVIDIA_FILES="$(find /run/host/usr/ -type f -iname "*nvidia*" \
-		-a -not -path "/run/host/usr/lib*" \
-		-a -not -path "/run/host/usr/lib*/modules*" \
-		-a -not -path "/run/host/usr/share/doc*" \
-		-a -not -path "/run/host/usr/share/man*" \
-		-a -not -path "/run/host/usr/src*")"
+	NVIDIA_FILES="$(find /run/host/usr/ \
+		-path "/run/host/usr/share/doc*" -prune -o \
+		-path "/run/host/usr/src*" -prune -o \
+		-path "/run/host/usr/lib*/modules*" -prune -o \
+		-path "/run/host/usr/share/man*" -prune -o \
+		-path "/run/host/usr/lib*" -prune -o \
+		-path "/run/host/usr/share/polkit*" -prune -o \
+		-type f -iname "*nvidia*" -print)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
 		mount_bind "${nvidia_file}" "${dest_file}" ro

--- a/distrobox-init
+++ b/distrobox-init
@@ -946,7 +946,8 @@ if [ "${nvidia}" -eq 1 ]; then
 	# Then we find all the ".so" libraries, there are searched separately
 	# because we need to extract the relative path to mount them in the
 	# correct path based on the guest's setup
-	NVIDIA_LIBS="$(find /run/host/usr/lib* -iname "*nvidia*.so*")"
+	NVIDIA_LIBS="$(find /run/host/usr/lib* \
+		-iname "*nvidia*.so*" -o -iname "libcuda*.so*" || :)"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
 		dest_file="$(printf "%s" "${nvidia_lib}" |
 			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |

--- a/distrobox-init
+++ b/distrobox-init
@@ -921,10 +921,11 @@ for host_socket in ${host_sockets}; do
 	fi
 done
 ###############################################################################
-printf "distrobox: Setting up host's nvidia drivers integration...\n"
 
 # If --nvidia, we try to integrate host's nvidia drivers in to the guest
 if [ "${nvidia}" -eq 1 ]; then
+	printf "distrobox: Setting up host's nvidia drivers integration...\n"
+
 	# First we find all non-lib files we need, this includes
 	#	- binaries
 	#	- confs

--- a/distrobox-init
+++ b/distrobox-init
@@ -937,10 +937,7 @@ if [ "${nvidia}" -eq 1 ]; then
 		-path "/run/host/usr/lib*/modules*" -prune -o \
 		-path "/run/host/usr/share/man*" -prune -o \
 		-path "/run/host/usr/lib*" -prune -o \
-		-path "/run/host/usr/share/polkit*" -prune -o \
-		-path "/run/host/usr/etc/skel*" -prune -o \
-		-path "/run/host/usr/etc/keys*" -prune -o \
-		-type f -iname "*nvidia*" -print)"
+		-type f -iname "*nvidia*" -print || :)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
 		mount_bind "${nvidia_file}" "${dest_file}" ro

--- a/distrobox-init
+++ b/distrobox-init
@@ -970,6 +970,11 @@ if [ "${nvidia}" -eq 1 ]; then
 			mount_bind "${nvidia_lib}" "/usr/lib/${dest_file}" ro
 		fi
 	done
+
+	# Refresh ldconfig cache, also detect if there are empty files remaining
+	# and clean them.
+	# This could happen when upgrading drivers and changing versions.
+	ldconfig 2>&1 | grep -Eo "File.*is empty" | cut -d' ' -f2 | xargs rm
 fi
 
 ###############################################################################

--- a/distrobox-init
+++ b/distrobox-init
@@ -938,6 +938,8 @@ if [ "${nvidia}" -eq 1 ]; then
 		-path "/run/host/usr/share/man*" -prune -o \
 		-path "/run/host/usr/lib*" -prune -o \
 		-path "/run/host/usr/share/polkit*" -prune -o \
+		-path "/run/host/usr/etc/skel*" -prune -o \
+		-path "/run/host/usr/etc/keys*" -prune -o \
 		-type f -iname "*nvidia*" -print)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
@@ -947,7 +949,7 @@ if [ "${nvidia}" -eq 1 ]; then
 	# Then we find all the ".so" libraries, there are searched separately
 	# because we need to extract the relative path to mount them in the
 	# correct path based on the guest's setup
-	NVIDIA_LIBS="$(find /run/host/usr/lib* -type f -iname "*nvidia*.so*")"
+	NVIDIA_LIBS="$(find /run/host/usr/lib* -iname "*nvidia*.so*")"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
 		dest_file="$(printf "%s" "${nvidia_lib}" |
 			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |

--- a/distrobox-init
+++ b/distrobox-init
@@ -27,11 +27,12 @@
 trap '[ "$?" -ne 0 ] && printf "Error: An error occurred\n"' EXIT
 
 # Defaults
+container_additional_packages=""
 init=0
 init_hook=""
-upgrade=0
+nvidia=0
 pre_init_hook=""
-container_additional_packages=""
+upgrade=0
 verbose=0
 version="1.4.2.1"
 # Print usage to stdout.
@@ -57,6 +58,7 @@ Options:
 	--additional-packages:	packages to install in addition
 	--init/-I:		whether to use or not init
 	--pre-init-hooks:	commands to execute prior to init
+	--nvidia:		try to integrate host's nVidia drivers in the guest
 	--upgrade/-U:		run init in upgrade mode
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -132,6 +134,13 @@ while :; do
 			fi
 			shift
 			shift
+			;;
+		--nvidia)
+			if [ -n "$2" ]; then
+				nvidia="$2"
+				shift
+				shift
+			fi
 			;;
 		--)
 			shift
@@ -259,6 +268,32 @@ mount_bind() (
 
 	return 0
 )
+
+# Extract soft path from full host library path
+# Arguments:
+#   source_dir
+# Outputs:
+#   Path in the guest container where to put the lib
+get_nvidia_lib_path() {
+	source_dir="$1"
+
+	# Some Debian based systems use this type of path
+	if [ -e "/run/host/usr/lib/x86_64-linux-gnu/" ]; then
+		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib/x86_64-linux-gnu||g')"
+		echo "${dest_dir}"
+		return
+	# /usr/lib64 is quite popular on rpm based distros
+	elif [ -e "/run/host/usr/lib64" ]; then
+		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib64||g')"
+		echo "${dest_dir}"
+		return
+	# Fallback to /usr/lib if none of the previous are present
+	else
+		dest_dir="$(printf "%s" "${source_dir}" | sed 's|/run/host/usr/lib||g')"
+		echo "${dest_dir}"
+		return
+	fi
+}
 
 if [ -n "${pre_init_hook}" ]; then
 	printf "distrobox: Executing pre-init hooks...\n"
@@ -913,6 +948,43 @@ for host_socket in ${host_sockets}; do
 done
 ###############################################################################
 
+# If --nvidia, we try to integrate host's nvidia drivers in to the guest
+if [ "${nvidia}" -eq 1 ]; then
+	# First we find all non-lib files we need, this includes
+	#	- binaries
+	#	- confs
+	#	- icd files
+	#	- egl files
+	NVIDIA_FILES="$(find /run/host/usr/ -type f -iname "*nvidia*" \
+		-a -not -path "/run/host/usr/lib*" \
+		-a -not -path "/run/host/usr/lib*/modules*" \
+		-a -not -path "/run/host/usr/share/doc*" \
+		-a -not -path "/run/host/usr/share/man*" \
+		-a -not -path "/run/host/usr/src*")"
+	for nvidia_file in ${NVIDIA_FILES}; do
+		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
+		mount_bind "${nvidia_file}" "${dest_file}"
+	done
+
+	# Then we find all the ".so" libraries, there are searched separately
+	# because we need to use get_nvidia_lib_path to mount them in the
+	# correct path based on the guest's setup
+	NVIDIA_LIBS="$(find /run/host/usr/lib* -type f -iname "*nvidia*.so*")"
+	for nvidia_lib in ${NVIDIA_LIBS}; do
+		# In the guest we need to adjust the destination path, so if we're on
+		# debian based containers, we need to target /usr/lib/x86_64-linux-gnu/
+		if [ -e "/usr/lib/x86_64-linux-gnu/" ]; then
+			mount_bind "${nvidia_lib}" "/usr/lib/x86_64-linux-gnu/$(get_nvidia_lib_path "${nvidia_lib}")" ro
+		# /usr/lib64 is common in rpm based distros
+		elif [ -e "/usr/lib64" ]; then
+			mount_bind "${nvidia_lib}" "/usr/lib64/$(get_nvidia_lib_path "${nvidia_lib}")" ro
+		# fallback to /usr/lib if none of the previous
+		else
+			mount_bind "${nvidia_lib}" "/usr/lib/$(get_nvidia_lib_path "${nvidia_lib}")" ro
+		fi
+	done
+fi
+
 ###############################################################################
 printf "distrobox: Integrating host's themes, icons, fonts...\n"
 # Themes and icons integration works using a bind mount inside the container
@@ -1145,6 +1217,8 @@ if [ -n "${DISTROBOX_HOST_HOME-}"  ] && [ -d "/etc/skel" ]; then
 	done
 fi
 
+###############################################################################
+
 printf "distrobox: Executing init hooks...\n"
 # execute eventual init hooks if specified
 # shellcheck disable=SC2086
@@ -1193,6 +1267,8 @@ if [ "${init}" -eq 0 ]; then
 		sleep 15
 	done
 fi
+
+###############################################################################
 
 # If we're here, the init support has been enabled.
 printf  "distrobox: Setting up init system...\n"

--- a/distrobox-init
+++ b/distrobox-init
@@ -947,7 +947,11 @@ if [ "${nvidia}" -eq 1 ]; then
 	# because we need to extract the relative path to mount them in the
 	# correct path based on the guest's setup
 	NVIDIA_LIBS="$(find /run/host/usr/lib* \
-		-iname "*nvidia*.so*" -o -iname "libcuda*.so*" || :)"
+		-iname "*nvidia*.so*" \
+		-o -iname "libcuda*.so*" \
+		-o -iname "libnvcuvid*.so*" \
+		-o -iname "libnvoptix*.so*" \
+		|| :)"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
 		dest_file="$(printf "%s" "${nvidia_lib}" |
 			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |

--- a/distrobox-init
+++ b/distrobox-init
@@ -950,8 +950,8 @@ if [ "${nvidia}" -eq 1 ]; then
 		-iname "*nvidia*.so*" \
 		-o -iname "libcuda*.so*" \
 		-o -iname "libnvcuvid*.so*" \
-		-o -iname "libnvoptix*.so*" \
-		|| :)"
+		-o -iname "libnvoptix*.so*" ||
+		:)"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
 		dest_file="$(printf "%s" "${nvidia_lib}" |
 			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -200,9 +200,9 @@ host.
 Keep also in mind that mirrors could be down for such old releases, so you will
 need to build a [custom distrobox image to ensure basic dependencies are met](./distrobox_custom.md).
 
-### GPU Accelleration support
+### GPU Acceleration support
 
-For Intel and AMD Gpus, the support is backed in, as the containers will install
+For Intel and AMD Gpus, the support is baked in, as the containers will install
 their latest available mesa/dri drivers.
 
 For NVidia, you can use the `--nvidia` flag during create, see [distrobox-create](./usage/distrobox-create.md)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -199,3 +199,14 @@ host.
 
 Keep also in mind that mirrors could be down for such old releases, so you will
 need to build a [custom distrobox image to ensure basic dependencies are met](./distrobox_custom.md).
+
+### GPU Accelleration support
+
+For Intel and AMD Gpus, the support is backed in, as the containers will install
+their latest available mesa/dri drivers.
+
+For NVidia, you can use the `--nvidia` flag during create, see [distrobox-create](./usage/distrobox-create.md)
+documentation to discover how to use it.
+
+Alternatively, you can use the [nvidia-container-toolkit](./useful_tips.md#using-nvidia-container-toolkit)
+utility to set up the integration independently from the distrobox's own flag.

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -15,9 +15,9 @@ graphical apps (X11/Wayland), and audio.
 
 **distrobox create**
 
-	--image/-i:		image to use for the container	default: registry.fedoraproject.org/fedora-toolbox:36
-	--name/-n:		name for the distrobox		default: my-distrobox
-	--pull/-p:		pull latest image unconditionally without asking
+	--image/-i:		image to use for the container
+	--name/-n:		name for the distrobox
+	--pull/-p:		pull the image even if it exists locally (implies --yes)
 	--yes/-Y:		non-interactive, pull images without asking
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
@@ -25,17 +25,18 @@ graphical apps (X11/Wayland), and audio.
 	--clone/-c:		name of the distrobox container to use as base for a new container
 				this will be useful to either rename an existing distrobox or have multiple copies
 				of the same environment.
-	--home/-H		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
-	--volume		additional volumes to add to the container
+	--home/-H:		select a custom HOME directory for the container. Useful to avoid host's home littering with temp files.
+	--volume:		additional volumes to add to the container
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--additional-packages/-ap:	additional packages to install during initial container setup
-	--init-hooks		additional commands to execute during container initialization
-	--pre-init-hooks	additional commands to execute prior to container initialization
-	--init/-I		use init system (like systemd) inside the container.
+	--init-hooks:		additional commands to execute during container initialization
+	--pre-init-hooks:	additional commands to execute prior to container initialization
+	--init/-I:		use init system (like systemd) inside the container.
 				this will make host's processes not visible from within the container.
+	--nvidia:		try to integrate host's nVidia drivers in the guest
 	--compatibility/-C:	show list of compatible images
 	--help/-h:		show this message
-	--no-entry:             do not generate a container entry in the application list
+	--no-entry:		do not generate a container entry in the application list
 	--dry-run/-d:		only print the container manager command generated
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -58,6 +59,7 @@ graphical apps (X11/Wayland), and audio.
 	distrobox create --image registry.fedoraproject.org/fedora-toolbox:35 --name fedora-toolbox-35
 	distrobox create --pull --image centos:stream9 --home ~/distrobox/centos9
 	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim"
+	distrobox create --image ubuntu:22.04 --name ubuntu-nvidia --nvidia
 
 You can also use environment variables to specify container name, image and container manager:
 
@@ -133,3 +135,26 @@ but will ensure that configs and dotfiles will not litter it.
 
 From version 1.4.0 of distrobox, when you create a new container, it will also generate
 an entry in the applications list.
+
+## NVidia integration
+
+If your host has an NVidia gpu, with installed proprietary drivers, you can integrate
+them with the guests by using the `--nvidia` flag:
+
+`distrobox create --nvidia --image ubuntu:latest --name ubuntu-nvidia`
+
+Be aware that **this is not compatible with non-glibc systems** and **nees newer
+distributions to work**.
+
+This feature was tested working on:
+
+- Almalinux
+- Archlinux
+- Centos 7 and newer
+- Clearlinux
+- Debian 10 and newer
+- OpenSUSE Leap
+- OpenSUSE Tumbleweed
+- Rockylinux
+- Ubuntu 18.04 and newer
+- Void Linux (glibc)

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -143,7 +143,7 @@ them with the guests by using the `--nvidia` flag:
 
 `distrobox create --nvidia --image ubuntu:latest --name ubuntu-nvidia`
 
-Be aware that **this is not compatible with non-glibc systems** and **nees newer
+Be aware that **this is not compatible with non-glibc systems** and **needs somewhat newer
 distributions to work**.
 
 This feature was tested working on:

--- a/docs/usage/distrobox-init.md
+++ b/docs/usage/distrobox-init.md
@@ -30,6 +30,7 @@ integration.
 	--additional-packages:	packages to install in addition
 	--init/-I:		whether to use or not init
 	--pre-init-hooks:	commands to execute prior to init
+	--nvidia:		try to integrate host's nVidia drivers in the guest
 	--upgrade/-U:		run init in upgrade mode
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -330,11 +330,11 @@ documentation to discover how to use it.
 ### Using nvidia-container-toolkit
 
 Alternatively from the `--nvidia` flag, you can use NVidia's own [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html).
-After following the [official guide to set nck up](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html)
+After following the [official guide to set nvidia-ctk up](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html)
 you can use it from distrobox doing:
 
 ```console
-distrobox create --name example-nvidia-toolkit --additional-flags "--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=2,3 -e NVIDIA_DRIVER_CAPABILITIES=compute,utility" --image nvidia/cuda
+distrobox create --name example-nvidia-toolkit --additional-flags "--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all" --image nvidia/cuda
 ```
 
 ## Slow creation on podman and image size getting bigger with distrobox create

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -15,6 +15,7 @@
   - [Using init system inside a distrobox](#using-init-system-inside-a-distrobox)
   - [Using distrobox as main cli](#using-distrobox-as-main-cli)
   - [Using a different architecture](#using-a-different-architecture)
+  - [Using the GPU inside the container](#using-the-gpu-inside-the-container)
   - [Slow creation on podman and image size getting bigger with distrobox create](#slow-creation-on-podman-and-image-size-getting-bigger-with-distrobox-create)
   - [Container save and restore](#container-save-and-restore)
   - [Check used resources](#check-used-resources)
@@ -313,6 +314,28 @@ aarch64
 ```
 
 ![image](https://user-images.githubusercontent.com/598882/170837120-9170a9fa-6153-4684-a435-d60a0136b563.png)
+
+## Using the GPU inside the container
+
+For Intel and AMD Gpus, the support is backed in, as the containers will install
+their latest available mesa/dri drivers.
+
+For NVidia, you can use the `--nvidia` flag during create, see [distrobox-create](./usage/distrobox-create.md)
+documentation to discover how to use it.
+
+```console
+~$ distrobox create --nvidia --name ubuntu-nvidia --image ubuntu:latest
+```
+
+### Using nvidia-container-toolkit
+
+Alternatively from the `--nvidia` flag, you can use NVidia's own [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html).
+After following the [official guide to set nck up](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html)
+you can use it from distrobox doing:
+
+```console
+distrobox create --name example-nvidia-toolkit --additional-flags "--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=2,3 -e NVIDIA_DRIVER_CAPABILITIES=compute,utility" --image nvidia/cuda
+```
 
 ## Slow creation on podman and image size getting bigger with distrobox create
 


### PR DESCRIPTION
This is a preliminary work to implement host's nVidia driver's integration, in the guest.

The procedure is simple enough, it will try and find all nVidia related files in the host, and bind mount them in the guest.

Right now this is confirmed working on:

    - Ubuntu 22+
    - Archlinux
    - VoidLinux (glibc)
    - Fedora
    - Redhat/Centos/Family (7+)

This is confirmed NOT working on non-glibc distros like

    - Alpine
    - Debian -> Seems like it uses a dedicated nvidia directory in lib? Works on Ubuntu not on Debian
    - Void (musl)

This needs more testing and confirmation, I don't have the hardware sadly.

Fix #477 #633 

Big thanks to @mirkobrombin for helping with the tests!

If anyone has suggestions to where to find a CI/CD that offers a machine with nVidia gpu, to do some automated testing, it will be great!