### PR TITLE
Remove --name since never used

### DIFF
--- a/distrobox-rm
+++ b/distrobox-rm
@@ -103,7 +103,6 @@ Usage:
 
 Options:
 
-	--name/-n:		name for the distrobox
 	--force/-f:		force deletion
 	--rm-home:		remove the mounted home if it differs from the host user's one
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred

--- a/docs/usage/distrobox-rm.md
+++ b/docs/usage/distrobox-rm.md
@@ -32,6 +32,6 @@ You can also use environment variables to specify container manager and name:
 # ENVIRONMENT VARIABLES
 
 	DBX_CONTAINER_MANAGER
-	DBX_CONTAINER_
+	DBX_CONTAINER_NAME
 	DBX_NON_INTERACTIVE
 	DBX_SUDO_PROGRAM

--- a/docs/usage/distrobox-rm.md
+++ b/docs/usage/distrobox-rm.md
@@ -12,7 +12,6 @@ distrobox-rm delete one of the available distroboxes.
 
 **distrobox rm**
 
-	--name/-n:		name for the distrobox
 	--force/-f:		force deletion
 	--rm-home:		remove the mounted home if it differs from the host user's one
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
@@ -24,8 +23,7 @@ distrobox-rm delete one of the available distroboxes.
 
 # EXAMPLES
 
-	distrobox-rm --name container-name [--force]
-	distrobox-rm container-name [-f]
+	distrobox-rm container-name [--force]
 
 You can also use environment variables to specify container manager and name:
 
@@ -34,6 +32,6 @@ You can also use environment variables to specify container manager and name:
 # ENVIRONMENT VARIABLES
 
 	DBX_CONTAINER_MANAGER
-	DBX_CONTAINER_NAME
+	DBX_CONTAINER_
 	DBX_NON_INTERACTIVE
 	DBX_SUDO_PROGRAM


### PR DESCRIPTION
I might be wrong but the `--name` flag is never used in the source, so removing from the help message.

```
distrobox rm --name apx-alpine --force
ERROR: Invalid flag '--name'

distrobox version: 1.5.0.2

Usage:

	distrobox-rm [-f/--force] container-name [container-name1 container-name2 ...]

Options:

	--name/-n:		name for the distrobox
	--force/-f:		force deletion
	--rm-home:		remove the mounted home if it differs from the host user's one
	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
	--help/-h:		show this message
	--verbose/-v:		show more verbosity
	--version/-V:		show version
```