### PR TITLE
init: improve NVIDIA integration when on openSUSE hosts

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -938,6 +938,8 @@ if [ "${nvidia}" -eq 1 ]; then
 		-path "/run/host/usr/share/man*" -prune -o \
 		-path "/run/host/usr/lib*" -prune -o \
 		-path "/run/host/usr/share/polkit*" -prune -o \
+		-path "/run/host/usr/etc/skel*" -prune -o \
+		-path "/run/host/usr/etc/keys*" -prune -o \
 		-type f -iname "*nvidia*" -print)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"
@@ -947,7 +949,7 @@ if [ "${nvidia}" -eq 1 ]; then
 	# Then we find all the ".so" libraries, there are searched separately
 	# because we need to extract the relative path to mount them in the
 	# correct path based on the guest's setup
-	NVIDIA_LIBS="$(find /run/host/usr/lib* -type f -iname "*nvidia*.so*")"
+	NVIDIA_LIBS="$(find /run/host/usr/lib* -iname "*nvidia*.so*")"
 	for nvidia_lib in ${NVIDIA_LIBS}; do
 		dest_file="$(printf "%s" "${nvidia_lib}" |
 			sed 's|/run/host/usr/lib/x86_64-linux-gnu/||g' |


### PR DESCRIPTION
With these changes, on my openSUSE MicroOS box, `nvidia-smi` works:

```
dario@tw-nvidia-test:~> nvidia-smi 
Mon Mar 20 15:07:49 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.89.02    Driver Version: 525.89.02    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
... ... ...
```

And `glxinfo` seems to be happy too:
```
name of display: :0
display: :0  screen: 0
direct rendering: Yes
server glx vendor string: NVIDIA Corporation
server glx version string: 1.4
server glx extensions:
    GLX_ARB_context_flush_control, GLX_ARB_create_context, 
    GLX_ARB_create_context_no_error, GLX_ARB_create_context_profile,
    ... ... ...
```
