### PR TITLE
Podman rootless fixes

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -99,8 +99,8 @@ jobs:
           echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
 
           # some variant of useradd need a password, otherwise you get prompted to enter one
-          timeout 10 useradd -p '' -m $USERNAME
-          passwd -d $USERNAME
+          timeout 10 sudo useradd -p '' -m $USERNAME
+          sudo passwd -d $USERNAME
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,10 +38,11 @@ jobs:
       # Fetch from compatibility table all the distros supported
       - id: check_file_changed
         run: |
+          # @see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
           if git diff --name-only HEAD^ HEAD | grep -Ev "host-exec|generate-entry|ephemeral|upgrade" | grep -E "^distrobox|compatibility.md"; then
-            echo "::set-output name=distrobox_changed::True"
+            echo "distrobox_changed=True" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=distrobox_changed::False"
+            echo "distrobox_changed=False" >> $GITHUB_OUTPUT
           fi
 
   # Prepare distros matrix
@@ -60,12 +61,13 @@ jobs:
       # Fetch from compatibility table all the distros supported
       - id: set-matrix
         run: |
-            echo "::set-output name=targets::$(grep -E 'docker.io|quay.io|ghcr|registry.|ecr.' docs/compatibility.md |
+            # @see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+            echo "targets=$(grep -E 'docker.io|quay.io|ghcr|registry.|ecr.' docs/compatibility.md |
               cut -d'|' -f 4 |
               sed 's/<br>/\n/g' |
               tr -d ' ' |
               tail -n +2 |
-              jq -R -s -c 'split("\n")[:-1]')"
+              jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   run:
 
@@ -90,7 +92,7 @@ jobs:
       #   if: ${{ matrix.rootless }} == "yes" && ${{ matrix.container_manager }} == "docker"
 
       - name: Podman rootless
-        if: ${{ matrix.container_manager }} == "podman-rootless"
+        if: ${{ matrix.container_manager == "podman-rootless" }}
         run: |
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=\"sudo su -s /bin/bash -c\" >> $GITHUB_ENV

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -98,8 +98,8 @@ jobs:
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
 
-          groupadd $USERNAME
-          useradd -m $USERNAME
+          sudo groupadd $USERNAME
+          sudo useradd -m $USERNAME
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -76,22 +76,38 @@ jobs:
       max-parallel: 8
       matrix:
         distribution: ${{fromJSON(needs.setup.outputs.targets)}}
-        container_manager: ["podman", "docker"]
+        container_manager: ["podman", "podman-rootless", "docker"]
     env:
       DBX_CONTAINER_MANAGER: ${{ matrix.container_manager }}
+      ELEVATE: eval
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      # - name: Use Docker in rootless mode.
+      #   uses: ScribeMD/rootless-docker@0.2.2
+      #   if: ${{ matrix.rootless }} == "yes" && ${{ matrix.container_manager }} == "docker"
+
+      - name: Podman rootless
+        if: ${{ matrix.container_manager }} == "podman-rootless"
+        run: |
+          echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
+          echo "ELEVATE=\"sudo su -s /bin/bash -c\" >> $GITHUB_ENV
+
+          USERNAME=actions
+          groupadd $USERNAME
+          useradd -m $USERNAME
+
       # Ensure distrobox create works:
       - name: Distrobox create
         shell: 'script -q -e -c "bash {0}"'
+        
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ${DBX_CONTAINER_MANAGER} pull "${image}"
-          ./distrobox create --yes -i "${image}" --name "${container_name}"
+          $ELEVATE "${DBX_CONTAINER_MANAGER} pull \"${image}\""
+          $ELEVATE "./distrobox create --yes -i \"${image}\" --name \"${container_name}\""
           #case "${container_name}" in
           #  *init*)
           #    echo "SYSTEMD DETECTED: creating container with --init..."
@@ -108,7 +124,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter --name "${container_name}" -- whoami
+          $ELEVATE "./distrobox enter --name \"${container_name}\" -- whoami"
           # Temporary disable systemd init on github runners, it seems to be incompatible
           # with runner services:
           #   Failed to create /system.slice/runner-provisioner.service/init.scope control group: Permission denied
@@ -131,7 +147,7 @@ jobs:
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- whoami | tr -d '\r' | tr -d '^@')"
+          command_output="$($ELEVATE "./distrobox enter --name \"${container_name}\" -- whoami | tr -d '\r' | tr -d '^@'")"
           expected_output="$(whoami)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -145,7 +161,7 @@ jobs:
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
           # Assert that distrobox exported binary indeed works
           set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- uname -n | tr -d '\r' | tr -d '^@')"
