### PR TITLE
init: add explicit creation of /etc/fish/conf.d 

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1830,6 +1830,7 @@ EOF
 
 # It's also importanto to keep this working on fish shells
 if [ -e "/etc/fish/config.fish" ]; then
+	mkdir -p /etc/fish/conf.d
 	cat << EOF > /etc/fish/conf.d/distrobox_config.fish
 test -z "\$USER" && set -gx USER (id -un 2> /dev/null)
 test -z "\$UID"  && set -gx UID (id -ur 2> /dev/null)


### PR DESCRIPTION
this fixes the profile creation for the fish shell on distributions like Gentoo that do not create `/etc/fish/conf.d` when fish is installed and allows entering with fish as the login shell
fixes #1347 