### PR TITLE
distrobox-init: do not fail if locale cannot be set

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1353,7 +1353,7 @@ EOF
 		# In case the locale is not available, install it
 		# will ensure we don't fallback to C.UTF-8
 		if ! locale -a | grep -qi en_us.utf8; then
-			LANG=en_US.UTF-8 localedef -i en_US -f UTF-8 en_US.UTF-8
+			LANG=en_US.UTF-8 localedef -i en_US -f UTF-8 en_US.UTF-8 || true
 		fi
 
 		# Ensure we have tzdata installed and populated, sometimes container


### PR DESCRIPTION
It can happen that the locale cannot be set to en_US (UTF-8) (e.g. only POSIX is available). This, however, doesn't prevent using distrobox, so it's better to ignore it.