+          command_output="$($ELEVATE "./distrobox enter --name \"${container_name}\" -- uname -n | tr -d '\r' | tr -d '^@'")"
           expected_output="${container_name}.$(uname -n)"
           if [ "$command_output" != "$expected_output" ]; then
             exit 1
@@ -157,7 +173,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path ${HOME}/
+          $ELEVATE "./distrobox enter \"${container_name}\" -- distrobox-export --bin /bin/uname --export-path ${HOME}/"
           # Assert that distrobox exported binary indeed works
           set -x
           command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
@@ -172,7 +188,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path ${HOME}/
+          $ELEVATE "./distrobox enter \"${container_name}\" -- distrobox-export --sudo --bin /bin/uname --export-path ${HOME}/"
           # Assert that distrobox exported binary indeed works
           set -x
           command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
@@ -186,14 +202,14 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox list | grep "${container_name}" | grep "${image}" | grep -E "Up|running"
+          $ELEVATE "./distrobox list" | grep "${container_name}" | grep "${image}" | grep -E "Up|running"
 
       # Ensure distrobox stop works:
       - name: Distrobox stop
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox stop --yes "${container_name}"
+          $ELEVATE "./distrobox stop --yes \"${container_name}\""
 
       # Ensure distrobox rm works:
       - name: Distrobox logs on failure
@@ -201,7 +217,7 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          $DBX_CONTAINER_MANAGER logs "${container_name}"
+          $ELEVATE "$DBX_CONTAINER_MANAGER logs \"${container_name}\""
 
       # Ensure distrobox rm works:
       - name: Distrobox rm
@@ -209,4 +225,4 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox rm --force "${container_name}"
+          $ELEVATE "./distrobox rm --force \"${container_name}\""

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           USERNAME=rootless
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
-          echo "ELEVATE=\"su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
+          echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
 
           sudo useradd -m $USERNAME
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -92,7 +92,7 @@ jobs:
       #   if: ${{ matrix.rootless }} == "yes" && ${{ matrix.container_manager }} == "docker"
 
       - name: Podman rootless
-        if: ${{ matrix.container_manager == "podman-rootless" }}
+        if: ${{ matrix.container_manager == 'podman-rootless' }}
         run: |
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=\"sudo su -s /bin/bash -c\" >> $GITHUB_ENV

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -94,13 +94,14 @@ jobs:
       - name: Podman rootless
         if: ${{ matrix.container_manager == 'podman-rootless' }}
         run: |
+          set -x
           USERNAME=rootless
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
 
           # some variant of useradd need a password, otherwise you get prompted to enter one
           timeout 10 sudo useradd -p '' -m $USERNAME
-          sudo passwd -d $USERNAME
+          timeout 10 sudo passwd -d -q $USERNAME
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -98,7 +98,7 @@ jobs:
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
 
-          sudo useradd -m $USERNAME
+          useradd -m $USERNAME
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -97,11 +97,14 @@ jobs:
           set -x
           USERNAME=rootless
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
-          echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
+          echo "ELEVATE=gosu $USERNAME bash -c" >> $GITHUB_ENV
 
           # some variant of useradd need a password, otherwise you get prompted to enter one
           timeout 10 sudo useradd -p '' -m $USERNAME
           timeout 10 sudo passwd -d -q $USERNAME
+
+          sudo curl -SsL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64
+          sudo chmod +x /bin/gosu
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -99,12 +99,18 @@ jobs:
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=gosu $USERNAME bash -c" >> $GITHUB_ENV
 
-          # some variant of useradd need a password, otherwise you get prompted to enter one
-          timeout 10 sudo useradd -p '' -m $USERNAME
-          timeout 10 sudo passwd -d -q $USERNAME
+          id
 
-          sudo curl -SsL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64
-          sudo chmod +x /bin/gosu
+          SUDO=
+          if [[ "$EUID" != 0 ]] && command -v sudo &>/dev/null; then
+            SUDO=sudo
+          fi
+          # some variant of useradd need a password, otherwise you get prompted to enter one
+          timeout 10 $SUDO useradd -p '' -m $USERNAME
+          timeout 10 $SUDOpasswd -d -q $USERNAME
+
+          $SUDO curl -SsL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64
+          $SUDO chmod +x /bin/gosu
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -98,7 +98,9 @@ jobs:
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=su -s /bin/bash $USERNAME -c" >> $GITHUB_ENV
 
