### PR TITLE
fix: Only prompt to delete home if `--rm-home` is passed

### DIFF
--- a/distrobox-rm
+++ b/distrobox-rm
@@ -272,7 +272,7 @@ delete_container() {
 	# Prompt for confirmation
 	if [ "${container_home}" != "${HOME}" ]; then
 		if [ "${non_interactive}" -eq 0 ] &&
-			[ "${rm_home}" -eq 0 ]; then
+			[ "${rm_home}" -eq 1 ]; then
 
 			printf "Do you want to remove custom home of container %s (%s)? [y/N]: " "${container_name}" "${container_home}"
 			read -r response_rm_home


### PR DESCRIPTION
Only prompt the user to delete their mounted home directory (if it differs from $HOME) if they pass the `--rm-home` flag.

```
$ distrobox-rm -f acme
acme
```

```
$ distrobox-rm -f --rm-home acme
Do you want to remove custom home of container acme (/var/home/stone/Clients/ACME)? [y/N]: y
acme
Successfully removed /var/home/stone/Clients/ACME
```

This is a suggested solution to the pending discussion in issue #894 and resolves the issue raised in #895.