### PR TITLE
init: Only install mesa vulkan packages if available

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -443,7 +443,11 @@ if [ "${upgrade}" -ne 0 ] || ! command -v find || ! command -v mount || ! comman
 		# These are graphics drivers for 3d applications
 		if dnf list mesa-dri-drivers > /dev/null; then
 			dnf install -y \
-				mesa-dri-drivers \
+				mesa-dri-drivers
+		fi
+
+		if dnf list mesa-vulkan-drivers > /dev/null; then
+			dnf install -y \
 				mesa-vulkan-drivers \
 				vulkan
 		fi


### PR DESCRIPTION
For example, these are not available on aarch64 CentOS Stream 9.
