### PR TITLE
Add DISTROBOX_EXPORT_PATH env var for distrobox-export.

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -37,7 +37,7 @@ enter_flags=""
 #	DBX_HOST_HOME is set in case container is created
 #	with custom --home directory
 host_home="${DISTROBOX_HOST_HOME:-"${HOME}"}"
-dest_path="${host_home}/.local/bin"
+dest_path="${DISTROBOX_EXPORT_PATH:-${host_home}/.local/bin}"
 is_sudo=0
 rootful=""
 sudo_prefix=""


### PR DESCRIPTION
Hi there. Just a small little thing I thought might be useful for others.

I keep Distrobox pretty concretely separated from everything else on my system, and that includes the binaries it exports. So I would want to pretty much always use `--export-path`, but it would be more convenient if the default value of that argument could be supplied by an environment variable. So I added precisely that: `DISTROBOX_EXPORT_PATH`.

Let me know if there's anything I should change or update in addition. The contributing guidelines mention testing, but it doesn't seem like Distrobox actually has a test suite. That said, I am using this particular change myself with success.

Thanks for your work on this software! 🙂