### PR TITLE
docs: fix hostname matching with --init-hooks

### DIFF
--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -222,7 +222,7 @@ creating it with the following init-hook:
 
 ```sh
 distrobox create --name test --image your-chosen-image:tag \
-                  --init-hooks 'echo "$(uname -n)" > /etc/hostname'
+    --init-hooks "echo '$(uname -n)' > /etc/hostname; hostname '$(uname -n)'"
 ```
 
 This will ensure SSH X-Forwarding will work when SSH-ing inside the distrobox:


### PR DESCRIPTION
The change #1182 had the intention to evaluate 'uname -n' while calling 'distrobox-create'. But had the quotation marks wrong. Double quotation marks must be the outer ones for the evaluation to occur directly.

When changing /etc/hostname, hostname does not change without a reboot. To avoid forcing the user to reboot the container after creating and entering the container, add 'hostname $(uname -n)' to be called with the --init-hooks flag.

See related issue #1164