### PR TITLE
Bump default container image to Fedora 39

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -53,7 +53,7 @@ container_clone=""
 container_generate_entry=1
 container_home_prefix=""
 container_image=""
-container_image_default="registry.fedoraproject.org/fedora-toolbox:38"
+container_image_default="registry.fedoraproject.org/fedora-toolbox:39"
 container_init_hook=""
 container_manager="autodetect"
 container_manager_additional_flags=""
@@ -146,12 +146,12 @@ distrobox version: ${version}
 Usage:
 
 	distrobox create --image alpine:latest --name test --init-hooks "touch /var/tmp/test1 && touch /var/tmp/test2"
-	distrobox create --image fedora:38 --name test --additional-flags "--env MY_VAR-value"
-	distrobox create --image fedora:38 --name test --volume /opt/my-dir:/usr/local/my-dir:rw --additional-flags "--pids-limit -1"
+	distrobox create --image fedora:39 --name test --additional-flags "--env MY_VAR-value"
+	distrobox create --image fedora:39 --name test --volume /opt/my-dir:/usr/local/my-dir:rw --additional-flags "--pids-limit -1"
 	distrobox create -i docker.io/almalinux/8-init --init --name test --pre-init-hooks "dnf config-manager --enable powertools && dnf -y install epel-release"
-	distrobox create --clone fedora-38 --name fedora-38-copy
+	distrobox create --clone fedora-39 --name fedora-39-copy
 	distrobox create --image alpine my-alpine-container
-	distrobox create --image registry.fedoraproject.org/fedora-toolbox:38 --name fedora-toolbox-38
+	distrobox create --image registry.fedoraproject.org/fedora-toolbox:39 --name fedora-toolbox-39
 	distrobox create --pull --image centos:stream9 --home ~/distrobox/centos9
 	distrobox create --image alpine:latest --name test2 --additional-packages "git tmux vim"
 	distrobox create --image ubuntu:22.04 --name ubuntu-nvidia --nvidia
@@ -420,7 +420,7 @@ fi
 # Examples:
 #	alpine -> alpine
 #	ubuntu:20.04 -> ubuntu-20.04
-#	registry.fedoraproject.org/fedora-toolbox:38 -> fedora-toolbox-38
+#	registry.fedoraproject.org/fedora-toolbox:39 -> fedora-toolbox-39
 #	ghcr.io/void-linux/void-linux:latest-full-x86_64 -> void-linux-latest-full-x86_64
 if [ -z "${container_name}" ]; then
 	container_name="$(basename "${container_image}" | sed -E 's/[:.]/-/g')"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -54,7 +54,7 @@ fi
 
 # Defaults
 container_command=""
-container_image_default="registry.fedoraproject.org/fedora-toolbox:38"
+container_image_default="registry.fedoraproject.org/fedora-toolbox:39"
 container_manager="autodetect"
 container_manager_additional_flags=""
 container_name=""
@@ -122,7 +122,7 @@ distrobox version: ${version}
 
 Usage:
 
-	distrobox-enter --name fedora-38 -- bash -l
+	distrobox-enter --name fedora-39 -- bash -l
 	distrobox-enter my-alpine-container -- sh -l
 	distrobox-enter --additional-flags "--preserve-fds" --name test -- bash -l
 	distrobox-enter --additional-flags "--env MY_VAR=value" --name test -- bash -l

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -195,7 +195,7 @@ If you want to use a non-pre-create image, you'll need to add the additional pac
 	distrobox create -i ubuntu:22.04 --init --additional-packages "systemd libpam-systemd" -n test
 	distrobox create -i archlinux:latest --init --additional-packages "systemd" -n test
 	distrobox create -i registry.opensuse.org/opensuse/tumbleweed:latest --init --additional-packages "systemd" -n test
-	distrobox create -i registry.fedoraproject.org/fedora:38 --init --additional-packages "systemd" -n test
+	distrobox create -i registry.fedoraproject.org/fedora:39 --init --additional-packages "systemd" -n test
 
 The `--init` flag is useful to create system containers, where the container acts
 more similar to a full VM than an application-container.

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -255,7 +255,7 @@ distrobox create -i debian:stable --init --additional-packages "systemd libpam-s
 distrobox create -i ubuntu:22.04 --init --additional-packages "systemd libpam-systemd" -n test
 distrobox create -i archlinux:latest --init --additional-packages "systemd" -n test
 distrobox create -i registry.opensuse.org/opensuse/tumbleweed:latest --init --additional-packages "systemd" -n test
-distrobox create -i registry.fedoraproject.org/fedora:38 --init --additional-packages "systemd" -n test
+distrobox create -i registry.fedoraproject.org/fedora:39 --init --additional-packages "systemd" -n test
 ```
 
 Note however that in this mode, you'll not be able to access host's processes

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -329,7 +329,7 @@ distrobox create -i debian:stable --init --additional-packages \[dq]systemd libp
 distrobox create -i ubuntu:22.04 --init --additional-packages \[dq]systemd libpam-systemd\[dq] -n test
 distrobox create -i archlinux:latest --init --additional-packages \[dq]systemd\[dq] -n test
 distrobox create -i registry.opensuse.org/opensuse/tumbleweed:latest --init --additional-packages \[dq]systemd\[dq] -n test
-distrobox create -i registry.fedoraproject.org/fedora:38 --init --additional-packages \[dq]systemd\[dq] -n test
+distrobox create -i registry.fedoraproject.org/fedora:39 --init --additional-packages \[dq]systemd\[dq] -n test
 \f[R]
 .fi
 .PP

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -1122,7 +1122,7 @@ distrobox create -i debian:stable --init --additional-packages \[dq]systemd libp
 distrobox create -i ubuntu:22.04 --init --additional-packages \[dq]systemd libpam-systemd\[dq] -n test
 distrobox create -i archlinux:latest --init --additional-packages \[dq]systemd\[dq] -n test
 distrobox create -i registry.opensuse.org/opensuse/tumbleweed:latest --init --additional-packages \[dq]systemd\[dq] -n test
-distrobox create -i registry.fedoraproject.org/fedora:38 --init --additional-packages \[dq]systemd\[dq] -n test
+distrobox create -i registry.fedoraproject.org/fedora:39 --init --additional-packages \[dq]systemd\[dq] -n test
 \f[R]
 .fi
 .PP


### PR DESCRIPTION
Best-effort, search-and-replace. Checked manually using:

    % rg -iC1 'fedora.*38'

Fedora 39 was released 2023-11-07 (about 2 months ago)

imho, 2 months is enough of a grace period.

Thoughts?

- Fixes 89luca89/distrobox#1119