### PR TITLE
Should fix issues with paths containing spaces

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -247,7 +247,7 @@ generate_script() {
 # distrobox_binary
 # name: ${container_name}
 if [ -z "\${CONTAINER_ID}" ]; then
-	exec ${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- \
+	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} -- \
 		${start_shell} ${exported_bin} ${extra_flags} "\$@"
 else
 	exec ${exported_bin} "\$@"


### PR DESCRIPTION
Found an issue when distrobox-export when distrobox paths contain spaces that would cause the export file to point to the wrong location.  Encapsulating the path with quotations should fix this issue. 