### PR TITLE
Update integrate_vscode_distrobox.md

### DIFF
--- a/docs/posts/integrate_vscode_distrobox.md
+++ b/docs/posts/integrate_vscode_distrobox.md
@@ -119,8 +119,8 @@ each Distrobox we choose to integrate with VSCode:
   "name" : // PUT YOUR DISTROBOX NAME HERE
   "remoteUser": "${localEnv:USER}",
   "settings": {
-    "remote.containers.copyGitConfig": false,
-    "remote.containers.gitCredentialHelperConfigLocation": "none",
+    "dev.containers.copyGitConfig": false,
+    "dev.containers.gitCredentialHelperConfigLocation": "none",
     "terminal.integrated.profiles.linux": {
       "shell": {
         "path": "${localEnv:SHELL}",


### PR DESCRIPTION
As of the latest release of the Dev Containers extension, the preferred syntax has changed in favor of `"dev.containers.copyGitConfig"` and `"dev.containers.gitCredentialHelperConfigLocation"` respectively.

This does not affect the functionality of the configuration file, it just prevents the IntelliSense from complaining.