### PR TITLE
Add ChromeOS as supported host OS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,7 +174,7 @@ Fedora Silverblue for the [uBlue](https://github.com/ublue-os) project
 ## Why
 
 - Provide a mutable environment on an immutable OS, like [Endless OS,
-  Fedora Silverblue, OpenSUSE MicroOS](compatibility.md#host-distros)  or [SteamOS3](posts/install_rootless.md)
+  Fedora Silverblue, OpenSUSE MicroOS, ChromeOS](compatibility.md#host-distros)  or [SteamOS3](posts/install_rootless.md)
 - Provide a locally privileged environment for sudoless setups
   (eg. company-provided laptops, security reasons, etc...)
 - To mix and match a stable base system (eg. Debian Stable, Ubuntu LTS, RedHat)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,6 +52,7 @@ Distrobox has been successfully tested on:
 | Alpine Linux | | To setup rootless podman, look [HERE](https://wiki.alpinelinux.org/wiki/Podman) |
 | Arch Linux | | `distrobox` and `distrobox-git` are available in AUR (thanks [M0Rf30](https://github.com/M0Rf30)!). <br> To setup rootless podman, look [HERE](https://wiki.archlinux.org/title/Podman) |
 | CentOS | 8 <br> 8 Stream <br> 9 Stream | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
+| ChromeOS | Debian 11 | This is using the built in Linux on ChromeOS mode which is debian-based. |
 | Debian | 11 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` (thanks [michel-slm!](https://github.com/michel-slm!)!) |
 | deepin | 23 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` |
 | EndlessOS | 4.0.0 | |


### PR DESCRIPTION
This is paricularly useful in the case of aarch64 Chromebooks, as there
is a lack of well upstreamed reasonably priced aarch64 machines.
aarch64 Chromebooks fill this gap well. This is using the built in
Linux on ChromeOS mode which is debian-based.
