### PR TITLE
chore: bump CI actions, minor fixes to README and other files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -30,7 +30,7 @@ jobs:
       distrobox_changed: ${{ steps.check_file_changed.outputs.distrobox_changed }}
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Ensure distrobox create works:
       - name: Distrobox create

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run dash -n
         run: |
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run shfmt
         run: |
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Exclude from bashate the following rules:
       #   - SC2310 we don't want to exit if errors happen inside a check, that's why we have a check...
@@ -85,7 +85,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Exclude from bashate the following rules:
       #   - E002 we use tab indentation as suggested by shfmt.
       #   - E003 we use tab indentation as suggested by shfmt.
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run markdownlint
         run: |
@@ -134,6 +134,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: codespell-project/actions-codespell@v1
+      - uses: codespell-project/actions-codespell@v2
         with:
           skip: .git,*.pdf,*.1,*.css,*.lock

--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -21,7 +21,7 @@ jobs:
       distrobox_changed: ${{ steps.check_file_changed.outputs.distrobox_changed }}
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2
@@ -42,7 +42,7 @@ jobs:
     if: needs.check_changes.outputs.distrobox_changed == 'True'
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
 
@@ -62,7 +62,7 @@ jobs:
 
           man/gen-man
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
           commit_message: Automatic Man Page Update

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ graphical apps (X11/Wayland), and audio.
 ---
 
 > [!WARNING]  
