### PR TITLE
terminal display fixes

### DIFF
--- a/distrobox-list
+++ b/distrobox-list
@@ -231,9 +231,10 @@ for container in ${container_list}; do
 			printf "${YELLOW}"
 		fi
 		# print it in yellow if not Running
-		printf "%-12s | %-20s | %-18s | %-16s | %-5s | %-30s\n" \
+		printf "%-12s | %-20s | %-18s | %-16s | %-5s | %-30s" \
 			"${container_id}" "${container_name}" "${container_status}" "${container_mem}" "${container_cpu}" "${container_image}"
+
+		# shellcheck disable=SC2059
+		printf "${CLEAR}\n"
 	fi
-	# shellcheck disable=SC2059
-	printf "${CLEAR}"
 done

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -247,7 +247,7 @@ for container_name in ${container_name_list}; do
 		else
 			printf >&2 "Please stop container %s before deletion\n" "${container_name}"
 			printf >&2 "Run:\n\t%s stop %s\n" "${container_manager}" "${container_name}"
-			printf >&2 'or use the "--force" flag'
+			printf >&2 "or use the \"--force\" flag\n"
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
* rm: add missing trailing newline

* list: reorder color reset

  The color might not get reset at the end if no actual character is printed and the output has reached the bottom of the terminal.

  ![Screenshot_20230507_203526](https://user-images.githubusercontent.com/6131885/236696447-21a3b386-5f77-4c56-bbaa-10354169b154.jpg)
