### PR TITLE
distrobox-generate-entry: respect DBX_CONTAINER_MANAGER variable

### DIFF
--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -19,6 +19,8 @@
 # along with distrobox; if not, see <http://www.gnu.org/licenses/>.
 
 # POSIX
+# Optional env variables:
+#	DBX_CONTAINER_MANAGER
 
 # Despite of running this script via SUDO/DOAS being not supported (the
 # script itself will call the appropriate tool when necessary), we still want
@@ -76,6 +78,8 @@ done
 # Fixup variable=[true|false], in case we find it in the config file(s)
 [ "${verbose}" = "true" ] && verbose=1
 [ "${verbose}" = "false" ] && verbose=0
+
+[ -n "${DBX_CONTAINER_MANAGER}" ] && container_manager="${DBX_CONTAINER_MANAGER}"
 
 # Print usage to stdout.
 # Arguments:


### PR DESCRIPTION
I noticed very weird errors about `distrobox-create` not finding container name after creating, and after checking out with `set -x` it turned out `podman` was being used for generating entry after creating container instead of `lilipod` (which i was expecting to be used with `DBX_CONTAINER_MANAGER` set)

This PR should fix that as now it respects that variable.