### PR TITLE
Prevent podman from logging stderr verbose output as priority 3 journald errors

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -72,9 +72,9 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: setup
+    timeout-minutes: 10
     strategy:
       fail-fast: false
-      max-parallel: 8
       matrix:
         distribution: ${{fromJSON(needs.setup.outputs.targets)}}
         container_manager: ["podman"] #, "docker"]
@@ -84,9 +84,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v6
 
       # Ensure distrobox create works:
       - name: Distrobox create
@@ -112,11 +109,6 @@ jobs:
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          # ./distrobox enter --name "${container_name}" -- whoami
-          # Temporary disable systemd init on github runners, it seems to be incompatible
-          # with runner services:
-          #   Failed to create /system.slice/runner-provisioner.service/init.scope control group: Permission denied
-          # works fine otherwise.
           case "${container_name}" in
             *init*)
               echo "SYSTEMD DETECTED: performing systemctl check..."
@@ -208,8 +200,8 @@ jobs:
           ./distrobox stop --yes "${container_name}"
 
       # Ensure distrobox rm works:
-      - name: Distrobox logs on failure
-        if: ${{ failure() }}
+      - name: Distrobox logs
+        if: ${{ always() }}
         run: |
           image=${{ matrix.distribution }}
           container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -582,19 +582,19 @@ if [ "${container_status}" != "running" ]; then
 		# read logs from log_timestamp to now, line by line
 		while IFS= read -r line; do
 			case "${line}" in
-				*"Error:"*)
+				"Error:"*)
 					printf >&2 "\033[31m %s\n\033[0m" "${line}"
 					exit 1
 					;;
-				*"Warning:"*)
+				"Warning:"*)
 					printf >&2 "\n\033[33m %s\033[0m" "${line}"
 					;;
-				*"distrobox:"*)
+				"distrobox:"*)
 					current_line="$(echo "${line}" | cut -d' ' -f2-)"
 					# Save current line in the status, to avoid printing the same line multiple times
 					printf >&2 "\033[32m [ OK ]\n\033[0m%-40s\t" "${current_line}"
 					;;
-				*"container_setup_done"*)
+				"container_setup_done"*)
 					printf >&2 "\033[32m [ OK ]\n\033[0m"
 					kill "${logs_pid}" > /dev/null 2>&1
 					break 2

--- a/distrobox-init
+++ b/distrobox-init
@@ -1984,7 +1984,7 @@ fi
 printf "distrobox: Ensuring user's access...\n"
 # If we're rootless, delete password for root and user
 if [ ! -e /etc/passwd.done ]; then
-	temporary_password="$(cat /proc/sys/kernel/random/uuid)"
+	temporary_password="$(md5sum < /proc/sys/kernel/random/uuid | cut -d' ' -f1)"
 	# We generate a random password to initialize the entry for the user.
 	printf "%s:%s" "${container_user_name}" "${temporary_password}" | chpasswd -e
 	printf "%s:" "${container_user_name}" | chpasswd -e

--- a/distrobox-init
+++ b/distrobox-init
@@ -26,6 +26,10 @@
 
 trap '[ "$?" -ne 0 ] && printf "Error: An error occurred\n"' EXIT
 
+# Redirect stderr to stdout as podman by default logs stderr as priority 3 journald errors.
+# Github issue: https://github.com/containers/podman/issues/20728
+exec 2>&1
+
 HOST_MOUNTS_RO_INIT="
 	/etc/localtime
 	/run/systemd/journal


### PR DESCRIPTION
Podman by default logs stderr as priority 3 journald errors. Don't know if other container managers do the same 😖
Github issue: https://github.com/containers/podman/issues/20728

`distrobox-create` by default enables verbose output for `distrobox-init` which causes the latter to output all xtrace output as priority 3 journald errors. 🤪

This PR redirects stderr in distrobox-init to stdout to prevent this *crazy* behavior. 😌