### PR TITLE
Fix --nvidia flag unreliably mounts libraries into /usr (#1128)

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1503,6 +1503,7 @@ if [ "${nvidia}" -eq 1 ]; then
 		-path "/run/host/usr/lib/x86_64-linux-gnu/*" -prune -o \
 		-path "/run/host/usr/lib32/*" -prune -o \
 		-path "/run/host/usr/lib64/*" -prune -o \
+		-path "/run/host/usr/lib/*" -prune -o \
 		-iname "*nvidia*" -not -type d -print 2> /dev/null || :)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"

--- a/distrobox-init
+++ b/distrobox-init
@@ -1478,6 +1478,17 @@ done
 if [ "${nvidia}" -eq 1 ]; then
 	printf "distrobox: Setting up host's nvidia integration...\n"
 
+
+	# Refresh ldconfig cache, also detect if there are empty files remaining
+	# and clean them.
+	# This could happen when upgrading drivers and changing versions.
+	empty_libs="$(ldconfig 2>&1 | grep -Eo "File.*is empty" | cut -d' ' -f2)"
+	if [ -n "${empty_libs}" ]; then
+		# shellcheck disable=SC2086
+                find ${empty_libs} -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
+                find /usr/ /etc/ -empty -iname "*nvidia*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
+	fi
+
 	# Find where the system expects libraries to be put
 	lib32_dir="/usr/lib/"
 	lib64_dir="/usr/lib/"
@@ -1575,15 +1586,9 @@ if [ "${nvidia}" -eq 1 ]; then
 		mount_bind "${nvidia_lib}" "${dest_file}" ro
 	done
 
-	# Refresh ldconfig cache, also detect if there are empty files remaining
-	# and clean them.
-	# This could happen when upgrading drivers and changing versions.
-	empty_libs="$(ldconfig 2>&1 | grep -Eo "File.*is empty" | cut -d' ' -f2)"
-	if [ -n "${empty_libs}" ]; then
-		# shellcheck disable=SC2086
-		find ${empty_libs} -delete 2> /dev/null || :
-		find /usr/ /etc/ -empty -iname "*nvidia*" -delete 2> /dev/null || :
-	fi
+        # Refresh ldconfig cache
+        ldconfig 2>&1 /dev/null
+
 fi
 
 ###############################################################################

--- a/distrobox-init
+++ b/distrobox-init
@@ -1478,15 +1478,14 @@ done
 if [ "${nvidia}" -eq 1 ]; then
 	printf "distrobox: Setting up host's nvidia integration...\n"
 
-
 	# Refresh ldconfig cache, also detect if there are empty files remaining
 	# and clean them.
 	# This could happen when upgrading drivers and changing versions.
 	empty_libs="$(ldconfig 2>&1 | grep -Eo "File.*is empty" | cut -d' ' -f2)"
 	if [ -n "${empty_libs}" ]; then
 		# shellcheck disable=SC2086
-                find ${empty_libs} -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
-                find /usr/ /etc/ -empty -iname "*nvidia*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
+		find ${empty_libs} -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
+		find /usr/ /etc/ -empty -iname "*nvidia*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
 	fi
 
 	# Find where the system expects libraries to be put
@@ -1586,8 +1585,8 @@ if [ "${nvidia}" -eq 1 ]; then
 		mount_bind "${nvidia_lib}" "${dest_file}" ro
 	done
 
-        # Refresh ldconfig cache
-        ldconfig 2>&1 /dev/null
+	# Refresh ldconfig cache
+	ldconfig 2>&1 /dev/null
 
 fi
 


### PR DESCRIPTION
This PR fixes a regression stemming from the [1.6.0](https://github.com/89luca89/distrobox/releases/tag/1.6.0) release, for further info refer to the #1128 issue.