### PR TITLE
Export to host_home by default

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -26,7 +26,6 @@
 #	DISTROBOX_HOST_HOME
 
 # Defaults
-dest_path="${HOME}/.local/bin"
 export_action=""
 exported_app=""
 exported_app_label=""
@@ -37,6 +36,7 @@ extra_flags=""
 #	DBX_HOST_HOME is set in case container is created
 #	with custom --home directory
 host_home="${DISTROBOX_HOST_HOME:-"${HOME}"}"
+dest_path="${host_home}/.local/bin"
 is_login=0
 is_sudo=0
 rootful=""


### PR DESCRIPTION
when you create a container using a diff home path, you export the app/bin into the container home rather than the host home, since the idea of exporting is to make available that application on the host system i think we need to export by default into the host_home instead. 