### PR TITLE
enter: fix the quoting of arguments

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -189,18 +189,7 @@ while :; do
 			container_command="$1"
 			shift
 			for arg in "$@"; do
-				if echo "${arg}" | grep -Eq "'|\""; then
-					container_command="${container_command} \
-						$(echo "${arg}" | sed 's|\\|\\\\|g' |
-						sed 's| |\\ |g' |
-						sed 's|\$|\\\$|g' |
-						sed "s|'|\\\'|g" |
-						sed 's|"|\\\"|g')"
-				elif echo "${arg}" | grep -q "'"; then
-					container_command="${container_command} \"${arg}\""
-				else
-					container_command="${container_command} '${arg}'"
-				fi
+				container_command="${container_command} '$(echo "${arg}" | sed 's|'\''|'\'\\\\\'\''|g')'"
 			done
 			break
 			;;

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -189,7 +189,9 @@ while :; do
 			container_command="$1"
 			shift
 			for arg in "$@"; do
-				container_command="${container_command} '$(echo "${arg}" | sed 's|'\''|'\'\\\\\'\''|g')'"
+				arg="$(echo "${arg}x" | sed 's|'\''|'\'\\\\\'\''|g')"
+				arg="${arg%x}"
+				container_command="${container_command} '$arg'"
 			done
 			break
 			;;


### PR DESCRIPTION
The current implementation of the quoting of the arguments does not work properly for many shell special characters. With the `git` command generated by `distrobox-export`, the following examples all result in errors.

```bash
$ git status '"`echo XXX`"'
/usr/lib/apx/distrobox-enter: 1: eval: echo XXX: not found
On branch main
nothing to commit, working tree clean
```

```bash
$ git status '"A&B"'
/usr/lib/apx/distrobox-enter: 1: eval: B": not found
On branch main
nothing to commit, working tree clean
```

```bash
$ git status '"(echo hello)"'
/usr/lib/apx/distrobox-enter: 1: eval: Syntax error: "(" unexpected
```

```bash
$ git status '"A;B"'
On branch main
nothing to commit, working tree clean
/usr/lib/apx/distrobox-enter: 1: eval: B": not found
```

To properly quote arguments, one can actually just replace `'` with `'\''` and enclose them in `' ... '`. Here, I submit the proper quoting.

Also, the command substitutions `$()` strip the newline characters at the end of the command outputs. To preserve the newlines at the end of arguments, one needs to output an "end marker" and then remove the marker. The second commit implements this.
