### PR TITLE
docs: remove extra ` from xhost command

### DIFF
--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -211,7 +211,7 @@ to your `~/.distroboxrc`
 
 ```console
 -$ cat ~/.distroboxrc
-xhost +si:localuser:$USER`
+xhost +si:localuser:$USER
 ```
 
 ## Enable SSH X-Forwarding when SSH-ing in a distrobox


### PR DESCRIPTION
Fixed a typo (extra backtick) from the xhost command which let's you connect to the host xserver. 