### PR TITLE
export & rm: correctly handle paths containing whitespace and quotes

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -389,11 +389,11 @@ export_application() {
 	# it is possible to export an app not only by its executable name but also
 	# by its launcher name.
 	desktop_files=$(
-		# shellcheck disable=SC2086,SC2038
-		find ${canon_dirs} -type f -printf "%p\n" -o -type l -printf '"%p"\n' |
-			xargs -I{} grep -le "Exec=.*${exported_app}.*" -le "Name=.*${exported_app}.*" "{}" |
-			xargs -I{} grep -Le "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox-enter"}.*" "{}" |
-			xargs -I{} printf "%s@" {}
+		# shellcheck disable=SC2086
+		find ${canon_dirs} -type f -print -o -type l -print | sed 's/./\\&/g' |
+			xargs -I{} grep -l -e "Exec=.*${exported_app}.*" -e "Name=.*${exported_app}.*" "{}" | sed 's/./\\&/g' |
+			xargs -I{} grep -L -e "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox-enter"}.*" "{}" | sed 's/./\\&/g' |
+			xargs -I{} printf "%s@" "{}"
 	)
 
 	# Ensure the app we're exporting is installed

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -315,9 +315,9 @@ delete_container() {
 
 	IFS='@'
 	# Remove exported binaries from this container in default path
-	binary_files="$(grep -rl "# distrobox_binary" "${HOME}/.local/bin" 2> /dev/null |
-		xargs -I{} grep -le "# name: ${container_name}$" "{}" |
-		xargs -I{} printf "%s@" {} 2> /dev/null || :)"
+	binary_files="$(grep -rl "# distrobox_binary" "${HOME}/.local/bin" 2> /dev/null | sed 's/./\\&/g' |
+		xargs -I{} grep -le "# name: ${container_name}$" "{}" | sed 's/./\\&/g' |
+		xargs -I{} printf "%s@" "{}" 2> /dev/null || :)"
 	for file in ${binary_files}; do
 		printf "Removing exported binary %s...\n" "${file}"
 		rm -f "${file}"
@@ -325,9 +325,9 @@ delete_container() {
 
 	# Remove exported gui apps from this container in default path
 	# shellcheck disable=SC2086,SC2038
-	desktop_files="$(find "${HOME}/.local/share/applications/${container_name}"* -type f -o -type l 2> /dev/null |
-		xargs -I{} grep -le "Exec=.*${container_name} " "{}" |
-		xargs -I{} printf "%s@" {} 2> /dev/null || :)"
+	desktop_files="$(find "${HOME}/.local/share/applications/${container_name}"* -type f -o -type l 2> /dev/null | sed 's/./\\&/g' |
+		xargs -I{} grep -le "Exec=.*${container_name} " "{}" | sed 's/./\\&/g' |
+		xargs -I{} printf "%s@" "{}" 2> /dev/null || :)"
 	for file in ${desktop_files}; do
 		if [ -e "${file}" ]; then
 			app="$(grep -Eo "Name=.*" "${file}" | head -n 1 | cut -d' ' -f1 | cut -d'=' -f2)"


### PR DESCRIPTION
~~In order to reliably handle paths with whitespace, quotes, or nonprintable characters, `find`, `xargs`, and `grep` should be configured to separate them using the NUL character rather than using newlines or ad-hoc escaping. (This is documented in the shellcheck linting rule SC2038, which documents a real issue and should not be disabled.)~~

Update:

In order to reliably process paths with whitespace or quotes to xargs without using non-POSIX features, each character must be escaped. (Quoting will handle whitespace, but not filenames with quotes in them.)