### PR TITLE
opensuse: init: handle untrusted repositories when installing basic packages

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1066,8 +1066,9 @@ EOF
 			libvulkan_intel
 			libvulkan_radeon
 		"
+		# Mark gpg errors (exit code 106) as non-fatal, but don't pull anything from unverified repos
 		# shellcheck disable=SC2086,SC2046
-		zypper install -y $(zypper -q se -x ${deps} | tail -n +4 | cut -d'|' -f2)
+		zypper -n install -y $(zypper -n -q se -x ${deps} | grep -e 'package$' | cut -d'|' -f2) || [ ${?} = 106 ]
 
 		# In case the locale is not available, install it
 		# will ensure we don't fallback to C.UTF-8


### PR DESCRIPTION
If the image ships some untrusted repositories initial package installation might fail for these two separate reasons

1) The package list obtained with `zypper se` is polluted with warnings coming
   from zypper itself about those untrusted repositories
2) Even with a correct package list, zypper would still return a non-zero exit
   code to acknowledge those untrusted repositories

This commit tries to tackle both points. The reason of checking for the exit code rather than using `--no-gpg-checks` is that this way untrusted packages wouldn't get in without user intervention.