### PR TITLE
docs: fix init-hook script for hostname matching

### DIFF
--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -222,7 +222,7 @@ creating it with the following init-hook:
 
 ```sh
 distrobox create --name test --image your-chosen-image:tag \
-                  --init-hooks '"$(uname -n)" > /etc/hostname'`
+                  --init-hooks 'echo "$(uname -n)" > /etc/hostname'
 ```
 
 This will ensure SSH X-Forwarding will work when SSH-ing inside the distrobox:


### PR DESCRIPTION
The init-hook provided in the [useful tips documentations](https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md) for creating a distrobox with the the same hostname as its host has two typos:

- Command substitution wrapping `uname -n` suppressing stdout redirect
- trailing "`"

Using this init-hook as suggested causes build errors (see #1164). This fix corrects the suggested script by removing the command substitution and the trailing "`".

To elaborate: I think command substitution here is misplaced since `uname -n` already prints to stdout and can be redirected directly. Or you can use `echo` on the provided command substitution. Or you can use the `hostname` command. I.e.

`uname -n > /etc/hostname`
`echo "$(uname -n)" > /etc/hostname`
`hostname "$(uname -n)"`


Tested on Fedora 39 below:

```
# Also tested the 'echo "$(uname -n)" > /etc/hostname' with the same result

user@hostname $ distrobox create --image ghcr.io/username/sample-image:latest -n box-name \ 
    --init-hooks 'uname -n > /etc/hostname' && distrobox enter box-name

...

Setting up groups...                    	 [ OK ]
Setting up users...                     	 [ OK ]
Setting up skel...                      	 [ OK ]
Executing init hooks...                 	 [ OK ]

Container Setup Complete!

user@box-name.hostname $ cat /etc/hostname 
box-name.hostname

user@box-name.hostname $ hostname
box-name.hostname  
```