### PR TITLE
Custom command

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -35,6 +35,7 @@ version="1.5.0.2"
 additional_flags=""
 additional_packages=""
 entry=""
+custom_command=""
 home=""
 image=""
 init=""
@@ -244,6 +245,9 @@ run_distrobox() (
 	fi
 	if [ -n "${entry}" ] && [ "${entry}" -eq 0 ]; then
 		result_command="${result_command} --no-entry"
+	fi
+	if [ -n "${custom_command}" ]; then
+		result_command="${result_command} --custom-entry $(sanitie_variable "${custom_command}")"
 	fi
 	if [ -n "${nvidia}" ] && [ "${nvidia}" -eq 1 ]; then
 		result_command="${result_command} --nvidia"

--- a/distrobox-create
+++ b/distrobox-create
@@ -352,7 +352,7 @@ while :; do
 				shift
 			fi
 			;;
-		--custom-entry)
+		--custom-command)
 			if [ -n "$2" ]; then
 				custom_command="$2"
 				shift
@@ -830,7 +830,7 @@ if eval ${cmd} > /dev/null; then
 	if [ "${rootful}" -eq 0 ]; then
 		if [ "${container_generate_entry}" -ne 0 ]; then
 			if [ -n "${custom_command}" ]; then
-				"${distrobox_genentry_path}" --custom-entry "${custom_command}" "${container_name}"
+				"${distrobox_genentry_path}" --custom-command "${custom_command}" "${container_name}"
 			else
 				"${distrobox_genentry_path}" "${container_name}"
 			fi

--- a/distrobox-create
+++ b/distrobox-create
@@ -152,7 +152,7 @@ Usage:
 	distrobox create --image alpine my-alpine-container
 	distrobox create --image registry.fedoraproject.org/fedora-toolbox:38 --name fedora-toolbox-38
 	distrobox create --pull --image centos:stream9 --home ~/distrobox/centos9
-	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim" --custom-entry tmux
+	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim" --custom-command tmux
 	distrobox create --image ubuntu:22.04 --name ubuntu-nvidia --nvidia
 
 	DBX_NON_INTERACTIVE=1 DBX_CONTAINER_NAME=test-alpine DBX_CONTAINER_IMAGE=alpine distrobox-create
@@ -183,7 +183,7 @@ Options:
 	--compatibility/-C:	show list of compatible images
 	--help/-h:		show this message
 	--no-entry:		do not generate a container entry in the application list
-	--custom-entry:		generate a desktop file with a custom entry
+	--custom-command:		generate a desktop file with a custom command
 	--dry-run/-d:		only print the container manager command generated
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version

--- a/distrobox-create
+++ b/distrobox-create
@@ -58,6 +58,7 @@ container_init_hook=""
 container_manager="autodetect"
 container_manager_additional_flags=""
 container_name=""
+custom_command=""
 container_name_default="my-distrobox"
 container_pre_init_hook=""
 container_user_custom_home=""
@@ -151,7 +152,7 @@ Usage:
 	distrobox create --image alpine my-alpine-container
 	distrobox create --image registry.fedoraproject.org/fedora-toolbox:38 --name fedora-toolbox-38
 	distrobox create --pull --image centos:stream9 --home ~/distrobox/centos9
-	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim"
+	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim" --custom-entry tmux
 	distrobox create --image ubuntu:22.04 --name ubuntu-nvidia --nvidia
 
 	DBX_NON_INTERACTIVE=1 DBX_CONTAINER_NAME=test-alpine DBX_CONTAINER_IMAGE=alpine distrobox-create
@@ -182,6 +183,7 @@ Options:
 	--compatibility/-C:	show list of compatible images
 	--help/-h:		show this message
 	--no-entry:		do not generate a container entry in the application list
+	--custom-entry:		generate a desktop file with a custom entry
 	--dry-run/-d:		only print the container manager command generated
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
@@ -346,6 +348,13 @@ while :; do
 		--pre-init-hooks)
 			if [ -n "$2" ]; then
 				container_pre_init_hook="${2}"
+				shift
+				shift
+			fi
+			;;
+		--custom-entry)
+			if [ -n "$2" ]; then
+				custom_command="$2"
 				shift
 				shift
 			fi
@@ -820,7 +829,11 @@ if eval ${cmd} > /dev/null; then
 	# We've created the box, let's also create the entry
 	if [ "${rootful}" -eq 0 ]; then
 		if [ "${container_generate_entry}" -ne 0 ]; then
-			"${distrobox_genentry_path}" "${container_name}"
+			if [ -n "${custom_command}" ]; then
+				"${distrobox_genentry_path}" --custom-entry "${custom_command}" "${container_name}"
+			else
+				"${distrobox_genentry_path}" "${container_name}"
+			fi
 		fi
 	fi
 	exit $?

