### PR TITLE
NixOS: Allow package maintainers to ship a static config file

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -74,6 +74,7 @@ unshare_ipc=0
 unshare_netns=0
 unshare_process=0
 unshare_devsys=0
+
 # Use cd + dirname + pwd so that we do not have relative paths in mount points
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
@@ -97,7 +98,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -78,7 +78,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -48,7 +48,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-list
+++ b/distrobox-list
@@ -47,7 +47,14 @@ container_manager="autodetect"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -57,7 +57,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -55,7 +55,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf

--- a/distrobox-upgrade
+++ b/distrobox-upgrade
@@ -42,7 +42,14 @@ version="1.6.0.1"
 # Source configuration files, this is done in an hierarchy so local files have
 # priority over system defaults
 # leave priority to environment variables.
+#
+# On NixOS, for the distrobox derivation to pick up a static config file shipped
+# by the package maintainer the path must be relative to the script itself.
+self_dir="$(dirname "$(realpath "$0")")"
+nix_config_file="$(realpath "${self_dir}/../share/distrobox/distrobox.conf")"
+
 config_files="
+	$nix_config_file
 	/usr/share/distrobox/distrobox.conf
 	/usr/share/defaults/distrobox/distrobox.conf
 	/usr/etc/distrobox/distrobox.conf


### PR DESCRIPTION
On NixOS, in order for the package maintainers to ship a default config file (as suggested [here](https://github.com/89luca89/distrobox/issues/978#issuecomment-1724077978)), the list of config files needs to be adjusted. 

None of the current config file paths are available from the derivation.
This PR essentially adds a config file path relative to the currrent script.

Ref: https://github.com/NixOS/nixpkgs/pull/268800
