### PR TITLE
create: fix pure flake NixOS system mounted files

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -578,6 +578,8 @@ generate_command() {
 		/nix
 		/gnu
 		/run/current-system/sw
+		/etc/profiles/per-user
+		/etc/static/profiles/per-user
 	"
 	for nix_dir in ${nix_dirs}; do
 		if [ -d "${nix_dir}" ]; then


### PR DESCRIPTION
Hi, first of all, thanks for the great work. Distrobox is really useful!

This PR is for fixing the mounting issue specific to pure flake NixOS systems (see [flakes](https://nixos.wiki/wiki/Flakes)).

## The issue:

Pure flake NixOS systems use `/etc/profiles/per-user/` and `/ect/static/profiles/per-user` paths for symlinking the installed applications instead of `~/.nix-profile/` and `/nix/var/nix/profiles` (see [nix profiles](https://nixos.org/manual/nix/stable/package-management/profiles.html)).

So the linking goes like this:

```
/etc/profiles/per-user/alice -> /etc/static/profiles/per-user/alice -> /nix/store/...
```

And the `PATH` environment variable is set like this:

```
PATH=...:/home/alice/.nix-profile/bin:/etc/profiles/per-user/alice/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:...
```

Since the system is installed via flakes purely, only the `/etc/profiles/per-user/alice` is defining proper path to the installed application symlinks that are pointing to `/nix/store/...`.

This requires mounting these directories on `create` as otherwise the symlinks that exist under these paths are not mounted to the box on `distrobox create`, resulting in not being able to find the installed applications of the host system inside the box.

## The fix:

Adding the following dirs to [this section](https://github.com/89luca89/distrobox/blob/40fdc93ff1b5a450abbccdb8503fdc8bd63bd449/distrobox-create#L577) fixes the issue:

- `/etc/profiles/per-user`
- `/etc/static/profiles/per-user`

I am not aware of any distro using these paths by default, so I think this would not break distrobox usage for other distros.

## Additional info:

The `/env/profiles/per-user` content:

```
$ ls -alF /etc/profiles/per-user/
lrwxrwxrwx 34 root alice -> /etc/static/profiles/per-user/mcst/
```

The `/env/static/profiles/per-user` content:

```
$ ls -alF /etc/static/profiles/per-user/
lrwxrwxrwx 60 root alice -> /nix/store/hd3jlybnnlsshiwbm0cqm84n34j405kd-user-environment
```

The `/nix/store/hd3jlybnnlsshiwbm0cqm84n34j405kd-user-environment` content:

```
$ ls -alF /nix/store/hd3jlybnnlsshiwbm0cqm84n34j405kd-user-environment
dr-xr-xr-x - root bin
dr-xr-xr-x - root etc
dr-xr-xr-x - root lib
dr-xr-xr-x - root libexec
dr-xr-xr-x - root sbin
dr-xr-xr-x - root share
```

The NixOS version: NixOS Unstable (23.05)