### PR TITLE
docs: ChromeOS compatibility should say Debian 12 bookworm

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,7 +52,7 @@ Distrobox has been successfully tested on:
 | Alpine Linux | | To setup rootless podman, look [HERE](https://wiki.alpinelinux.org/wiki/Podman) |
 | Arch Linux | | `distrobox` and `distrobox-git` are available in AUR (thanks [M0Rf30](https://github.com/M0Rf30)!). <br> To setup rootless podman, look [HERE](https://wiki.archlinux.org/title/Podman) |
 | CentOS | 8 <br> 8 Stream <br> 9 Stream | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
-| ChromeOS | Debian 11 | This is using the built in Linux on ChromeOS mode which is debian-based. |
+| ChromeOS | Debian 11 (docker with make-shared workaround #non-shared-mounts) <br> Debian 12 (podman) | using built-in Linux on ChromeOS mode which is debian-based, which can be [upgraded](https://wiki.debian.org/DebianUpgrade) from 11 bullseye to 12 bookworm (in fact 12 is recommended) |
 | Debian | 11 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` (thanks [michel-slm!](https://github.com/michel-slm!)!) |
 | deepin | 23 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` |
 | EndlessOS | 4.0.0 | |


### PR DESCRIPTION
It works better on Debian 12 bookworm, this requires an upgrade, all
repos in the environment have 12 versions including the Google
maintained one for cros-packages. But there is an option to use docker
and Debian 11 bullseye. Original testing was done on podman with Debian
12, both rootful and rootless.
