### PR TITLE
Capture full container command when exporting app

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -451,7 +451,7 @@ export_application() {
 		# Add closing quote
 		# If a TryExec is present, we have to fake it as it will not work
 		# through the container separation
-		sed "s|^Exec=|Exec=${container_command_prefix} |g" "${desktop_file}" |
+		sed "s|^Exec=\(.*\)|Exec=${container_command_prefix} '\1' |g" "${desktop_file}" |
 			sed "s|\(%.*\)|${extra_flags} \1|g" |
 			sed "/^TryExec=.*/d" |
 			sed "/^DBusActivatable=true/d" |


### PR DESCRIPTION
When exporting RStudio from a Fedora container, the resulting .desktop file contains the line
```
Exec=/usr/bin/distrobox-enter  -n rstudio -- /bin/sh -l -c  env RSTUDIO_DISABLE_CHECK_FOR_UPDATES=1 rstudio  %F 
```

Executing the file results in only `env` being executed. The command should be wrapped in quotes like
```
Exec=/usr/bin/distrobox-enter  -n rstudio -- /bin/sh -l -c  'env RSTUDIO_DISABLE_CHECK_FOR_UPDATES=1 rstudio  %F' 
```

This PR fixes that.