-          useradd -m $USERNAME
+          # some variant of useradd need a password, otherwise you get prompted to enter one
+          timeout 10 useradd -p '' -m $USERNAME
+          passwd -d $USERNAME
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -94,11 +94,10 @@ jobs:
       - name: Podman rootless
         if: ${{ matrix.container_manager == 'podman-rootless' }}
         run: |
-          USERNAME=actions
+          USERNAME=rootless
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
           echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
 
-          sudo groupadd $USERNAME
           sudo useradd -m $USERNAME
 
       # Ensure distrobox create works:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.ref != 'refs/heads/main' }}
       max-parallel: 8
       matrix:
         distribution: ${{fromJSON(needs.setup.outputs.targets)}}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           USERNAME=rootless
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
-          echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
+          echo "ELEVATE=\"su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
 
           sudo useradd -m $USERNAME
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -94,10 +94,10 @@ jobs:
       - name: Podman rootless
         if: ${{ matrix.container_manager == 'podman-rootless' }}
         run: |
-          echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
-          echo "ELEVATE=\"sudo su -s /bin/bash -c\" >> $GITHUB_ENV
-
           USERNAME=actions
+          echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
+          echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\" >> $GITHUB_ENV
+
           groupadd $USERNAME
           useradd -m $USERNAME
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           USERNAME=actions
           echo "DBX_CONTAINER_MANAGER=podman" >> $GITHUB_ENV
-          echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\" >> $GITHUB_ENV
+          echo "ELEVATE=\"sudo su -s /bin/bash $USERNAME -c\"" >> $GITHUB_ENV
 
           groupadd $USERNAME
           useradd -m $USERNAME

--- a/distrobox-create
+++ b/distrobox-create
@@ -67,6 +67,7 @@ container_user_uid="$(id -ru)"
 dryrun=0
 init=0
 non_interactive=0
+use_shm=1
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -152,6 +153,7 @@ Options:
 	--name/-n:		name for the distrobox		default: ${container_name_default}
 	--pull/-p:		pull the image even if it exists locally (implies --yes)
 	--yes/-Y:		non-interactive, pull images without asking
+	--no-shm:		Do not use SHM, even if it is available
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
@@ -283,6 +285,10 @@ while :; do
 			;;
 		-Y | --yes)
 			non_interactive=1
+			shift
+			;;
+		--no-shm)
+			use_shm=0
 			shift
 			;;
 		--volume)
@@ -459,6 +465,21 @@ clone_container() {
 	return 0
 }
 
+is_shared_or_slave() {
+	local mount="$1"
+
+	propagation="$(findmnt -o PROPAGATION "$mount" | head -2 | tail -1)"
+	case "$propagation" in 
+		*slave*)
+			return 0
+			;;
+		*shared*)
+			return 0
+			;;
+	esac
+	return 1
+}
+
 # Generate Podman or Docker command to execute.
 # Arguments:
 #   None
@@ -481,6 +502,32 @@ generate_command() {
 		result_command="${result_command}
 			--pid host"
 	fi
+
+	dev_mode=""
+	sys_mode=""
+	tmp_mode=""
+	home_mode=""
+	root_dir_mode=""
+	if is_shared_or_slave /sys; then
+		sys_mode=":rslave"
+	fi
+
+	if is_shared_or_slave /dev; then
+		dev_mode=":rslave"
+	fi
+
+	if is_shared_or_slave /tmp; then
+		tmp_mode=":rslave"
+	fi
+
+	if is_shared_or_slave "${container_user_home}"; then
+		home_mode=":rslave"
+	fi
+
+	if is_shared_or_slave "/"; then
+		root_dir_mode=":rslave"
+	fi
+
 	# Mount useful stuff inside the container.
 	# We also mount host's root filesystem to /run/host, to be able to syphon
 	# dynamic configurations from the host.
@@ -495,14 +542,15 @@ generate_command() {
 		--label \"manager=distrobox\"
 		--env \"SHELL=${SHELL:-"/bin/bash"}\"
 		--env \"HOME=${container_user_home}\"
-		--volume /:/run/host:rslave
-		--volume /dev:/dev:rslave
-		--volume /sys:/sys:rslave
-		--volume /tmp:/tmp:rslave
+		--volume /:/run/host${root_dir_mode}
+		--volume /dev:/dev${dev_mode}
+		--volume /sys:/sys${sys_mode}
+		--volume /tmp:/tmp${tmp_mode}
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
 		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+		--volume \"${container_user_home}\":\"${container_user_home}\"${home_mode}"
+
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.
@@ -535,7 +583,7 @@ generate_command() {
 	# to /run/shm, instead of the other way around.
 	# Resolve this detecting if /dev/shm is a symlink and mount original
 	# source also in the container.
-	if [ -L "/dev/shm" ]; then
+	if [ -L "/dev/shm" ] && [ "$use_shm" = "1" ]; then
 		result_command="${result_command}
 			--volume $(realpath /dev/shm):$(realpath /dev/shm)"
 	fi

--- a/distrobox-create
+++ b/distrobox-create
@@ -466,18 +466,20 @@ clone_container() {
 }
 
 is_shared_or_slave() {
-	local mount="$1"
+	mount="$1"
 
-	propagation="$(findmnt -o PROPAGATION "$mount" | head -2 | tail -1)"
-	case "$propagation" in 
-		*slave*)
+	propagation="$(findmnt -o PROPAGATION "${mount}" | head -2 | tail -1)"
+	case "${propagation}" in
+		"*slave*")
 			return 0
 			;;
-		*shared*)
+		"*shared*")
 			return 0
