### PR TITLE
Add missing instructions to make the podman launcher binary executable 

### DIFF
--- a/docs/posts/install_podman_static.md
+++ b/docs/posts/install_podman_static.md
@@ -12,8 +12,8 @@ between updates, then you could use this script to install `podman` in your `$HO
 This is particularly indicated also for completely *sudoless* setups, where you don't
 have any superuser access to the system, like for example company provided computers.
 
-Download the latest release of [podman-launcher](https://github.com/89luca89/podman-launcher/releases)
-and put it somewhere in your $PATH
+Download the latest release of [podman-launcher](https://github.com/89luca89/podman-launcher/releases),
+make it executable and put it somewhere in your $PATH
 
 Provided the only dependency on the host (`newuidmap/newgidmap`, of the package `uidmap` or `shadow`),
 you should be good to go.

--- a/docs/posts/steamdeck_guide.md
+++ b/docs/posts/steamdeck_guide.md
@@ -1,4 +1,4 @@
-# Install Distrobox on the Steamdecl
+# Install Distrobox on the Steamdeck
 
 To install Distrobox on the steamdeck, we can install both `podman` and `distrobox`
 inside the `$HOME` so that containers will survive updates.
@@ -9,6 +9,8 @@ To install podman, [refer to the install guide](install_podman_static.md#):
 
 - Download the latest release of `podman-launcher` and place it in your home and rename it to `podman`,
   this example will use `~/.local/bin`
+- Make the `podman` binary executable:
+  - `chmod +x ~/.local/bin/podman`
 - Setup `deck` user password using:
   - `passwd`
 - Setup `deck` user uidmap:


### PR DESCRIPTION
Hi,

This PR aims to add the instructions to make the `podman` launcher binary executable, which were missing from the documentation. Related to https://github.com/89luca89/podman-launcher/pull/4
It also corrects a little typo in the title of the Steamdeck install guide.
