### PR TITLE
More aesthetically pleasing install script

### DIFF
--- a/install
+++ b/install
@@ -187,5 +187,5 @@ printf >&2 "\033[0m Shell scripts are located in \033[1;31m%s\n\033[0m" "${dest_
 printf >&2 "\033[0m Manpages are located in \033[1;31m%s\n\033[0m" "${man_dest_path}"
 
 if ! echo "${PATH}" | grep -q "${dest_path}"; then
-    printf >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
+	printf  >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
 fi

--- a/install
+++ b/install
@@ -187,5 +187,5 @@ printf >&2 "\033[0m Shell scripts are located in \033[1;31m%s\n\033[0m" "${dest_
 printf >&2 "\033[0m Manpages are located in \033[1;31m%s\n\033[0m" "${man_dest_path}"
 
 if ! echo "${PATH}" | grep -q "${dest_path}"; then
-	printf  >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
+	printf >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
 fi

--- a/install
+++ b/install
@@ -182,5 +182,10 @@ fi
 [ ! -w "${dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${dest_path}" && exit 1
 [ ! -w "${man_dest_path}" ] && printf >&2 "Cannot write into %s, permission denied.\n" "${man_dest_path}" && exit 1
 
-printf >&2 "\033[1;31m Successfully installed to %s.\n\033[0m" "${dest_path}"
-printf >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable for it to work.\n\033[0m" "${dest_path}"
+printf >&2 "\033[1;32m Installation successful!\n\033[0m"
+printf >&2 "\033[0m Shell scripts are located in \033[1;31m%s\n\033[0m" "${dest_path}"
+printf >&2 "\033[0m Manpages are located in \033[1;31m%s\n\033[0m" "${man_dest_path}"
+
+if ! echo "${PATH}" | grep -q "${dest_path}"; then
+    printf >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
+fi

--- a/install
+++ b/install
@@ -187,5 +187,5 @@ printf >&2 "\033[0m Shell scripts are located in \033[1;31m%s\n\033[0m" "${dest_
 printf >&2 "\033[0m Manpages are located in \033[1;31m%s\n\033[0m" "${man_dest_path}"
 
 if ! echo "${PATH}" | grep -q "${dest_path}"; then
-	printf >&2 "\033[1;31m Be sure that %s is in your \$PATH environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
+	printf >&2 "\033[0m Be sure that \033[1;31m%s\033[0m is in your \033[1;31m\$PATH\033[0m environment variable to be able to use distrobox without specifying the full path.\n\033[0m" "${dest_path}"
 fi

--- a/uninstall
+++ b/uninstall
@@ -103,4 +103,6 @@ done
 [  -e "${icon_dest_path}"/terminal-distrobox-icon.png ] && rm "${icon_dest_path}"/terminal-distrobox-icon.png
 [  -e "${icon_dest_path}"/distrobox ] && rm -rf "${icon_dest_path}"/distrobox
 
-printf >&2 "\033[1;31m Thank you for using Distrobox. Uninstall complete.\n\033[0m"
+printf >&2 "\033[1;32m Thank you for using Distrobox. Uninstall complete.\n\033[0m"
+printf >&2 "\033[0m Removed shell scripts located in \033[1;31m%s\n\033[0m" "${dest_path}"
+printf >&2 "\033[0m Removed manpages located in \033[1;31m%s\n\033[0m" "${man_dest_path}"


### PR DESCRIPTION
Makes the install prints more readable by not making it all red. Also shows the manpage path which gets used.
Only warns about PATH if `$dest_path` is not already in it.

![image](https://user-images.githubusercontent.com/50531162/230721583-c89b86f9-1217-4333-87e5-1bf2e66b3038.png)
