### PR TITLE
Changed echo for printf in distrobox-init

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2286,7 +2286,7 @@ if [ -e /usr/lib/systemd/systemd ] || [ -e /lib/systemd/systemd ]; then
 	# Start user Systemd unit, this will attempt until Systemd is ready
 	sh -c "	sleep 1 && while true; do \
 	    systemctl is-system-running | grep -E 'running|degraded' && break; \
-	    echo 'waiting for systemd to come up...\n' && sleep 1; \
+	    printf "waiting for systemd to come up...'\n'" && sleep 1; \
 	done && \
 	systemctl start user@${container_user_name}.service && \
 	systemctl start user-integration@${container_user_name}.service && \


### PR DESCRIPTION
Probably not an issue, but the rpmlint bashism checks caught this one, with the following error: possible bashism in distrobox-init line 2294 (unsafe echo with backslash):

Changed it for printf, with a properly escaped '/n'