### PR TITLE
export: Add call to update-desktop-database tool

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -45,7 +45,7 @@ verbose=0
 version="1.5.0.2"
 
 # We depend on some commands, let's be sure we have them
-base_dependencies="basename grep sed find"
+base_dependencies="basename find grep sed update-desktop-database"
 for dep in ${base_dependencies}; do
 	if ! command -v "${dep}" > /dev/null; then
 		printf >&2 "Missing dependency: %s\n" "${dep}"
@@ -460,6 +460,11 @@ export_application() {
 		sed -i "s|pixmaps|icons|g" \
 			"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
 	done
+
+	# Update the desktop files database to ensure exported applications will
+	# show up in the taskbar/desktop menu/whatnot right after running this
+	# script.
+	update-desktop-database "/run/host/${host_home}/.local/share/applications"
 
 	if [ "${exported_delete}" -ne 0 ]; then
 		printf "Application %s successfully un-exported.\nOK!\n" "${exported_app}"

--- a/distrobox-export
+++ b/distrobox-export
@@ -45,7 +45,7 @@ verbose=0
 version="1.5.0.2"
 
 # We depend on some commands, let's be sure we have them
-base_dependencies="basename find grep sed update-desktop-database"
+base_dependencies="basename find grep sed"
 for dep in ${base_dependencies}; do
 	if ! command -v "${dep}" > /dev/null; then
 		printf >&2 "Missing dependency: %s\n" "${dep}"
@@ -464,7 +464,7 @@ export_application() {
 	# Update the desktop files database to ensure exported applications will
 	# show up in the taskbar/desktop menu/whatnot right after running this
 	# script.
-	update-desktop-database "/run/host/${host_home}/.local/share/applications"
+	/usr/bin/distrobox-host-exec --yes update-desktop-database "${host_home}/.local/share/applications" 2> /dev/null || :
 
 	if [ "${exported_delete}" -ne 0 ]; then
 		printf "Application %s successfully un-exported.\nOK!\n" "${exported_app}"


### PR DESCRIPTION
That's important to ensure exported applications will show up in whatever the user/DE is using desktop files for (taskbars, desktop menus, etc) right after exportation.

Desktop Environments should already install `update-desktop-database` by default - that's how they handle packages installing `.desktop` files. I'd believe that most Window Managers should also have it.