### PR TITLE
Add a flag to upgrade only running instances

### DIFF
--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -31,7 +31,7 @@ if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
 fi
 
 all=0
-up=0
+running=0
 container_manager="autodetect"
 distrobox_flags=""
 distrobox_path="$(dirname "$(realpath "${0}")")"
@@ -87,7 +87,7 @@ Options:
 
 	--help/-h:		show this message
 	--all/-a:		perform for all distroboxes
-	--up/-u:		perform for all running distroboxes
+	--running:		perform only for running distroboxes
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
@@ -121,8 +121,8 @@ while :; do
 			all=1
 			shift
 			;;
-		-u | --up)
-			up=1
+		--running)
+			running=1
 			shift
 			;;
 		-r | --root)
@@ -158,7 +158,7 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
-if [ -z "${container_name}" ] && [ "${all}" -eq 0 ] && [ "${up}" -eq 0 ]; then
+if [ -z "${container_name}" ] && [ "${all}" -eq 0 ] && [ "${running}" -eq 0 ]; then
 	printf >&2 "Please specify the name of the container.\n"
 	exit 1
 fi
@@ -216,11 +216,12 @@ if [ "${all}" -ne 0 ]; then
 	container_name="$("${distrobox_path}"/distrobox-list ${distrobox_flags} --no-color |
 		tail -n +2 | cut -d'|' -f2 | tr -d ' ')"
 
-# If up, set container_name to the list of names of running instances
-elif [ "${up}" -ne 0 ]; then
-	# shellcheck disable=SC2086,2248
-	container_name="$("${distrobox_path}"/distrobox-list ${distrobox_flags} --no-color |
-		tail -n +2 | grep '.* | .* | Up ' | cut -d'|' -f2 | tr -d ' ')"
+	# If running, set container_name to the list of names of running instances
+	if [ "${running}" -ne 0 ]; then
+		# shellcheck disable=SC2086,2248
+		container_name="$("${distrobox_path}"/distrobox-list ${distrobox_flags} --no-color |
+			tail -n +2 | grep -iE '\| running|up' | cut -d'|' -f2 | tr -d ' ')"
+	fi
 fi
 
 # Launch the entrypoint in upgrade mode

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -31,6 +31,7 @@ if [ -n "${SUDO_USER}" ] || [ -n "${DOAS_USER}" ]; then
 fi
 
 all=0
+up=0
 container_manager="autodetect"
 distrobox_flags=""
 distrobox_path="$(dirname "$(realpath "${0}")")"
@@ -86,6 +87,7 @@ Options:
 
 	--help/-h:		show this message
 	--all/-a:		perform for all distroboxes
+	--up/-u:		perform for all running distroboxes
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
@@ -117,6 +119,10 @@ while :; do
 			;;
 		-a | --all)
 			all=1
+			shift
+			;;
+		-u | --up)
+			up=1
 			shift
 			;;
 		-r | --root)
@@ -152,7 +158,7 @@ if [ "${verbose}" -ne 0 ]; then
 	set -o xtrace
 fi
 
-if [ -z "${container_name}" ] && [ "${all}" -eq 0 ]; then
+if [ -z "${container_name}" ] && [ "${all}" -eq 0 ] && [ "${up}" -eq 0 ]; then
 	printf >&2 "Please specify the name of the container.\n"
 	exit 1
 fi
@@ -209,6 +215,12 @@ if [ "${all}" -ne 0 ]; then
 	# shellcheck disable=SC2086,2248
 	container_name="$("${distrobox_path}"/distrobox-list ${distrobox_flags} --no-color |
 		tail -n +2 | cut -d'|' -f2 | tr -d ' ')"
+
+# If up, set container_name to the list of names of running instances
+elif [ "${up}" -ne 0 ]; then
+	# shellcheck disable=SC2086,2248
+	container_name="$("${distrobox_path}"/distrobox-list ${distrobox_flags} --no-color |
+		tail -n +2 | grep '.* | .* | Up ' | cut -d'|' -f2 | tr -d ' ')"
 fi
 
 # Launch the entrypoint in upgrade mode

--- a/docs/usage/distrobox-upgrade.md
+++ b/docs/usage/distrobox-upgrade.md
@@ -14,6 +14,7 @@ an upgrade using the container's package manager.
 
 	--help/-h:		show this message
 	--all/-a:		perform for all distroboxes
+	--up/-u:		perform for all running distroboxes
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)

--- a/docs/usage/distrobox-upgrade.md
+++ b/docs/usage/distrobox-upgrade.md
@@ -14,7 +14,7 @@ an upgrade using the container's package manager.
 
 	--help/-h:		show this message
 	--all/-a:		perform for all distroboxes
-	--up/-u:		perform for all running distroboxes
+	--running:		perform only on running distroboxes
 	--root/-r:		launch podman/docker with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
 				specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)
@@ -26,6 +26,10 @@ an upgrade using the container's package manager.
 Upgrade all distroboxes
 
 	distrobox-upgrade --all
+
+Upgrade all running distroboxes
+
+	distrobox-upgrade --all --running
 
 Upgrade a specific distrobox
 


### PR DESCRIPTION
i created multiple instances for different projects, and updating all instances means starting all instances that some do heavy operations at startup, so i want to keep them up-to-date but only for the ones i'm currently using so i thought that --up variable could be useful to add for other/similar usages