### PR TITLE
fix(assemble): Use read instead of cat

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -411,10 +411,7 @@ parse_file() (
 	file="${1}"
 	name=""
 
-	IFS='
-	'
-	# shellcheck disable=SC2013
-	for line in $(cat "${file}"); do
+	while IFS="" read -r line || [ -n "$line" ]; do
 		if [ -z "${line}" ]; then
 			# blank line, skip
 			continue
@@ -461,7 +458,7 @@ parse_file() (
 			fi
 			echo "${key}=${value}" >> "${tmpfile}"
 		fi
-	done
+	done < "${file}"
 	#	# Execute now one last time for the last block
 	run_distrobox "${name}"
 )


### PR DESCRIPTION
Hey there,

not sure if this was intentional, but I would prefer to use `read` instead of `cat` since `cat` tends to break stuff from time to time (escaping)