### PR TITLE
export: fix hard path icon export

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -384,17 +384,16 @@ export_application() {
 		icon_name="$(grep Icon= "${desktop_file}" | cut -d'=' -f2- | paste -sd "@" -)"
 
 		for icon in ${icon_name}; do
-			# In case it's an hard path, conserve it and continue
 			if [ -e "${icon_name}" ]; then
+				# In case it's an hard path, conserve it and continue
 				icon_files="${icon_files}@${icon_name}"
-				continue
+			else
+				# If it's not an hard path, find all files in the canonical paths.
+				icon_files="${icon_files}@$(find \
+					/usr/share/icons \
+					/usr/share/pixmaps \
+					/var/lib/flatpak/exports/share/icons -iname "*${icon}*")"
 			fi
-
-			# If it's not an hard path, find all files in the canonical paths.
-			icon_files="${icon_files}@$(find \
-				/usr/share/icons \
-				/usr/share/pixmaps \
-				/var/lib/flatpak/exports/share/icons -iname "*${icon}*")"
 		done
 
 		# remove leading delimiter

--- a/distrobox-export
+++ b/distrobox-export
@@ -381,21 +381,24 @@ export_application() {
 			continue
 		fi
 
-		icon_name="$(grep Icon= "${desktop_file}" | cut -d'=' -f2- | tr '\n' '@')"
+		icon_name="$(grep Icon= "${desktop_file}" | cut -d'=' -f2- | paste -sd "@" -)"
 
-		# In case it's an hard path, conserve it and continue
-		if [ -e "${icon_name}" ]; then
-			icon_files="${icon_files}@${icon_name}"
-			continue
-		fi
 		for icon in ${icon_name}; do
+			# In case it's an hard path, conserve it and continue
+			if [ -e "${icon_name}" ]; then
+				icon_files="${icon_files}@${icon_name}"
+				continue
+			fi
+
 			# If it's not an hard path, find all files in the canonical paths.
 			icon_files="${icon_files}@$(find \
 				/usr/share/icons \
 				/usr/share/pixmaps \
-				/var/lib/flatpak/exports/share/icons -iname "*${icon}*" \
-				-printf "%p@" 2> /dev/null || :)"
+				/var/lib/flatpak/exports/share/icons -iname "*${icon}*")"
 		done
+
+		# remove leading delimiter
+		icon_files=${icon_files#@}
 	done
 
 	# create applications dir if not existing


### PR DESCRIPTION
icon_name would always have a trailing '@', resulting in the hard path check to always fail.

Also moving the hard path check into the for loop for multi icon support.