### PR TITLE
Fish fixes

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1748,7 +1748,7 @@ EOF
 
 # It's also importanto to keep this working on fish shells
 if [ -e "/etc/fish/config.fish" ]; then
-	cat << EOF >> /etc/fish/conf.d/config.fish
+	cat << EOF > /etc/fish/conf.d/distrobox_config.fish
 test -z "\$USER" && set -Ux USER "\$(id -un 2> /dev/null)"
 test -z "\$UID"  && set -Ux UID "\$(id -ur 2> /dev/null)"
 test -z "\$EUID" && set -Ux EUID "\$(id -u  2> /dev/null)"

--- a/distrobox-init
+++ b/distrobox-init
@@ -1749,11 +1749,11 @@ EOF
 # It's also importanto to keep this working on fish shells
 if [ -e "/etc/fish/config.fish" ]; then
 	cat << EOF > /etc/fish/conf.d/distrobox_config.fish
-test -z "\$USER" && set -Ux USER "\$(id -un 2> /dev/null)"
-test -z "\$UID"  && set -Ux UID "\$(id -ur 2> /dev/null)"
-test -z "\$EUID" && set -Ux EUID "\$(id -u  2> /dev/null)"
-test -z "\$MARONNE" && set -Ux MARONNE "\$(id -u  2> /dev/null)"
-set -Ux SHELL "\$(getent passwd "\$USER" | cut -f 7 -d :)"
+test -z "\$USER" && set -gx USER "\$(id -un 2> /dev/null)"
+test -z "\$UID"  && set -gx UID "\$(id -ur 2> /dev/null)"
+test -z "\$EUID" && set -gx EUID "\$(id -u  2> /dev/null)"
+test -z "\$MARONNE" && set -gx MARONNE "\$(id -u  2> /dev/null)"
+set -gx SHELL "\$(getent passwd "\$USER" | cut -f 7 -d :)"
 
 # This will ensure we have a first-shell password setup for an user if needed.
 # We're going to use this later in case of rootful containers

--- a/distrobox-init
+++ b/distrobox-init
@@ -1749,10 +1749,10 @@ EOF
 # It's also importanto to keep this working on fish shells
 if [ -e "/etc/fish/config.fish" ]; then
 	cat << EOF > /etc/fish/conf.d/distrobox_config.fish
-test -z "\$USER" && set -gx USER "\$(id -un 2> /dev/null)"
-test -z "\$UID"  && set -gx UID "\$(id -ur 2> /dev/null)"
-test -z "\$EUID" && set -gx EUID "\$(id -u  2> /dev/null)"
-set -gx SHELL "\$(getent passwd "\$USER" | cut -f 7 -d :)"
+test -z "\$USER" && set -gx USER (id -un 2> /dev/null)
+test -z "\$UID"  && set -gx UID (id -ur 2> /dev/null)
+test -z "\$EUID" && set -gx EUID (id -u  2> /dev/null)
+set -gx SHELL (getent passwd "\$USER" | cut -f 7 -d :)
 
 # This will ensure we have a first-shell password setup for an user if needed.
 # We're going to use this later in case of rootful containers

--- a/distrobox-init
+++ b/distrobox-init
@@ -1752,7 +1752,6 @@ if [ -e "/etc/fish/config.fish" ]; then
 test -z "\$USER" && set -gx USER "\$(id -un 2> /dev/null)"
 test -z "\$UID"  && set -gx UID "\$(id -ur 2> /dev/null)"
 test -z "\$EUID" && set -gx EUID "\$(id -u  2> /dev/null)"
-test -z "\$MARONNE" && set -gx MARONNE "\$(id -u  2> /dev/null)"
 set -gx SHELL "\$(getent passwd "\$USER" | cut -f 7 -d :)"
 
 # This will ensure we have a first-shell password setup for an user if needed.


### PR DESCRIPTION
Doing a git-diff of my `~/.config/fish/` (on the host) , I found some mysterious additions to fish_variables (`SHELL`, `UID`, `MARONNE`). Thanks to the unique string "MARONNE", I was able to track down the culprit: an `/etc/fish/conf.d/config.fish` written (seven times) by distrobox-init.

"MARONNE" seems most likely to be the result of a find/replace with clipboard contents? The command that sets it is otherwise the same as the previous line.

And then I searched for "fish" in the bug tracker to see if this had been reported already, and found #1115, so I fixed that too.