### PR TITLE
distrobox-assemble fix missing ¤ in volume handling

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -330,7 +330,7 @@ run_distrobox() (
 		result_command="${result_command} --additional-packages $(sanitize_variable "${args}")"
 	fi
 	if [ -n "${volume}" ]; then
-		IFS=" "
+		IFS="¤"
 		for vol in ${volume}; do
 			result_command="${result_command} --volume $(sanitize_variable "${vol}")"
 		done


### PR DESCRIPTION
With this '¤' volumes can be on multiple lines

```
volume="/abc:/abc "
volume="/def:/def"
```

basically the same as for `additional_packages` and `additional_flags`.