### PR TITLE
Fix: xargs was breaking mid find search due to files with quotes on filename

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -348,10 +348,10 @@ export_application() {
 	# by its launcher name.
 	desktop_files=$(
 		# shellcheck disable=SC2086,SC2038
-		find ${canon_dirs} -type f -printf "%p\n" -o -type l -printf '"%p"\n' |
-			xargs -I{} grep -le "Exec=.*${exported_app}.*" -le "Name=.*${exported_app}.*" "{}" |
-			xargs -I{} grep -Le "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox-enter"}.*" "{}" |
-			xargs -I{} printf "%s@" {}
+		find ${canon_dirs} -type f -printf "\"%p\" \n" -o -type l -printf "\"%p\" \n"|
+			xargs grep -le "Exec=.*${exported_app}.*" -le "Name=.*${exported_app}.*" "{}" |
+			xargs grep -Le "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox-enter"}.*" "{}" |
+			xargs printf "%s@" {}
 	)
 
 	# Ensure the app we're exporting is installed


### PR DESCRIPTION
**Issue**: https://github.com/89luca89/distrobox/issues/1097

**What it does:**
Now any file name searched by `find`, with scape characters `'` or `"` will print it's full name and passed down to `xargs`. 