### PR TITLE
fix: distrobox assemble --name params cleanup missing.

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -203,6 +203,7 @@ run_distrobox() (
 
 	# Skip item if --name used and no match is found
 	if [ "${boxname}" != "" ] && [ "${boxname}" != "${name}" ]; then
+		rm -f "${tmpfile}"
 		return
 	fi
 


### PR DESCRIPTION
Fixes issue #1013