### PR TITLE
init: massively speed up apk deps install

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -421,6 +421,7 @@ if [ "${upgrade}" -ne 0 ] ||
 				gnutar
 				man-db
 				mesa
+				openssh-client
 				posix-libc-utils
 			"
 		elif apk add alpine-base; then
@@ -433,6 +434,7 @@ if [ "${upgrade}" -ne 0 ] ||
 				man-pages
 				mandoc
 				musl-utils
+				openssh-client-default
 				pinentry
 				sudo
 				tar
@@ -463,9 +465,7 @@ if [ "${upgrade}" -ne 0 ] ||
 			ncurses
 			ncurses-terminfo
 			net-tools
-			openssh-client
 			pigz
-			procps
 			rsync
 			shadow
 			su-exec
@@ -482,12 +482,18 @@ if [ "${upgrade}" -ne 0 ] ||
 			xauth
 			xz
 			zip
+			$(apk search -qe procps)
 		"
+		# shellcheck disable=SC2086
+		found_deps="$(apk search -qe ${deps} | tr '\n' ' ')"
 		install_pkg=""
 		for dep in ${deps}; do
-			if apk info "${dep}" > /dev/null; then
-				install_pkg="${install_pkg} ${dep}"
-			fi
+			# shellcheck disable=SC2249
+			case " ${found_deps} " in
+				*" ${dep} "*)
+					install_pkg="${install_pkg} ${dep}"
+					;;
+			esac
 		done
 		# shellcheck disable=SC2086
 		apk add --force-overwrite ${install_pkg}


### PR DESCRIPTION
Instead of running `apk info` on each package individually instead just compare the list of requested packages to an `apk search` of them and pick the ones that could be found; perhaps something similar could be done for the other package managers as well to avoid such wasted time :p

On alpine due to the way searching for providers of `openssh-client` and exact matching of the found packages (`procps` is `procps-ng`) adjust these both accordingly to keep the end result consistent for alpine and wolfi.

On my end this halves the setup time for the non-toolbox alpine and wolfi images from ~30 and 40 seconds to ~15 and 20 seconds respectively.