### PR TITLE
Fix the issue when export would fail if there is a quote in filename(s).

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -358,7 +358,7 @@ export_application() {
 	# by its launcher name.
 	desktop_files=$(
 		# shellcheck disable=SC2086,SC2038
-		find ${canon_dirs} -type f -o -type l |
+		find ${canon_dirs} -type f -o -type l -printf '"%p"\n' |
 			xargs -I{} grep -le "Exec=.*${exported_app}.*" -le "Name=.*${exported_app}.*" "{}" |
 			xargs -I{} grep -Le "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox-enter"}.*" "{}" |
 			xargs -I{} printf "%s@" {}


### PR DESCRIPTION
Apparently, the export cannot handle filenames with quote, in my case it was the "...local/share/applications/Baldur's Gate 3.desktop" that caused the error in https://github.com/89luca89/distrobox/blob/9b4e7ec439544768a8e9a51675ec3f18465d5393/distrobox-export#L361

++ xargs '-I{}' grep -le 'Exec=.*steam.*' -le 'Name=.*steam.*' '{}'
++ xargs '-I{}' grep -Le 'Exec=.*/usr/bin/distrobox-enter.*' '{}'
++ xargs '-I{}' printf %s@ '{}'
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option