### PR TITLE
init: Add '--stdin' flag to 'passwd root' call if supported

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1987,7 +1987,11 @@ if [ ! -e /etc/passwd.done ]; then
 
 	if [ "${rootful}" -eq 0 ]; then
 		# We're rootless so we don't care about account password, so we remove it
-		printf "%s\n%s\n" "${temporary_password}" "${temporary_password}" | passwd root
+		passwd_cmd=passwd
+		if passwd --help 2>&1 | grep -q -- --stdin; then
+			passwd_cmd="passwd --stdin"
+		fi
+		printf "%s\n%s\n" "${temporary_password}" "${temporary_password}" | ${passwd_cmd} root
 		printf "%s:" "root" | chpasswd -e
 	else
 		# We're rootful, so we don't want passwordless accounts, so we lock them


### PR DESCRIPTION
Fedora recently changed their `passwd` implementation from its own package to the implementation in `shadow-utils`, adding `--stdin` in the process (which has been subsequently accepted upstream). Without that flag, entering up a Fedora container for the first time fails with

```
+ printf '%s\n%s\n' 7867745a-41ea-4493-8b7b-83d8fd18924a 7867745a-41ea-4493-8b7b-83d8fd18924a
+ passwd root
The password for root is unchanged.
Changing password for root
Enter the new password (minimum of 8 characters)
Please use a combination of upper and lower case letters and numbers.
+ '[' 1 -ne 0 ']'
+ printf 'Error: An error occurred\n'
Error: An error occurred
```

Look for `--stdin` in the help output of `passwd` and use it if it is supported so the root password is properly changed.

Closes: https://github.com/89luca89/distrobox/issues/1209
Link: https://github.com/shadow-maint/shadow/commit/49001ca846d1e2894b4719d66889ab7e1b4b698a