--- a/distrobox-ephemeral
+++ b/distrobox-ephemeral
@@ -49,6 +49,7 @@ verbose=0
 version="1.5.0.2"
 container_additional_packages=""
 container_init_hook=" "
+custom_command=""
 container_manager_additional_flags=""
 container_pre_init_hook=" "
 
@@ -111,6 +112,13 @@ while :; do
 			# Ignore --name on ephemeral
 			if [ -n "$2" ]; then
 				name="${2}"
+				shift
+				shift
+			fi
+			;;
+		--custom-command)
+			if [ -n "$2" ]; then
+				custom_command="$2"
 				shift
 				shift
 			fi
@@ -184,6 +192,10 @@ generate_command() {
 		result_command="${result_command} \
 			--additional-packages \"${container_additional_packages}\""
 	fi
+	if [ -n "${custom_command}" ]; then
+		result_command="${result_command} \
+			--custom-command \"${custom_command}\""
+	fi
 	if [ -n "${container_init_hook}" ]; then
 		result_command="${result_command} \
 			--init-hooks \"${container_init_hook}\""
@@ -203,7 +215,11 @@ cmd="$(generate_command)"
 # shellcheck disable=SC2086
 eval ${cmd}
 # shellcheck disable=SC2086
+if [ -n "${custom_command}" ]; then
+	"${distrobox_path}"/distrobox-enter ${extra_flags} "${name}" ${container_command} -- ${custom_command}
+else
 "${distrobox_path}"/distrobox-enter ${extra_flags} "${name}" ${container_command}
+fi
 # shellcheck disable=SC2086
 "${distrobox_path}"/distrobox-stop ${extra_flags} "${name}" --yes
 # shellcheck disable=SC2086

--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -42,6 +42,7 @@ container_name_default="my-distrobox"
 delete=0
 icon="auto"
 icon_default="${HOME}/.local/share/icons/terminal-distrobox-icon.svg"
+custom_command=""
 verbose=0
 version="1.5.0.2"
 
@@ -86,6 +87,7 @@ Options:
 	--delete/-d:		delete the entry
 	--icon/-i:		specify a custom icon [/path/to/icon] (default auto)
 	--root/-r:		perform on rootful distroboxes
+	--custom-entry/-c:	specify a custom entrypoint (ex. tmux)
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
 EOF
@@ -129,6 +131,13 @@ while :; do
 		--) # End of all options.
 			shift
 			break
+			;;
+		-c | --custom-entry)
+			if [ -n "$2" ]; then
+				custom_command="$2"
+				shift
+				shift
+			fi
 			;;
 		-*) # Invalid options.
 			printf >&2 "ERROR: Invalid flag '%s'\n\n" "$1"
@@ -289,6 +298,10 @@ if [ "${icon}" = "auto" ]; then
 		rm -f /tmp/"${container_name}".os-release
 	fi
 
+	if [ -n "$custom_command" ]; then
+		custom_command="-- ${custom_command}"
+	fi
+
 	icon_url="$(echo "${DISTRO_ICON_MAP}" | grep "${container_distro}:" | cut -d':' -f2-)"
 	if [ -n "${icon_url}" ] && [ "${download}" != "null" ]; then
 		icon_extension="${icon_url##*.}"
@@ -311,7 +324,7 @@ Name=${entry_name}
 GenericName=Terminal entering ${entry_name}
 Comment=Terminal entering ${entry_name}
 Categories=Distrobox;System;Utility
-Exec=${distrobox_path}/distrobox enter ${extra_flags} ${container_name}
+Exec=${distrobox_path}/distrobox enter ${extra_flags} ${container_name} ${custom_command}
 Icon=${icon}
 Keywords=distrobox;
 NoDisplay=false

--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -87,7 +87,7 @@ Options:
 	--delete/-d:		delete the entry
 	--icon/-i:		specify a custom icon [/path/to/icon] (default auto)
 	--root/-r:		perform on rootful distroboxes
-	--custom-entry/-c:	specify a custom entrypoint (ex. tmux)
+	--custom-command/-c:	specify a custom entrypoint (ex. tmux)
 	--verbose/-v:		show more verbosity
 	--version/-V:		show version
 EOF
@@ -132,7 +132,7 @@ while :; do
 			shift
 			break
 			;;
-		-c | --custom-entry)
+		-c | --custom-command)
 			if [ -n "$2" ]; then
 				custom_command="$2"
 				shift


### PR DESCRIPTION
This Pull Request introduces a new flag called --custom-command <bin>. This creates directly a desktop file with the specified binary to enter. 

I see this use case for using tmux directly, so there is no need to actually export it manually. Additionally, when using it with ephemeral, you get directly "thrown" into tmux, no manually executing tmux necessary (and creates also the desktop file with tmux as the command).

Hope you could critique a bit more, as this is my first steps into programming, and my first PR.