+			;;
+		*)
+			return 1
 			;;
 	esac
-	return 1
 }
 
 # Generate Podman or Docker command to execute.
@@ -551,7 +553,6 @@ generate_command() {
 		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
 		--volume \"${container_user_home}\":\"${container_user_home}\"${home_mode}"
 
-
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.
 	#
@@ -583,7 +584,7 @@ generate_command() {
 	# to /run/shm, instead of the other way around.
 	# Resolve this detecting if /dev/shm is a symlink and mount original
 	# source also in the container.
-	if [ -L "/dev/shm" ] && [ "$use_shm" = "1" ]; then
+	if [ -L "/dev/shm" ] && [ "${use_shm}" = "1" ]; then
 		result_command="${result_command}
 			--volume $(realpath /dev/shm):$(realpath /dev/shm)"
 	fi

--- a/distrobox-create
+++ b/distrobox-create
@@ -459,30 +459,6 @@ clone_container() {
 	return 0
 }
 
-is_shared_or_slave() {
-	mount="$1"
-
-	propagation="$(findmnt -o PROPAGATION "${mount}" | head -2 | tail -1)"
-	case "${propagation}" in
-		"*slave*")
-			return 0
-			;;
-		"*shared*")
-			return 0
-			;;
-		*)
-			return 1
-			;;
-	esac
-}
-
-is_container_manager_podman_rootless() {
-	if [ "${container_manager}" = 'podman' ] && [ "$(podman info -f '{{json .Host.Security.Rootless}}')" = 'true' ]; then
-		return 0
-	fi
-	return 1
-}
-
 # Generate Podman or Docker command to execute.
 # Arguments:
 #   None
@@ -512,32 +488,6 @@ generate_command() {
 		result_command="${result_command}
 			--pid host"
 	fi
-
-	dev_mode=""
-	sys_mode=""
-	tmp_mode=""
-	home_mode=""
-	root_dir_mode=""
-	if is_shared_or_slave /sys; then
-		sys_mode=":rslave"
-	fi
-
-	if is_shared_or_slave /dev; then
-		dev_mode=":rslave"
-	fi
-
-	if is_shared_or_slave /tmp; then
-		tmp_mode=":rslave"
-	fi
-
-	if is_shared_or_slave "${container_user_home}"; then
-		home_mode=":rslave"
-	fi
-
-	if is_shared_or_slave "/"; then
-		root_dir_mode=":rslave"
-	fi
-
 	# Mount useful stuff inside the container.
 	# We also mount host's root filesystem to /run/host, to be able to syphon
 	# dynamic configurations from the host.
@@ -552,18 +502,14 @@ generate_command() {
 		--label \"manager=distrobox\"
 		--env \"SHELL=${SHELL:-"/bin/bash"}\"
 		--env \"HOME=${container_user_home}\"
-		--volume /:/run/host${root_dir_mode}
-		--volume /sys:/sys${sys_mode}
-		--volume /tmp:/tmp${tmp_mode}
+		--volume /:/run/host:rslave
+		--volume /dev:/dev:rslave
+		--volume /sys:/sys:rslave
+		--volume /tmp:/tmp:rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
 		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-		--volume \"${container_user_home}\":\"${container_user_home}\"${home_mode}"
-
-	if ! is_container_manager_podman_rootless; then
-		result_command="${result_command}
-			--volume /dev:/dev${dev_mode}"
-	fi
+		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.

--- a/distrobox-create
+++ b/distrobox-create
@@ -67,7 +67,6 @@ container_user_uid="$(id -ru)"
 dryrun=0
 init=0
 non_interactive=0
-use_shm=1
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -153,7 +152,6 @@ Options:
 	--name/-n:		name for the distrobox		default: ${container_name_default}
 	--pull/-p:		pull the image even if it exists locally (implies --yes)
 	--yes/-Y:		non-interactive, pull images without asking
-	--no-shm:		Do not use SHM, even if it is available
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
@@ -285,10 +283,6 @@ while :; do
 			;;
 		-Y | --yes)
 			non_interactive=1
-			shift
-			;;
-		--no-shm)
-			use_shm=0
 			shift
 			;;
 		--volume)
