### PR TITLE
Trim comments from ini file lines only when `#` is outside of quotes

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -360,6 +360,35 @@ run_distrobox() (
 	fi
 )
 
+# Remove comments from ini file line. Respects quoted instances of `#`.
+# Arguments:
+#   a value string
+# Outputs:
+#   a value string with the comments removed
+remove_comments() {
+  line="${1}"
+  filtered_line=$(echo "${line}" | awk '
+    # Configure awk to treat each character as a separate field
+    BEGIN { FS="" }
+    {
+      # Loop through each character of the line
+      for(i = 1; i <= NF; i++){
+        # If character is a quote, toggle the quoting flag
+        if ($i == "\"") {
+          q = !q
+        }
+        # If character is a hash and we are outside of quotes, stop processing
+        if (!q && $i == "#") {
+          exit
+        }
+        # Print the current character
+        printf("%s", $i)
+      }
+    }
+  ')
+  echo "${filtered_line}"
+}
+
 # Sanitize an input, add single/double quotes and escapes
 # Arguments:
 #   a value string
@@ -397,7 +426,7 @@ parse_file() (
 			continue
 		fi
 		# Remove comments and trailing spaces
-		line="$(echo "${line}" | sed 's/#.*//g' | sed 's/\s*$//g')"
+		line="$(remove_comments "${line}" | sed 's/\s*$//g')"
 
 		# Detect start of new section
 		if [ "$(echo "${line}" | cut -c 1)" = '[' ]; then

--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -366,8 +366,8 @@ run_distrobox() (
 # Outputs:
 #   a value string with the comments removed
 remove_comments() {
-  line="${1}"
-  filtered_line=$(echo "${line}" | awk '
+	line="${1}"
+	filtered_line=$(echo "${line}" | awk '
     # Configure awk to treat each character as a separate field
     BEGIN { FS="" }
     {
@@ -386,7 +386,7 @@ remove_comments() {
       }
     }
   ')
-  echo "${filtered_line}"
+	echo "${filtered_line}"
 }
 
 # Sanitize an input, add single/double quotes and escapes


### PR DESCRIPTION
Updates the `distrobox-assemble` logic for reading the INI file so `#` characters within quotes are not considered the start of a comment.  Given the following lines in the INI file:

```ini
init_hooks="echo 'Hello #World'"
init_hooks="echo 'Hello'" #World
```

With the current implementation, the first line will cause the following error when running `distrobox-assemble`:

```
line 1: unexpected EOF while looking for matching `"'
```

The _desired_ behavior is that these lines should cause the following to be printed in the container (and no errors when assembling):
```
Hello #World
Hello
```

This behavior is achieved by the code change in this PR!

Closes #956 
