### PR TITLE
generate-entry: drop apparent debug statements

### DIFF
--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -151,7 +151,6 @@ fi
 # If we delete, just ask confirmation and exit.
 if [ "${delete}" -ne 0 ]; then
 	rm -f "${HOME}/.local/share/applications/${container_name}.desktop"
-	printf "%s\n" "${container_name}"
 	exit
 fi
 
@@ -282,5 +281,3 @@ Terminal=true
 TryExec=${distrobox_path}/distrobox
 Type=Application
 EOF
-
-printf "%s\n" "${container_name}"


### PR DESCRIPTION
Commit 888d4561 ("generate-entry: add icon auto-download for known distros") added two printf statements printing the bare container name without any context.  This leads to superfluous on diststrobox-rm:

    $ distrobox rm test_alpine
    Do you really want to delete test_alpine? [Y/n]: y
    test_alpine
    test_alpine