### PR TITLE
distrobox-rm: add missing newline in error message

### DIFF
--- a/distrobox-rm
+++ b/distrobox-rm
@@ -247,7 +247,7 @@ for container_name in ${container_name_list}; do
 		else
 			printf >&2 "Please stop container %s before deletion\n" "${container_name}"
 			printf >&2 "Run:\n\t%s stop %s\n" "${container_manager}" "${container_name}"
-			printf >&2 'or use the "--force" flag'
+			printf >&2 'or use the "--force\n" flag'
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
The following error message did not have a terminating newline, thus the shell prompt would appear slightly messed up.

```
Please stop container XXX before deletion
Run:
        podman stop XXX
or use the "--force" flag <- no newline
```