### PR TITLE
enter: fix $PATH when it contains spaces

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -345,11 +345,11 @@ generate_command() {
 		fi
 	done
 	# Ensure the $PATH entries from the host are appended as well
-	for standard_path in $(echo "${PATH}" | tr ':' ' '); do
+	while read -d ':' standard_path; do
 		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
-	done
+	done <<< "$PATH:"
 	result_command="${result_command} --env \"PATH=${container_paths}\""
 
 	# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -345,11 +345,11 @@ generate_command() {
 		fi
 	done
 	# Ensure the $PATH entries from the host are appended as well
-	while read -d ':' standard_path; do
+	container_paths=$(echo "${PATH}" | (while IFS=: read -r standard_path; do
 		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
-	done <<< "$PATH:"
+	done && echo "${container_paths}"))
 	result_command="${result_command} --env \"PATH=${container_paths}\""
 
 	# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -345,11 +345,13 @@ generate_command() {
 		fi
 	done
 	# Ensure the $PATH entries from the host are appended as well
-	container_paths=$(echo "${PATH}" | (while IFS=: read -r standard_path; do
+	ORIG_IFS="${IFS}"; IFS=:
+	for standard_path in ${PATH}; do
 		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
-	done && echo "${container_paths}"))
+	done
+	IFS="${ORIG_IFS}"
 	result_command="${result_command} --env \"PATH=${container_paths}\""
 
 	# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment


### PR DESCRIPTION
When the $PATH in host contain spaces, iterating with "for ... in ..."
will produce a wrong result.

refer to https://stackoverflow.com/a/44524309
