### PR TITLE
Add workaround for large groups

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -783,7 +783,7 @@ generate_command() {
 		# Use keep-id only if going rootless.
 		if [ "${rootful}" -eq 0 ]; then
 			result_command="${result_command}
-				--userns keep-id"
+				--userns=keep-id:uid=$(id -u),gid=$(id -g)"
 		fi
 	fi
 


### PR DESCRIPTION
This PR adds a work around for large groups. Currently if groups exceed a certain size in go, the system gives up https://github.com/golang/go/blob/a2a2c5b947263ee9328674d229892841197a0a94/src/os/user/cgo_lookup_unix.go#L181 searching. When podman look up uids and gids it means that exceeding a threshold will trigger an error.

>> Error: unable to start container "980124...": creating temporary passwd file for container 980124...: failed to get current group: user: lookup groupid group_id: internal buffer exceeds 1048576 bytes


This PR works around the issue by providing uid and gid of the user that should be retained.