### PR TITLE
export: consider only absolute candidate icon paths that exist

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -477,7 +477,8 @@ export_application() {
 		icon_name="$(grep Icon= "${desktop_file}" | cut -d'=' -f2- | paste -sd "@" -)"
 
 		for icon in ${icon_name}; do
-			if [ -e "${icon_name}" ]; then
+			if case "${icon_name}" in "/"*) true ;; *) false ;; esac &&
+				[ -e "${icon_name}" ]; then
 				# In case it's an hard path, conserve it and continue
 				icon_files="${icon_files}@${icon_name}"
 			else


### PR DESCRIPTION
Previously (for nearly two years since 4522f29?) attempting e.g. `distrobox-export -a htop` with a file/dir named `htop` in `$PWD` it would mistakenly get detected as the icon for the program, copied over to `~/.local/share/icons/` and attempted to be used by the `.desktop` file.

Not sure if this is following the spec exactly but it does fix this very odd issue I only noticed because I happened to have a local git tree checkout of a program in my `$HOME` and while there tried to export a launcher for it to my host and dug deeper when the icon was showing up as entirely blank in GNOME.