### PR TITLE
init: debian: fix installation of deprecated libgl1-mesa-glx and libegl1-mesa

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -570,8 +570,9 @@ if [ "${upgrade}" -ne 0 ] ||
 			xauth
 			xz-utils
 			zip
-			libegl1-mesa
-			libgl1-mesa-glx
+			libgl1
+			libegl1
+			libglx-mesa0
 			libvulkan1
 			mesa-vulkan-drivers
 		"


### PR DESCRIPTION
Fixes #995

Since at least Debian Buster (2019), libgl1-mesa-glx and libegl1-mesa are transitional packages for libgl1+libglx-mesa0 and libegl1 respectively.

In Debian Trixie, the transitional packages have been removed. Install the actual packages directly.

If you think that it would be better to add a check for even older releases I could add that as well (so that libgl1-mesa-glx and libegl1-mesa are installed on ancient releases), but I'm not sure if anyone has such an usecase :thinking:  