### PR TITLE
export: simplify `distro_binary` script

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -247,26 +247,10 @@ generate_script() {
 # distrobox_binary
 # name: ${container_name}
 if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
-	command="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
-${start_shell} ${exported_bin} ${extra_flags} "
-
-	for arg in "\$@"; do
-		if echo "\${arg}" | grep -Eq "'|\""; then
-			command="\${command} \\
-				\$(echo "\${arg}" | sed 's|\\\|\\\\\\\|g' |
-				sed 's| |\\\ |g' |
-				sed 's|\\$|\\\\\\$|g' |
-				sed "s|'|\\\\\'|g" |
-				sed 's|"|\\\\\"|g')"
-		elif echo "\${arg}" | grep -q "'"; then
-			command="\${command} \"\${arg}\""
-		else
-			command="\${command} '\${arg}'"
-		fi
-	done
-	eval \${command}
+	exec ${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
+		${start_shell} ${exported_bin} ${extra_flags} "\$@"
 else
-	${exported_bin} "\$@"
+	exec ${exported_bin} "\$@"
 fi
 EOF
 	return $?


### PR DESCRIPTION
In Vanilla OS, I have installed `git` through `apx install git`. Then, a script file `~/.local/bin/git` is generated. The script file seems to be created by distrobox, specifically, by the shell function `generate_script` in this file (`distrobox-export`).

In the script file, I noticed that it creates at least `1 + 6 x (number of arguments)` extra processes just to quote the arguments and then unquote them, which seems redundant. If the arguments contain `'` or `"`, the number of processes would increase further. We can simply pass the arguments to the command instead of quoting the arguments by external commands and then again unquoting them by `eval`.

Or is there any particular background to redundantly quote and unquote the arguments? I noticed #448, which introduced this quoting/unquoting in `distrobox-export`, but I think the change to `distrobox-enter` was sufficient in #448. While `distrobox-enter` needs to generate a command string for later use, distrobox_binary generated by `distrobox-export` evaluates the quoted arguments in the same place so actually does not need to quote them in the first place.

Even when there is a reason to first quote and then unquote the arguments, `eval ${command}` is vulnerable because when an argument containing `'*'` is passed, it can pick up an arbitrary string from the filenames in the current directory through pathname expansions and execute it. Even when this PR would be rejected, at least, the `eval` should be quoted as `eval "${command}"`. For example,

```bash
$ touch "''; echo Arbitrary Command Execution; : ''"
$ git commit -m '*'
```

Also, we can use exec to run `distribox-enter` in order to reduce the number of forks.
