### PR TITLE
Add extra check to detect if we are in a container

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -547,7 +547,7 @@ generate_command() {
 		--label \"manager=distrobox\"
 		--env \"SHELL=$(basename "${SHELL:-"/bin/bash"}")\"
 		--env \"HOME=${container_user_home}\"
-		--mount type=tmpfs,destination=/run
+		--env \"container=${container_manager}\"
 		--volume /:/run/host:rslave
 		--volume /dev:/dev:rslave
 		--volume /sys:/sys:rslave
@@ -556,6 +556,15 @@ generate_command() {
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
 		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
 		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+
+	if [ "${init}" -eq 1 ] && echo "${container_manager}" | grep -q "docker"; then
+		result_command="${result_command}
+			--cgroupns host
+			--stop-signal SIGRTMIN+3
+			--mount type=tmpfs,destination=/run
+			--mount type=tmpfs,destination=/run/lock
+			--mount type=tmpfs,destination=/var/lib/journal"
+	fi
 
 	# This fix is needed so that the container can have a separate devpts instance
 	# inside

--- a/distrobox-export
+++ b/distrobox-export
@@ -167,7 +167,7 @@ if [ "${verbose}" -ne 0 ]; then
 fi
 
 # Check we're running inside a container and not on the host.
-if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
+if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ] && [ -z "${container}" ]; then
 	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
 	exit 126
 fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -169,7 +169,7 @@ while :; do
 done
 
 # Check we're running inside a container and not on the host
-if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ]; then
+if [ ! -f /run/.containerenv ] && [ ! -f /.dockerenv ] && [ -z "${container}" ]; then
 	printf >&2 "You must run %s inside a container!\n" " $(basename "$0")"
 	printf >&2 "distrobox-init should only be used as an entrypoint for a distrobox!\n\n"
 	printf >&2 "This is not intended to be used manually, but instead used by distrobox-enter\n"


### PR DESCRIPTION
In a podman container, if the container environment variable is set, it
means you are in a container.

--mount type=tmpfs,destination=/run only in initful docker

It's required for systemd on docker, on podman it's taken care of
--systemd=always flag.