### PR TITLE
Change rootful detection condition

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -187,7 +187,7 @@ fi
 #
 # if /run/.nopasswd is present, let's treat the init as rootless, this is not
 # a good thing, users behold!
-if cat /run/host/etc/shadow > /dev/null && [ ! -e /run/.nopasswd ]; then
+if [ -w /run/host/etc/shadow ] && [ ! -e /run/.nopasswd ]; then
 	rootful=1
 fi
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -187,7 +187,9 @@ fi
 #
 # if /run/.nopasswd is present, let's treat the init as rootless, this is not
 # a good thing, users behold!
-if [ -w /run/host/etc/shadow ] && [ ! -e /run/.nopasswd ]; then
+if stat /run/host/etc/shadow &&
+	[ "$(stat -c "%u" /run/host/etc/shadow)" = "0" ] &&
+	[ ! -e /run/.nopasswd ]; then
 	rootful=1
 fi
 


### PR DESCRIPTION
https://github.com/89luca89/distrobox/blob/ace500978b8df4ff84f749a3be4723b64d13b9a4/distrobox-init#L190
`cat /run/host/etc/shadow > /dev/null` appears to always return true even when rootless.

This can be changed to check to see if `/etc/shadow` is writable to determine access. The earlier commit for checking readability (`-r /run/host/etc/shadow`) also always returned true.

```
> ls -l /etc/shadow
-rw-r--r--. 1 root root 1145 Aug  8 22:09 /etc/shadow
```

I believe this addresses the issue I had in #899 

Running `./distrobox ephemeral -i archlinux:latest -n test`

Log excerpt:

```
> podman logs -f test
+ '[' -w /run/host/etc/shadow ']'
+ '[' -n ' ' ']'
+ printf 'distrobox: Executing pre-init hooks...\n'
```

[distrobox-init fix.txt](https://github.com/89luca89/distrobox/files/12329659/distrobox-init.fix.txt)

For comparison, running  `./distrobox ephemeral --root -i archlinux:latest -n test`

```
> sudo podman logs -f roottest

[sudo] password for outphase: 
+ '[' -w /run/host/etc/shadow ']'
+ '[' '!' -e /run/.nopasswd ']'
+ rootful=1
distrobox: Executing pre-init hooks...
+ '[' -n ' ' ']'
+ printf 'distrobox: Executing pre-init hooks...\n'
```