### PR TITLE
Add --enter-flags to distrobox-export

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -242,10 +242,10 @@ if [ -n "${enter_flags}" ]; then
 	# Inform user that certain flags are redundant
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			--root|-r)
+			--root | -r)
 				printf >&2 "Warning: %s argument will be set automatically and should be removed.\n" "${1}"
 				;;
-			--name|-n)
+			--name | -n)
 				printf >&2 "Warning: %s argument will be set automatically and should be removed.\n" "${1}"
 				shift
 				;;

--- a/distrobox-export
+++ b/distrobox-export
@@ -32,6 +32,7 @@ exported_app_label=""
 exported_bin=""
 exported_delete=0
 extra_flags=""
+enter_flags=""
 # Use DBX_HOST_HOME if defined, else fallback to HOME
 #	DBX_HOST_HOME is set in case container is created
 #	with custom --home directory
@@ -63,8 +64,8 @@ distrobox version: ${version}
 
 Usage:
 
-	distrobox-export --app mpv [--extra-flags "flags"] [--delete] [--sudo]
-	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--delete] [--sudo]
+	distrobox-export --app mpv [--extra-flags "flags"] [--enter-flags "flags"] [--delete] [--sudo]
+	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--enter-flags "flags"] [--delete] [--sudo]
 
 Options:
 
@@ -76,6 +77,7 @@ Options:
 				Defaults to (on \$container_name)
 	--export-path/-ep:	path where to export the binary
 	--extra-flags/-ef:	extra flags to add to the command
+	--enter-flags/-nf:	flags to add to distrobox-enter
 	--sudo/-S:		specify if the exported item should be run as sudo
 	--help/-h:		show this message
 	--verbose/-v:		show more verbosity
@@ -136,6 +138,13 @@ while :; do
 		-ef | --extra-flags)
 			if [ -n "$2" ]; then
 				extra_flags="$2"
+				shift
+				shift
+			fi
+			;;
+		-nf | --enter-flags)
+			if [ -n "$2" ]; then
+				enter_flags="$2"
 				shift
 				shift
 			fi
@@ -225,8 +234,32 @@ if  [ "${is_sudo}" -ne 0 ]; then
 	fi
 fi
 
+# Filter enter_flags and remove redundant options
+if [ -n "${enter_flags}" ]; then
+	# shellcheck disable=SC2086
+	set -- ${enter_flags}
+	filtered_flags=""
+	# Inform user that certain flags are redundant
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root|-r)
+				printf >&2 "Warning: %s argument will be set automatically and should be removed.\n" "${1}"
+				;;
+			--name|-n)
+				printf >&2 "Warning: %s argument will be set automatically and should be removed.\n" "${1}"
+				shift
+				;;
+			*)
+				filtered_flags="${filtered_flags} $1"
+				;;
+		esac
+		shift
+	done
+	enter_flags="${filtered_flags}"
+fi
+
 # Prefix to add to an existing command to work through the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} -- ${start_shell} "
+container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} ${enter_flags} -- ${start_shell} "
 if [ -z "${exported_app_label}" ]; then
 	exported_app_label=" (on ${container_name})"
 elif [ "${exported_app_label}" = "none" ]; then
@@ -247,7 +280,7 @@ generate_script() {
 # distrobox_binary
 # name: ${container_name}
 if [ -z "\${CONTAINER_ID}" ]; then
-	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} -- \
+	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} ${enter_flags} -- \
 		${start_shell} '${exported_bin} ${extra_flags} \$@' -- "\$@"
 elif [ -n "\${CONTAINER_ID}" ] && [ "\${CONTAINER_ID}" != "${container_name}" ]; then
 	exec distrobox-host-exec ${dest_path}/$(basename "${exported_bin}") ${extra_flags} "\$@"


### PR DESCRIPTION
This PR allows the user to specify additional flags for `distrobox-enter` as described [here](https://github.com/89luca89/distrobox/blob/main/docs/usage/distrobox-enter.md) when using `distrobox-export`.

For example, I had the use case that I wanted the container not to run in the current working directory as this was a symlink from my root partition and thus not available inside the container. This would result in an error when starting the container.
Appending `--no-workdir` to the exported command was the solution. 