### PR TITLE
Fix inability to enter Gentoo container after adding --ask to EMERGE_DEFAULT_OPTS

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -735,7 +735,7 @@ if [ "${upgrade}" -ne 0 ] ||
 		"
 		install_pkg=""
 		for dep in ${deps}; do
-			if [ "$(emerge --search "${dep}" | grep "Applications found" | grep -Eo "[0-9]")" -gt 0 ]; then
+			if [ "$(emerge --ask=n --search "${dep}" | grep "Applications found" | grep -Eo "[0-9]")" -gt 0 ]; then
 				# shellcheck disable=SC2086
 				install_pkg="${install_pkg} ${dep}"
 			fi


### PR DESCRIPTION
This PR fixes the error during the initialization of a Gentoo container. 
If user adds an `--ask` option to the `EMERGE_DEFAULT_OPTS` then they can not enter the Gentoo container anymore:
```
>>> Jobs: 0 of 0 complete                           Load avg: 0.04, 0.10, 0.12

+ deps='
                        zsh
                        app-crypt/gnupg
                        bash-completion
                        diffutils
                        findutils
                        less
                        ncurses
                        net-misc/curl
                        app-crypt/pinentry
                        procps
                        shadow
                        sudo
                        sys-devel/bc
                        sys-process/lsof
                        util-linux
                        wget
                '
+ install_pkg=
+ for dep in ${deps}
++ emerge --search zsh
++ grep -Eo '[0-9]'
++ grep 'Applications found'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search app-crypt/gnupg
++ grep -Eo '[0-9]'
++ grep 'Applications found'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search bash-completion
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search diffutils
++ grep -Eo '[0-9]'
++ grep 'Applications found'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search findutils
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search less
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search ncurses
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search net-misc/curl
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search app-crypt/pinentry
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search procps
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search shadow
++ grep -Eo '[0-9]'
++ grep 'Applications found'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search sudo
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search sys-devel/bc
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search sys-process/lsof
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search util-linux
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ for dep in ${deps}
++ emerge --search wget
++ grep 'Applications found'
++ grep -Eo '[0-9]'
!!! "--ask" should only be used in a terminal. Exiting.
+ '[' '' -gt 0 ']'
/usr/bin/entrypoint: line 738: [: : integer expression expected
+ emerge --ask=n --autounmask-continue --noreplace --quiet-build
emerge: command-line interface to the Portage system
Usage:
   emerge [ options ] [ action ] [ ebuild | tbz2 | file | @set | atom ] [ ... ]
   emerge [ options ] [ action ] < @system | @world >
   emerge < --sync | --metadata | --info >
   emerge --resume [ --pretend | --ask | --skipfirst ]
   emerge --help
Options: -[abBcCdDefgGhjkKlnNoOpPqrsStuUvVwW]
          [ --color < y | n >            ] [ --columns    ]
          [ --complete-graph             ] [ --deep       ]
          [ --jobs JOBS ] [ --keep-going ] [ --load-average LOAD            ]
          [ --newrepo   ] [ --newuse     ] [ --noconfmem  ] [ --nospinner   ]
          [ --oneshot   ] [ --onlydeps   ] [ --quiet-build [ y | n ]        ]
          [ --reinstall changed-use      ] [ --with-bdeps < y | n >         ]
Actions:  [ --depclean | --list-sets | --search | --sync | --version        ]

   For more help consult the man page.
Error: An error occurred
+ '[' 1 -ne 0 ']'
+ printf 'Error: An error occurred\n'
```