-> Documentation on Github strictly refers to the code in the main branch. For the official documentation
+> Documentation on GitHub strictly refers to the code in the main branch. For the official documentation
 > Head over [https://distrobox.it](https://distrobox.it)
 
 - [Distrobox](#distrobox)
@@ -144,7 +144,7 @@ graphical apps (X11/Wayland), and audio.
 
 ## What it does
 
-Simply put it's a fancy wrapper around `podman`, `docker` or `lilipod` to create and start
+Simply put it's a fancy wrapper around `podman`, `docker`, or `lilipod` to create and start
 containers highly integrated with the hosts.
 
 The distrobox environment is based on an OCI image.
@@ -192,25 +192,25 @@ Fedora Silverblue for the [uBlue](https://github.com/ublue-os) project
 
 ## Why
 
-- Provide a mutable environment on an immutable OS, like [Endless OS,
-  Fedora Silverblue, OpenSUSE MicroOS, ChromeOS](compatibility.md#host-distros)  or [SteamOS3](posts/steamdeck_guide.md)
+- Provide a mutable environment on an immutable OS, like [ChromeOS, Endless OS,
+  Fedora Silverblue, OpenSUSE MicroOS, Vanilla OS](compatibility.md#host-distros), or [SteamOS3](posts/steamdeck_guide.md)
 - Provide a locally privileged environment for sudoless setups
   (eg. company-provided laptops, security reasons, etc...)
 - To mix and match a stable base system (eg. Debian Stable, Ubuntu LTS, RedHat)
   with a bleeding-edge environment for development or gaming
-  (eg. Arch, OpenSUSE Tumbleweed or Fedora with latest Mesa)
-- Leverage high abundance of curated distro images for docker/podman to
-  manage multiple environments
+  (eg. Arch, OpenSUSE Tumbleweed, or Fedora with the latest Mesa)
+- Leverage a high abundance of curated distro images for `docker`/`podman` to
+  manage multiple environments.
 
-Refer to the compatibility list for an overview of supported host's distro
+Refer to the compatibility list for an overview of the supported host distros
 [HERE](compatibility.md#host-distros) and container's distro [HERE](compatibility.md#containers-distros).
 
 ### Aims
 
 This project aims to bring **any distro userland to any other distro**
-supporting podman, docker or lilipod.
-It has been written in POSIX sh to be as portable as possible and not have
-problems with dependencies and glibc version's compatibility.
+supporting `podman`, `docker`, or `lilipod`.
+It has been written in POSIX shell to be as portable as possible and it does not have
+problems with dependencies and `glibc` version's compatibility.
 
 Refer [HERE](compatibility.md#supported-container-managers) for a list of
 supported container managers and minimum supported versions.
@@ -230,19 +230,19 @@ Benchmark 1: distrobox enter bench -- whoami
 
 #### Security implications
 
-Isolation and sandboxing is **not** the main aim of the project, on the contrary
+Isolation and sandboxing are **not** the main aims of the project, on the contrary
 it aims to tightly integrate the container with the host.
-The container will have complete access to your home, pen drives and so on,
+The container will have complete access to your home, pen drive, and so on,
 so do not expect it to be highly sandboxed like a plain
-docker/podman container or a flatpak.
+`docker`/`podman` container or a Flatpak.
 
-⚠️ **BE CAREFUL**:⚠️  if you use docker, or you use podman/lilipod with the `--root/-r` flag,
+⚠️ **BE CAREFUL**:⚠️  if you use `docker`, or you use `podman`/`lilipod` with the `--root/-r` flag,
 the containers will run as root, so **root inside the rootful container can modify
 system stuff outside the container**,
-Be also aware that **In rootful mode, you'll be asked to setup user's password**, this will
+Be also aware that **In rootful mode, you'll be asked to setup the user's password**, this will
 ensure at least that the container is not a passwordless gate to root,
-but if you have security concern for this, **use podman or lilipod that runs in rootless mode**.
-Rootless docker is still not working as intended and will be included in the future
+but if you have security concerns for this, **use `podman` or `lilipod` that runs in rootless mode**.
+Rootless `docker` is still not working as intended and will be included in the future
 when it will be complete.
 
 That said, it is in the works to implement some sort of decoupling with the host,
@@ -265,7 +265,7 @@ as discussed here: [#28 Sandboxed mode](https://github.com/89luca89/distrobox/is
 `distrobox enter test`
 
 **Add one with a [different distribution](https://github.com/89luca89/distrobox/blob/main/docs/compatibility.md#host-distros),
-eg Ubuntu 20.04:**
+eg. Ubuntu 20.04:**
 
 `distrobox create -i ubuntu:20.04`
 
@@ -328,7 +328,7 @@ skip_workdir="0"
 PATH="$PATH:/path/to/custom/podman"
 ```
 
-Alternatively it is possible to specify preferences using ENV variables:
+Alternatively, it is possible to specify preferences using ENV variables:
 
 - DBX_CONTAINER_ALWAYS_PULL
 - DBX_CONTAINER_CUSTOM_HOME
@@ -354,7 +354,7 @@ Thanks to the maintainers for their work: [M0Rf30](https://github.com/M0Rf30),
 
 ## Alternative methods
 
-Here is a list of alternative ways to install distrobox
+Here is a list of alternative ways to install `distrobox`.
 
 ### Curl or Wget
 
@@ -375,7 +375,7 @@ curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -
 wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local
 ```
 
-If you want to install the last development version, directly from last commit on git, you can use:
+If you want to install the last development version, directly from the last commit on Git, you can use:
 
 ```sh
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh -s -- --next
@@ -395,12 +395,12 @@ wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh
 
 Just run the `curl` or `wget` command again.
 
-> **Warning**
+> [WARNING]
 > Remember to add prefix-path-you-choose/bin to your PATH, to make it work.
 
 ### Git
 
-Alternatively you can clone the project using `git clone` or using the latest
+Alternatively, you can clone the project using `git clone` or using the latest
 release [HERE](https://github.com/89luca89/distrobox/releases/latest).
 
 Enter the directory and run `./install`, by default it will attempt to install
@@ -419,7 +419,7 @@ distro-specific instructions.
 ## Dependencies
 
 Distrobox depends on a container manager to work, you can choose to install
-either podman, docker or [lilipod](https://github.com/89luca89/lilipod).
+either `podman`, `docker` or [`lilipod`](https://github.com/89luca89/lilipod).
 
 Please look in the [Compatibility Table](compatibility.md#host-distros) for your
 distribution notes.
@@ -433,7 +433,7 @@ This should play well with completely sudoless setups and with devices like the 
 
 ## Uninstallation
 
-If you installed distrobox using the `install` script in the default install
+If you installed `distrobox` using the `install` script in the default install
 directory use this:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -395,7 +395,7 @@ wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh
 
 Just run the `curl` or `wget` command again.
 
-> [WARNING]
+> [!WARNING]
 > Remember to add prefix-path-you-choose/bin to your PATH, to make it work.
 
 ### Git


### PR DESCRIPTION
## Changes

- Bump CI action across all workflows. (Added a dependabot configuration file to automatically check for updates monthly and dependabot will create a PR if there is a new version of the action)
- Set the default end of line (eol) to LF in `.gitattributes`.
- Minor fixes and changes to README.