@@ -482,6 +476,13 @@ is_shared_or_slave() {
 	esac
 }
 
+is_container_manager_podman_rootless() {
+	if [ "${container_manager}" = 'podman' ] && [ "$(podman info -f '{{json .Host.Security.Rootless}}')" = 'true' ]; then
+		return 0
+	fi
+	return 1
+}
+
 # Generate Podman or Docker command to execute.
 # Arguments:
 #   None
@@ -493,12 +494,19 @@ generate_command() {
 	# use the host's namespace for ipc, network, pid, ulimit
 	result_command="${result_command}
 		--hostname \"${container_name}.$(uname -n)\"
-		--ipc host
 		--name \"${container_name}\"
 		--network host
 		--privileged
 		--security-opt label=disable
 		--user root:root"
+
+	ipc_host="--ipc host"
+	# ipc host is not possible when running Podman rootless
+	if is_container_manager_podman_rootless; then
+		ipc_host=""
+	fi
+
+	result_command="${result_command} ${ipc_host}"
 
 	if [ "${init}" -eq 0 ]; then
 		result_command="${result_command}
@@ -545,13 +553,17 @@ generate_command() {
 		--env \"SHELL=${SHELL:-"/bin/bash"}\"
 		--env \"HOME=${container_user_home}\"
 		--volume /:/run/host${root_dir_mode}
-		--volume /dev:/dev${dev_mode}
 		--volume /sys:/sys${sys_mode}
 		--volume /tmp:/tmp${tmp_mode}
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
 		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
 		--volume \"${container_user_home}\":\"${container_user_home}\"${home_mode}"
+
+	if ! is_container_manager_podman_rootless; then
+		result_command="${result_command}
+			--volume /dev:/dev${dev_mode}"
+	fi
 
 	# This fix is needed as on Selinux systems, the host's selinux sysfs directory
 	# will be mounted inside the rootless container.
@@ -584,7 +596,7 @@ generate_command() {
 	# to /run/shm, instead of the other way around.
 	# Resolve this detecting if /dev/shm is a symlink and mount original
 	# source also in the container.
-	if [ -L "/dev/shm" ] && [ "${use_shm}" = "1" ]; then
+	if [ -L "/dev/shm" ] && ! is_container_manager_podman_rootless; then
 		result_command="${result_command}
 			--volume $(realpath /dev/shm):$(realpath /dev/shm)"
 	fi

--- a/distrobox-create
+++ b/distrobox-create
@@ -459,6 +459,14 @@ clone_container() {
 	return 0
 }
 
+is_container_manager_podman_rootless() {
+	if [ "${container_manager}" = 'podman' ] && [ "$(podman info -f '{{json .Host.Security.Rootless}}')" = 'true' ]; then
+		return 0
+	fi
+	return 1
+}
+
+
 # Generate Podman or Docker command to execute.
 # Arguments:
 #   None


### PR DESCRIPTION
Do not mount `/dev` and use `--ipc host` when using Podman rootless because it is not supported.

Mounting `/dev` and `/dev/shm`:
```
$ distrobox enter
Container my-distrobox is not running.
Starting container my-distrobox
run this command to follow along:

 podman logs -f my-distrobox

Error: unable to start container "9c9d2eba2dc93066e02506f60bc4ff4e640b12f9d792442a8e62e15e2ae52025": crun: openat2 `dev/shm`: No such file or directory: OCI runtime attempted to invoke a command that was not found
```

Using `--ipc host`
```
$ podman run --rm -it --ipc host alpine Error: statfs /dev/mqueue: no such file or directory
```

Fixes #670 

