### PR TITLE
Switch to doas for AlpineLinux as it is the default

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -434,7 +434,7 @@ if [ "${upgrade}" -ne 0 ] ||
 				mandoc
 				musl-utils
 				pinentry
-				sudo
+				doas-sudo-shim
 				tar
 				vte3
 				which


### PR DESCRIPTION
Use doas-sudo-shim to allow to use "sudo" as an alias.