### PR TITLE
Fix systemd/init container startup

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -564,7 +564,8 @@ if [ "${container_status}" != "running" ]; then
 	printf >&2 "\nContainer Setup Complete!\n"
 	# check if container was created with init/systemd, so we can
 	# wait until the system has been booted up before entering
-	if ${container_manager} inspect "${container_name}" --format "{{.Args}}" | grep -q 'init 1' && ${container_manager} exec "${container_name}" sh -c 'command -v systemctl' > /dev/null 2>&1; then
+	if ${container_manager} inspect "${container_name}" --format "{{.Args}}" | grep -q 'init 1' && \
+	${container_manager} exec "${container_name}" sh -c 'command -v systemctl' > /dev/null 2>&1; then
 		printf >&2 "Waiting for systemd startup...\n"
 		WAIT_COUNTER=0
 		while true; do

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -343,6 +343,7 @@ generate_command() {
 	# and export them to the container.
 	set +o xtrace
 	# disable logging for this snippet, or it will be too talkative.
+	ENV_LIST=""
 	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
 		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
 		# We filter the environment so that we do not have strange variables,
@@ -351,6 +352,7 @@ generate_command() {
 		# and needs to stay that way to use custom home dirs.
 		result_command="${result_command}
 			--env \"${i}\""
+		ENV_LIST="${ENV_LIST:-}$(echo "${i}" | sed 's/=.*//'),"
 	done
 
 	# Start with the $PATH set in the container's config
@@ -433,12 +435,12 @@ generate_command() {
 
 	if [ -n "${container_command}" ]; then
 		result_command="${result_command}
-			${container_command}"
+			sudo --user ${USER} --login --preserve-env='\"${ENV_LIST}\"' ${container_command}"
 	else
 		# if no command was specified, let's execute a command that will find
 		# and run the default shell for the user
 		result_command="${result_command}
-			sudo --user ${USER} --login"
+			sudo --user ${USER} --login --preserve-env='\"${ENV_LIST}\"'"
 	fi
 
 	# Return generated command.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -304,6 +304,8 @@ generate_command() {
 		--interactive"
 	result_command="${result_command}
 		--detach-keys=\"\""
+	result_command="${result_command}
+		--user=\"${USER}\""
 
 	# For some usage, like use in service, or launched by non-terminal
 	# eg. from desktop files, TTY can fail to instantiate, and fail to enter
@@ -343,16 +345,14 @@ generate_command() {
 	# and export them to the container.
 	set +o xtrace
 	# disable logging for this snippet, or it will be too talkative.
-	ENV_LIST=""
 	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
-		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
+		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_.*_DIRS|^_)'); do
 		# We filter the environment so that we do not have strange variables,
 		# multiline or containing spaces.
 		# We also NEED to ignore the HOME variable, as this is set at create time
 		# and needs to stay that way to use custom home dirs.
 		result_command="${result_command}
 			--env \"${i}\""
-		ENV_LIST="${ENV_LIST:-}$(echo "${i}" | sed 's/=.*//'),"
 	done
 
 	# Start with the $PATH set in the container's config
@@ -435,12 +435,12 @@ generate_command() {
 
 	if [ -n "${container_command}" ]; then
 		result_command="${result_command}
-			sudo --user ${USER} --login --preserve-env='\"${ENV_LIST}\"' ${container_command}"
+			su ${USER} -c '${container_command}'"
 	else
 		# if no command was specified, let's execute a command that will find
 		# and run the default shell for the user
 		result_command="${result_command}
-			sudo --user ${USER} --login --preserve-env='\"${ENV_LIST}\"'"
+			su ${USER}"
 	fi
 
 	# Return generated command.
@@ -583,14 +583,6 @@ if [ "${container_status}" != "running" ]; then
 				break
 			fi
 		done
-		# create a long running pam_systemd session and assign seat0 to it.
-		# this is necessary for subsequent sessions to be assigned a new
-		# session id and for everything to work across multiple login sessions
-		${container_manager} exec \
-			--env "XDG_SEAT=${XDG_SEAT:-seat0}" \
-			--env "XDG_VTNR=${XDG_VTNR:-7}" \
-			"${container_name}" \
-			sudo --user "${USER}" --login sh -c 'sleep 10000d &'
 	fi
 fi
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -305,7 +305,7 @@ generate_command() {
 	result_command="${result_command}
 		--detach-keys=\"\""
 	result_command="${result_command}
-		--user=\"${USER}\""
+		--user='root'"
 
 	# For some usage, like use in service, or launched by non-terminal
 	# eg. from desktop files, TTY can fail to instantiate, and fail to enter

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -562,8 +562,25 @@ if [ "${container_status}" != "running" ]; then
 	# cleanup fifo
 	rm -f "${HOME}/.cache/.${container_name}.fifo"
 	printf >&2 "\nContainer Setup Complete!\n"
-	printf >&2 "\nWaiting for init!\n"
-	sleep 1
+	# check if container was created with init/systemd, so we can
+	# wait until the system has been booted up before entering
+	if ${container_manager} inspect "${container_name}" --format "{{.Args}}" | grep -q 'init 1' && ${container_manager} exec "${container_name}" sh -c 'command -v systemctl' > /dev/null 2>&1; then
+		printf >&2 "Waiting for systemd startup...\n"
+		WAIT_COUNTER=0
+		while true; do
+			if ${container_manager} exec "${container_name}" systemctl is-system-running | grep -vq offline > /dev/null 2>&1; then
+				printf >&2 "Systemd Startup Complete!\n"
+				break
+			fi
+			sleep 0.1
+			WAIT_COUNTER=$((WAIT_COUNTER + 1))
+			# do not wait more than 10s
+			if [ "${WAIT_COUNTER}" -gt 100 ]; then
+				printf >&2 "Timeout waiting for systemd startup.\n"
+				break
+			fi
+		done
+	fi
 fi
 
 # Generate the exec command and run it

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -344,7 +344,7 @@ generate_command() {
 	set +o xtrace
 	# disable logging for this snippet, or it will be too talkative.
 	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
-		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_.*_DIRS|^_)'); do
+		grep -Ev '^(HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
 		# We filter the environment so that we do not have strange variables,
 		# multiline or containing spaces.
 		# We also NEED to ignore the HOME variable, as this is set at create time
@@ -568,7 +568,7 @@ if [ "${container_status}" != "running" ]; then
 		printf >&2 "Waiting for systemd startup...\n"
 		WAIT_COUNTER=0
 		while true; do
-			if ${container_manager} exec "${container_name}" systemctl is-system-running | grep -vq offline > /dev/null 2>&1; then
+			if ${container_manager} exec "${container_name}" systemctl is-system-running 2>&1 | grep -qE 'running|degraded'; then
 				printf >&2 "Systemd Startup Complete!\n"
 				break
 			fi
@@ -580,6 +580,14 @@ if [ "${container_status}" != "running" ]; then
 				break
 			fi
 		done
+		# create a long running pam_systemd session and assign seat0 to it.
+		# this is necessary for subsequent sessions to be assigned a new
+		# session id and for everything to work across multiple login sessions
+		${container_manager} exec \
+			--env "XDG_SEAT=${XDG_SEAT:-seat0}" \
+			--env "XDG_VTNR=${XDG_VTNR:-7}" \
+			"${container_name}" \
+			sudo --user "${USER}" --login sh -c 'sleep 10000d &'
 	fi
 fi
 

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -304,8 +304,6 @@ generate_command() {
 		--interactive"
 	result_command="${result_command}
 		--detach-keys=\"\""
-	result_command="${result_command}
-		--user=\"${USER}\""
 
 	# For some usage, like use in service, or launched by non-terminal
 	# eg. from desktop files, TTY can fail to instantiate, and fail to enter
@@ -440,7 +438,7 @@ generate_command() {
 		# if no command was specified, let's execute a command that will find
 		# and run the default shell for the user
 		result_command="${result_command}
-			sh -c \"\\\$(getent passwd ${USER} | cut -f 7 -d :) -l"\"
+			sudo --user ${USER} --login"
 	fi
 
 	# Return generated command.
@@ -564,6 +562,8 @@ if [ "${container_status}" != "running" ]; then
 	# cleanup fifo
 	rm -f "${HOME}/.cache/.${container_name}.fifo"
 	printf >&2 "\nContainer Setup Complete!\n"
+	printf >&2 "\nWaiting for init!\n"
+	sleep 1
 fi
 
 # Generate the exec command and run it


### PR DESCRIPTION
This PR fixes issue #1060, with Firefox and other complex programs segfaulting due to the following issues:

1. Entering distrobox prior to systemd completing bootup and user integrations.
2.  [pam_systemd](https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html) not creating new user session when opening default shell or running program as argument to distrobox-enter.

**Test results for hosts**
1. LMDE 6:
- Debian 12 container with init: ✅
- Debian 12 container without init: ✅
2. Fedora 39 Silverblue:
- Debian 12 container with init: ✅
- Debian 12 container without init: ✅
- Fedora 39 container with init: ✅
- Fedora 39 container without init: ✅
- OpenSuse tumbleweed container with init: ❌ 
- Arch Linux container with init: ❌

**Remarks**
1. OpenSuse tumbleweed: init support remains partially broken as `systemd-logind.service` initializes `seat0` but does not initialize a new session when using `su <user>` to login. Using `sudo --user <user> --login` does create a new session and fixes the issue. Cannot use `su` or `sudo` login shell by default as it erases existing environment variables making them not suitable for distrobox purposes.
2. Arch Linux: init support remains permanently broken as `systemd-logind.service` initializes `seat0` but does not initialize a new session when using `su` or `sudo` to login.

Overall, no side effects to existing or new container workflows.