### PR TITLE
enter: fix `XDG_DATA_DIRS` and `XDG_CONFIG_DIRS` handling

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -358,11 +358,11 @@ generate_command() {
 	standard_paths="/usr/local/share /usr/share"
 	container_paths="${XDG_DATA_DIRS:=}"
 	# add to the XDG_DATA_DIRS only after the host's paths, and only if not already present.
-	for standard_path in $standard_paths; do
-		pattern="(:|^)$standard_path(:|$)"
-		if [ -z "$container_paths" ]; then
-			container_paths="$standard_path"
-		elif ! echo "$container_paths" | grep -Eq "$pattern"; then
+	for standard_path in ${standard_paths}; do
+		pattern="(:|^)${standard_path}(:|$)"
+		if [ -z "${container_paths}" ]; then
+			container_paths="${standard_path}"
+		elif ! echo "${container_paths}" | grep -Eq "${pattern}"; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
 	done
@@ -373,11 +373,11 @@ generate_command() {
 	standard_paths="/etc/xdg"
 	container_paths="${XDG_CONFIG_DIRS:=}"
 	# add to the XDG_CONFIG_DIRS only after the host's paths, and only if not already present.
-	for standard_path in $standard_paths; do
-		pattern="(:|^)$standard_path(:|$)"
-		if [ -z "$container_paths" ]; then
-			container_paths="$standard_path"
-		elif ! echo "$container_paths" | grep -Eq "$pattern"; then
+	for standard_path in ${standard_paths}; do
+		pattern="(:|^)${standard_path}(:|$)"
+		if [ -z "${container_paths}" ]; then
+			container_paths="${standard_path}"
+		elif ! echo "${container_paths}" | grep -Eq "${pattern}"; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
 	done

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -358,8 +358,11 @@ generate_command() {
 	standard_paths="/usr/local/share /usr/share"
 	container_paths="${XDG_DATA_DIRS:=}"
 	# add to the XDG_DATA_DIRS only after the host's paths, and only if not already present.
-	for standard_path in ${standard_paths}; do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+	for standard_path in $standard_paths; do
+		pattern="(:|^)$standard_path(:|$)"
+		if [ -z "$container_paths" ]; then
+			container_paths="$standard_path"
+		elif ! echo "$container_paths" | grep -Eq "$pattern"; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
 	done
@@ -370,8 +373,11 @@ generate_command() {
 	standard_paths="/etc/xdg"
 	container_paths="${XDG_CONFIG_DIRS:=}"
 	# add to the XDG_CONFIG_DIRS only after the host's paths, and only if not already present.
-	for standard_path in ${standard_paths}; do
-		if [ -n "${container_paths##*:"${standard_path}"*}" ]; then
+	for standard_path in $standard_paths; do
+		pattern="(:|^)$standard_path(:|$)"
+		if [ -z "$container_paths" ]; then
+			container_paths="$standard_path"
+		elif ! echo "$container_paths" | grep -Eq "$pattern"; then
 			container_paths="${container_paths}:${standard_path}"
 		fi
 	done


### PR DESCRIPTION
Resolves #911 

when `XDG_DATA_DIRS` is empty

```bash
++ standard_paths='/usr/local/share /usr/share'
++ container_paths=
++ for standard_path in '$standard_paths'
++ pattern='(:|^)/usr/local/share(:|$)'
++ '[' -z '' ']'
++ container_paths=/usr/local/share
++ for standard_path in '$standard_paths'
++ pattern='(:|^)/usr/share(:|$)'
++ '[' -z /usr/local/share ']'
++ echo /usr/local/share
++ grep -Eq '(:|^)/usr/share(:|$)'
++ container_paths=/usr/local/share:/usr/share
++ set +x
```

when `XDG_DATA_DIRS` is not empty at the beginning

```bash
++ standard_paths='/usr/local/share /usr/share'
++ container_paths=/home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share
++ for standard_path in '$standard_paths'
++ pattern='(:|^)/usr/local/share(:|$)'
++ '[' -z /home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share ']'
++ echo /home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share
++ grep -Eq '(:|^)/usr/local/share(:|$)'
++ for standard_path in '$standard_paths'
++ pattern='(:|^)/usr/share(:|$)'
++ '[' -z /home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share ']'
++ echo /home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share
++ grep -Eq '(:|^)/usr/share(:|$)'
++ container_paths=/home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share
++ set +x
```