### PR TITLE
Add host terminfo as a fallback

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -602,8 +602,7 @@ generate_command() {
 		--env \"SHELL=$(basename "${SHELL:-"/bin/bash"}")\"
 		--env \"HOME=${container_user_home}\"
 		--env \"container=${container_manager}\"
-		--env \"TERMINFO_DIRS=/usr/share/terminfo:/usr/share/terminfo-host\"
-		--volume /usr/share/terminfo:/usr/share/terminfo-host:ro
+		--env \"TERMINFO_DIRS=/usr/share/terminfo:/run/host/usr/share/terminfo\"
 		--volume /:/run/host:rslave
 		--volume /tmp:/tmp:rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro

--- a/distrobox-create
+++ b/distrobox-create
@@ -602,6 +602,8 @@ generate_command() {
 		--env \"SHELL=$(basename "${SHELL:-"/bin/bash"}")\"
 		--env \"HOME=${container_user_home}\"
 		--env \"container=${container_manager}\"
+		--env \"TERMINFO_DIRS=/usr/share/terminfo:/usr/share/terminfo-host\"
+		--volume /usr/share/terminfo:/usr/share/terminfo-host:ro
 		--volume /:/run/host:rslave
 		--volume /tmp:/tmp:rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro


### PR DESCRIPTION
This should allow the user to use a modern terminal without installing anything additional inside the container itself but it will still prioritize terminfo from the container