### PR TITLE
Fix bash completions and init/systemd user integrations

### DIFF
--- a/completions/bash/distrobox
+++ b/completions/bash/distrobox
@@ -52,7 +52,9 @@ _generate_from_help() {
 
 __distrobox() {
 	if [ "${#COMP_WORDS[@]}" == "2" ]; then
-		COMPREPLY=($(compgen -W "$(distrobox | tail -n+4 | tr -d '|' | xargs echo)" "$(echo ${COMP_WORDS[1]} | tr -d '-')"))
+		VALID_WORDS=$(distrobox | tail -n+4 | tr -d '|' | xargs echo)
+		VALID_WORDS+=" --version --help"
+		COMPREPLY=($(compgen -W "${VALID_WORDS}" -- "${COMP_WORDS[1]}"))
 	elif [ "${#COMP_WORDS[@]}" -gt "2" ]; then
 		_generate_from_help distrobox-"${COMP_WORDS[1]}"
 	fi

--- a/completions/bash/distrobox
+++ b/completions/bash/distrobox
@@ -52,7 +52,7 @@ _generate_from_help() {
 
 __distrobox() {
 	if [ "${#COMP_WORDS[@]}" == "2" ]; then
-		COMPREPLY=($(compgen -W "$(distrobox | tail -n+4 | xargs echo)" "${COMP_WORDS[1]}"))
+		COMPREPLY=($(compgen -W "$(distrobox | tail -n+4 | tr -d '|' | xargs echo)" "$(echo ${COMP_WORDS[1]} | tr -d '-')"))
 	elif [ "${#COMP_WORDS[@]}" -gt "2" ]; then
 		_generate_from_help distrobox-"${COMP_WORDS[1]}"
 	fi

--- a/distrobox
+++ b/distrobox
@@ -44,6 +44,7 @@ Choose one of the available commands:
 	ephemeral
 	generate-entry
 	version
+	help
 EOF
 }
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -2210,6 +2210,7 @@ mkdir -p /run/user/\$(id -ru)/keyring && ln -sf /run/host/run/user/\$(id -ru)/ke
 mkdir -p /run/user/\$(id -ru)/p11-kit && ln -sf /run/host/run/user/\$(id -ru)/p11-kit/* /run/user/\$(id -ru)/p11-kit/
 mkdir -p /run/user/\$(id -ru)/pulse && ln -sf /run/host/run/user/\$(id -ru)/pulse/* /run/user/\$(id -ru)/pulse/
 find /run/user/\$(id -ru) -maxdepth 2 -xtype l -delete
+loginctl enable-linger \$(id -ru)
 EOF
 
 	chmod +x /usr/local/bin/user-integration

--- a/distrobox-init
+++ b/distrobox-init
@@ -2210,7 +2210,6 @@ mkdir -p /run/user/\$(id -ru)/keyring && ln -sf /run/host/run/user/\$(id -ru)/ke
 mkdir -p /run/user/\$(id -ru)/p11-kit && ln -sf /run/host/run/user/\$(id -ru)/p11-kit/* /run/user/\$(id -ru)/p11-kit/
 mkdir -p /run/user/\$(id -ru)/pulse && ln -sf /run/host/run/user/\$(id -ru)/pulse/* /run/user/\$(id -ru)/pulse/
 find /run/user/\$(id -ru) -maxdepth 2 -xtype l -delete
-loginctl enable-linger \$(id -ru)
 EOF
 
 	chmod +x /usr/local/bin/user-integration
@@ -2241,6 +2240,7 @@ if [ -e /usr/lib/systemd/systemd ] || [ -e /lib/systemd/systemd ]; then
 	done && \
 	systemctl start user@${container_user_name}.service && \
 	systemctl start user-integration@${container_user_name}.service && \
+	loginctl enable-linger ${container_user_name} && \
 	echo container_setup_done" &
 
 	[ -e /usr/lib/systemd/systemd ] && exec /usr/lib/systemd/systemd --system --log-target=console --unit=multi-user.target

--- a/distrobox-init
+++ b/distrobox-init
@@ -2200,7 +2200,7 @@ if [ -e /usr/lib/systemd/system/user@.service ]; then
 sleep 1
 ln -sf /run/host/run/user/\$(id -ru)/wayland-* /run/user/\$(id -ru)/
 ln -sf /run/host/run/user/\$(id -ru)/pipewire-* /run/user/\$(id -ru)/
-find /run/host/run/user/\$(id -ru)/ -maxdepth 1 -type f -exec sh -c 'grep -qlE COOKIE \\\$0 && ln -sf \\\$0 /run/user/\$(id -ru)/\\\$(basename \\\$0)' {} \;
+find /run/host/run/user/\$(id -ru)/ -maxdepth 1 -type f -exec sh -c 'grep -qlE COOKIE \$0 && ln -sf \$0 /run/user/\$(id -ru)/\$(basename \$0)' {} \;
 mkdir -p /run/user/\$(id -ru)/app && ln -sf /run/host/run/user/\$(id -ru)/app/* /run/user/\$(id -ru)/app/
 mkdir -p /run/user/\$(id -ru)/at-spi && ln -sf /run/host/run/user/\$(id -ru)/at-spi/* /run/user/\$(id -ru)/at-spi/
 mkdir -p /run/user/\$(id -ru)/dbus-1 && ln -sf /run/host/run/user/\$(id -ru)/dbus-1/* /run/user/\$(id -ru)/dbus-1/


### PR DESCRIPTION
Hi Luca,

This PR fixes the following:
1. Bash completions for the `distrobox` wrapper command
2. Auth cookie symlink in user integration for systemd/init containers
3. User integrations from being cleaned up by systemd when no session for the user is active, which causes future sessions to break (no access to wayland/pipewire, etc).

🚀