### PR TITLE
enter: make log_timestamp date format universally compatible

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -613,7 +613,7 @@ if [ "${container_status}" != "running" ]; then
 	#
 	# Here, we save the timestamp before launching the start command, so we can
 	# be sure we're working with this very same session of logs later.
-	log_timestamp="$(date +%FT%T.%N%:z)"
+	log_timestamp="$(date -u +%FT%T)"
 	${container_manager} start "${container_name}" > /dev/null
 	#
 	# Check if the container is going in error status earlier than the


### PR DESCRIPTION
Tested as working on Chimera Linux with FreeBSD `date(1)` and Alpine Linux with busybox `date(1)` which both cannot report nanoseconds or timezone with `:` separator only supported on GNU coreutils which handles these extensions via a `strftime()` wrapper in gnulib.

Digging deeper in https://github.com/mirror/busybox/blob/master/coreutils/date.c technically busybox *can* support at least nanoseconds if the Alpine one was compiled with `CONFIG_ENABLE_FEATURE_DATE_NANO=y`, but it's not and `%N` is still not portable. Besides I can't think of a situation where reading log output would need sub-second accuracy so in my eyes this should be perfectly fine.

https://docs.podman.io/en/stable/markdown/podman-logs.1.html#since-timestamp lists some of the other supported formats, I basically picked one of the ISO 8601 options listed on https://ijmacd.github.io/rfc3339-iso8601/ while accounting for timezone offset by always dealing in UTC timestamps.