### PR TITLE
Fix missing icons error, distrobox-export

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -396,7 +396,9 @@ export_application() {
 
 		# we wanto to export the application's icons
 		mkdir -p "${icon_home_directory}"
-		cp -r "$(realpath "${icon_file}")" "${icon_home_directory}"
+		if [ -e "$(realpath "${icon_file}")" ]; then
+			cp -r "$(realpath "${icon_file}")" "${icon_home_directory}"
+		fi
 	done
 
 	# create desktop files for the distrobox


### PR DESCRIPTION
Some applications have symbolic link to non existing icons (Zoom for example) and this prevent exporting such apps into the host system, by simply checking the file exist before copying solves this problem