### PR TITLE
FIX: Split multiple apps and bins by space

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -370,15 +370,27 @@ run_distrobox() (
 		"${distrobox_path}"/distrobox enter "${name}" -- touch /dev/null
 
 		IFS="¤"
-		for app in ${exported_apps}; do
-			app="$(echo "${app}" | tr -d '[:space:]')"
-			"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --app "${app}"
+		for apps in ${exported_apps}; do
+			# Split the string by spaces
+			IFS=" "
+			for app in ${apps}; do
+				# Remove spaces
+				app="$(echo "${app}" | tr -d '[:space:]')"
+				# Export the app
+				"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --app "${app}"
+			done
 		done
 
 		IFS="¤"
-		for bin in ${exported_bins}; do
-			bin="$(echo "${bin}" | tr -d '[:space:]')"
-			"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --bin "${bin}" --export-path "${exported_bins_path}"
+		for bins in ${exported_bins}; do
+			# Split the string by spaces
+			IFS=" "
+			for bin in ${bins}; do
+				# Remove spaces
+				bin="$(echo "${bin}" | tr -d '[:space:]')"
+				# Export the bin
+				"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --bin "${bin}" --export-path "${exported_bins_path}"
+			done
 		done
 	fi
 )

--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -374,8 +374,6 @@ run_distrobox() (
 			# Split the string by spaces
 			IFS=" "
 			for app in ${apps}; do
-				# Remove spaces
-				app="$(echo "${app}" | tr -d '[:space:]')"
 				# Export the app
 				"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --app "${app}"
 			done
@@ -386,8 +384,6 @@ run_distrobox() (
 			# Split the string by spaces
 			IFS=" "
 			for bin in ${bins}; do
-				# Remove spaces
-				bin="$(echo "${bin}" | tr -d '[:space:]')"
 				# Export the bin
 				"${distrobox_path}"/distrobox enter "${name}" -- distrobox-export --bin "${bin}" --export-path "${exported_bins_path}"
 			done


### PR DESCRIPTION
## Description

> See #1083

Based on the docs, it should be possible to provide a list to `exported_bins`. This PR addresses this issue and extends the functionality also to the `exported_apps`.

**Note:** This is my first PR to this project. Please don't hesitate to test and modify it to your standards.

## Testing

By this fix, I was able to run the example shown in the referred issue.