### PR TITLE
Sidesteping sssd non-standard USER env var with a id command.

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -305,7 +305,7 @@ generate_command() {
 	result_command="${result_command}
 		--detach-keys=\"\""
 	result_command="${result_command}
-		--user=\"${USER}\""
+		--user=\"$(id --user --name)\""
 
 	# For some usage, like use in service, or launched by non-terminal
 	# eg. from desktop files, TTY can fail to instantiate, and fail to enter
@@ -440,7 +440,7 @@ generate_command() {
 		# if no command was specified, let's execute a command that will find
 		# and run the default shell for the user
 		result_command="${result_command}
-			sh -c \"\\\$(getent passwd ${USER} | cut -f 7 -d :) -l"\"
+			sh -c \"\\\$(getent passwd $(id --user --name) | cut -f 7 -d :) -l"\"
 	fi
 
 	# Return generated command.

--- a/distrobox-export
+++ b/distrobox-export
@@ -227,7 +227,7 @@ if [ "${is_login}" -ne 0 ]; then
 	if [ "${is_sudo}" -ne 0 ]; then
 		start_shell="$(command -v sudo) -i"
 	else
-		start_shell="$(command -v sudo) -u ${USER} -i"
+		start_shell="$(command -v sudo) -u $(id --user --name) -i"
 	fi
 elif [ "${is_sudo}" -ne 0 ]; then
 	start_shell="$(command -v sudo)"

--- a/distrobox-init
+++ b/distrobox-init
@@ -57,7 +57,7 @@ distrobox version: ${version}
 
 Usage:
 
-	distrobox-init --name ${USER} --user $(id -ru) --group $(id -rg) --home ${HOME}
+	distrobox-init --name $(id --user --name) --user $(id -ru) --group $(id -rg) --home ${HOME}
 
 Options:
 


### PR DESCRIPTION
This is a possible way of bypassing **sssd** generating non standard USER environment variables by adding @domain.  

This is hopefully a more robust approach than trying to replace the illegal characters, which the Kerberos solution is doing.  Not tested on a host setup with Kerberos as yet.

Amazon Workspaces Ubuntu and Amazon Linux exhibit this behavior, where sssd is adding the Active Directory domain in the $USER name, e.g. user@domain.name.  
