### PR TITLE
Make exported binaries runnable within other Distrobox containers

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -253,6 +253,8 @@ generate_script() {
 if [ -z "\${CONTAINER_ID}" ]; then
 	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} -- \
 		${start_shell} ${exported_bin} ${extra_flags} "\$@"
+elif [ -n "\${CONTAINER_ID}" ] && [ "\${CONTAINER_ID}" != "${container_name}" ]; then
+	exec distrobox-host-exec ${dest_path}/$(basename "${exported_bin}") ${extra_flags} "\$@"
 else
 	exec ${exported_bin} "\$@"
 fi


### PR DESCRIPTION
Solves #482

- test if we are not in a container and run distrobox-enter if not

- test if we are in a container and if the container name is not the same as the one we are exporting from

- else run the binary