### PR TITLE
init: massively speed up apt/pacman/xbps deps install

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -600,14 +600,8 @@ if [ "${upgrade}" -ne 0 ] ||
 			libvulkan1
 			mesa-vulkan-drivers
 		"
-		install_pkg=""
-		for dep in ${deps}; do
-			if apt-cache policy "${dep}" | grep Candidate | grep -qv none; then
-				install_pkg="${install_pkg} ${dep}"
-			fi
-		done
-		# shellcheck disable=SC2086
-		apt-get install -y ${install_pkg}
+		# shellcheck disable=SC2086,2046
+		apt-get install -y $(apt list ${deps} 2> /dev/null | tail -n +2 | cut -d/ -f1)
 
 		# In case the locale is not available, install it
 		# will ensure we don't fallback to C.UTF-8

--- a/distrobox-init
+++ b/distrobox-init
@@ -1142,14 +1142,8 @@ EOF
 			mesa-vulkan-intel
 			mesa-vulkan-radeon
 		"
-		install_pkg=""
-		for dep in ${deps}; do
-			if [ "$(xbps-query -Rs "${dep}" | wc -l)" -gt 0 ]; then
-				install_pkg="${install_pkg} ${dep}"
-			fi
-		done
-		# shellcheck disable=SC2086
-		xbps-install -Sy ${install_pkg}
+		# shellcheck disable=SC2086,2046
+		xbps-install -Sy $(xbps-query -Rs '*' | awk '{print $2}' | sed 's/-[^-]*$//' | grep -E "^($(echo ${deps} | tr ' ' '|'))$")
 
 		# In case the locale is not available, install it
 		# will ensure we don't fallback to C.UTF-8

--- a/distrobox-init
+++ b/distrobox-init
@@ -943,19 +943,11 @@ EOF
 			xorg-xauth
 			zip
 			mesa
-			opengl-driver
 			vulkan-intel
-			vte-common
 			vulkan-radeon
 		"
-		install_pkg=""
-		for dep in ${deps}; do
-			if pacman -Ss "${dep}" > /dev/null; then
-				install_pkg="${install_pkg} ${dep}"
-			fi
-		done
-		# shellcheck disable=SC2086
-		pacman -S --noconfirm ${install_pkg}
+		# shellcheck disable=SC2086,2046
+		pacman -S --needed --noconfirm $(pacman -Ssq | grep -E "^($(echo ${deps} | tr ' ' '|'))$")
 
 		# Ensure we have tzdata installed and populated, sometimes container
 		# images blank the zoneinfo directory, so we reinstall the package to

--- a/distrobox-init
+++ b/distrobox-init
@@ -601,7 +601,7 @@ if [ "${upgrade}" -ne 0 ] ||
 			mesa-vulkan-drivers
 		"
 		# shellcheck disable=SC2086,2046
-		apt-get install -y $(apt list ${deps} 2> /dev/null | tail -n +2 | cut -d/ -f1)
+		apt-get install -y $(apt-cache show ${deps} 2> /dev/null | grep "Package:" | sort -u | cut -d' ' -f2-)
 
 		# In case the locale is not available, install it
 		# will ensure we don't fallback to C.UTF-8

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -136,7 +136,7 @@ Distrobox guests tested successfully with the following container images:
 | Chainguard Wolfi | Small note: sudo is missing, use su-exec instead. | cgr.dev/chainguard/wolfi-base:latest |
 | ClearLinux |      | docker.io/library/clearlinux:latest <br> docker.io/library/clearlinux:base    |
 | Crystal Linux | | registry.getcryst.al/crystal/misc/docker:latest |
-| Debian | 7 <br> 8 <br> 9 <br> 10 <br> 11 <br> 12 | docker.io/debian/eol:wheezy <br> docker.io/library/debian:buster-backports <br> docker.io/library/debian:bullseye-backports <br> docker.io/library/debian:bookworm-backports <br> docker.io/library/debian:stable-backports |
+| Debian | 7 <br> 8 <br> 9 <br> 10 <br> 11 <br> 12 | docker.io/debian/eol:wheezy <br> docker.io/library/debian:buster <br> docker.io/library/debian:bullseye-backports <br> docker.io/library/debian:bookworm-backports <br> docker.io/library/debian:stable-backports |
 | Debian | Testing    | docker.io/library/debian:testing  <br>  docker.io/library/debian:testing-backports    |
 | Debian | Unstable | docker.io/library/debian:unstable    |
 | deepin | 20 (apricot) <br> 23 (beige) | docker.io/linuxdeepin/apricot |


### PR DESCRIPTION
For more details check the commit descriptions. Originally this just had `apt` changes, let me know if I should split the others to different PRs.

## apt
Similar to the previous `apk` optimization (#1298) instead of checking each package one by one instead grab the matching ones from `apt list` and pass them directly over to `apt-get install`.

## pacman
On Arch we can `grep` the `pacman -Ssq` output (all packages) for the ones we're interested in.

`--needed` was already used previously but was dropped with bdf78c39f2bd71296d85da2f0b4a0b7a9624e20c, commented there as well.

## xbps
Similar to Arch on Void we can instead `grep` the `xbps-query -Rs '*'` output (all packages) for the ones we're interested in after filtering out install status, description and versions.