### PR TITLE
fix: enable multiple init_hooks in assemble

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -370,7 +370,7 @@ parse_file() (
 		touch "${tmpfile}"
 		if [ -n "${key}" ] && [ -n "${value}" ]; then
 			if grep -q "${key}" "${tmpfile}"; then
-				if [ ${key} == "init_hooks" ] || [ ${key} == "pre_init_hooks" ]; then
+				if [ "${key}" = "init_hooks" ] || [ "${key}" = "pre_init_hooks" ]; then
 					concatenator=' \&\& '
 				else
 					concatenator=' '

--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -370,7 +370,12 @@ parse_file() (
 		touch "${tmpfile}"
 		if [ -n "${key}" ] && [ -n "${value}" ]; then
 			if grep -q "${key}" "${tmpfile}"; then
-				value="$(echo "${value}" | sed "s|\"|\" \${${key}} |")"
+				if [ ${key} == "init_hooks" ] || [ ${key} == "pre_init_hooks" ]; then
+					concatenator=' \&\& '
+				else
+					concatenator=' '
+				fi
+				value="$(echo "${value}" | sed "s|\"|\" \${${key}}${concatenator}|")"
 			fi
 			echo "${key}=${value}" >> "${tmpfile}"
 		fi


### PR DESCRIPTION
This fixes the issue from #844 by explicitly concatenating duplicate `init_hooks`/`pre_init_hooks` lines together with `&&`.