### PR TITLE
host-exec: Fix CONTAINER_ID: unbound variable error

### DIFF
--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -28,6 +28,7 @@ if [ ! -t 1 ] ||
 fi
 distrobox_host_exec_default_command="${SHELL:-/bin/sh}"
 host_spawn_version="1.4.2"
+download_command=""
 sudo_command=""
 verbose=0
 version="1.5.0.2"
@@ -132,9 +133,9 @@ else
 fi
 
 if  command -v curl > /dev/null 2>&1; then
-	download="curl -sLo"
+	download_command="curl -sLo"
 elif  command -v wget > /dev/null 2>&1; then
-	download="wget -qO"
+	download_command="wget -qO"
 fi
 
 # Setup host-spawn as a way to execute commands back on the host
@@ -156,7 +157,7 @@ if ! command -v host-spawn > /dev/null ||
 	case "${response}" in
 		y | Y | Yes | yes | YES)
 			# Download matching version with current distrobox
-			if ! ${download} /tmp/host-spawn \
+			if ! ${download_command} /tmp/host-spawn \
 				"https://github.com/1player/host-spawn/releases/download/${host_spawn_version}/host-spawn-$(uname -m)"; then
 
 				printf "Error: Cannot download host-spawn\n"

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -116,7 +116,7 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 # Check we're running inside a container and not on the host
-if [ -z "${CONTAINER_ID}" ]; then
+if [ -z "${CONTAINER_ID:-}" ]; then
 	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
 	exit 126
 fi


### PR DESCRIPTION
Currently the script sets the `nounset` shell option, but it doesn't define the `CONTAINER_ID` variable and nor it should (something else does it). In such cases, we should resort to shell parameter expansion in order to use a default value (an empty string, in this case) if the parameter - read `CONTAINER_ID` variable - is unset or null.

So, we should use `${CONTAINER_ID:-}` instead, to avoid this error.

Fixes #882