### PR TITLE
fix: docs show wrong example to define multiple volumes

### DIFF
--- a/docs/usage/distrobox-assemble.md
+++ b/docs/usage/distrobox-assemble.md
@@ -49,7 +49,7 @@ This is an example manifest file to create two containers:
 	pull=true
 	root=false
 	replace=false
-	volume="/tmp/test:/run/a /tmp/test:/run/b"
+	volume="/tmp/test:/run/a|/tmp/test:/run/b"
 
 **Create**
 

--- a/extras/distrobox-example-manifest.ini
+++ b/extras/distrobox-example-manifest.ini
@@ -47,7 +47,7 @@ init_hooks="touch /init-normal"
 pre_init_hooks="touch /pre-init"
 pull=true
 root=false
-volume=/tmp/test:/run/a /tmp/test:/run/b
+volume=/tmp/test:/run/a|/tmp/test:/run/b
 unshare_netns=true
 unshare_ipc=true
 # We can choose to start the container immediately, it's off by default

--- a/man/man1/distrobox-assemble.1
+++ b/man/man1/distrobox-assemble.1
@@ -74,7 +74,7 @@ pre_init_hooks=\[dq]touch /pre-init\[dq]
 pull=true
 root=false
 replace=false
-volume=\[dq]/tmp/test:/run/a /tmp/test:/run/b\[dq]
+volume=\[dq]/tmp/test:/run/a|/tmp/test:/run/b\[dq]
 \f[R]
 .fi
 .PP

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -74,7 +74,7 @@ pre_init_hooks=\[dq]touch /pre-init\[dq]
 pull=true
 root=false
 replace=false
-volume=\[dq]/tmp/test:/run/a /tmp/test:/run/b\[dq]
+volume=\[dq]/tmp/test:/run/a|/tmp/test:/run/b\[dq]
 \f[R]
 .fi
 .PP


### PR DESCRIPTION
In the docs a space is shown, while the code uses a pipe as IFS. Including the pipe makes multiple volumes work, otherwise only the first one is used.