### PR TITLE
Fix Nvidia integration on Fedora containers

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1630,7 +1630,7 @@ if [ "${nvidia}" -eq 1 ]; then
 
 		if [ "${type}" = "link" ]; then
 			mkdir -p "$(dirname "${dest_file}")"
-			if [ "$(md5sum "${nvidia_lib}" | cut -d ' ' -f 1)" != "$(md5sum "${dest_file}" | cut -d ' ' -f 1)" ]; then
+			if [ $(md5sum "${nvidia_lib}" | cut -d ' ' -f 1) != $(md5sum "${dest_file}" | cut -d ' ' -f 1) ] ; then
 				cp -d "${nvidia_lib}" "${dest_file}"
 			fi
 			continue


### PR DESCRIPTION
When I added file comparison I tested it on Ubuntu and Debian, it worked there, but on Fedora it didn't work as it turned out