### PR TITLE
fix: missing .fifo logfile in distrobox-enter

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -575,13 +575,16 @@ if [ "${container_status}" != "running" ]; then
 		fi
 		# save starting loop timestamp in temp variable, we'll use it
 		# after to let logs command minimize possible holes
-		${container_manager} logs --since "${log_timestamp}" -f "${container_name}" 2> /dev/null \
-			> "${app_cache_dir}/.${container_name}.fifo" &
+		${container_manager} logs --since "${log_timestamp}" -f "${container_name}" \
+			> "${app_cache_dir}/.${container_name}.fifo" 2>&1 &
 		logs_pid="$!"
 
 		# read logs from log_timestamp to now, line by line
 		while IFS= read -r line; do
 			case "${line}" in
+				"+"*)
+					# Ignoring logging commands
+					;;
 				"Error:"*)
 					printf >&2 "\033[31m %s\n\033[0m" "${line}"
 					exit 1


### PR DESCRIPTION
## Overview

For the past week I've noticed issues where distroboxes will spontaneously crash in CLI, especially during a long process like system package updates. I find it difficult to reproduce consistently, but something like a large `paru -Syu` or `apt update && apt upgrade -y` for example, would almost always trigger the crash.

Upon trying to re-run the distrobox, the process would hang:

```
 Starting container...                          
```

After interrupting with CTRL-C:

```
/usr/bin/distrobox-enter: line 514: /home/user/.cache/.ubuntu-distrobox.fifo: No such file or directory
```

[This comment](https://github.com/89luca89/distrobox/issues/610#issuecomment-1971360249) in #610 suggests that the original fix for this problem has been reverted. 

I've tried that out on my own system with this code in this pull request and so far 
I am no longer experiencing the missing .fifo nor crashing container problem. 

## Details

- issue #610: bug and fix description
- original fix: fea7a84
- commit reverting the fix: a7df145

## Related

- issue #1303