### PR TITLE
fix: binary exports should handle arguments containing spaces

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -248,7 +248,7 @@ generate_script() {
 # name: ${container_name}
 if [ -z "\${CONTAINER_ID}" ]; then
 	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} -- \
-		${start_shell} '${exported_bin} ${extra_flags} \$@' -- "\$@"
+		${start_shell} '${exported_bin} ${extra_flags} "\$@"' -- "\$@"
 elif [ -n "\${CONTAINER_ID}" ] && [ "\${CONTAINER_ID}" != "${container_name}" ]; then
 	exec distrobox-host-exec ${dest_path}/$(basename "${exported_bin}") ${extra_flags} "\$@"
 else


### PR DESCRIPTION
Without these quotes, arguments (particularly paths) containing spaces are "splatted" by the shell, turning them into multiple arguments (and causing path-not-found issues in particular).