### PR TITLE
Fix SHELL using absolute path and disable duplicate profile inclusion

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1792,19 +1792,21 @@ printf "distrobox: Setting up distrobox profile...\n"
 # This ensures compatibility with prompts and tools between toolbx and distrobox
 touch /run/.toolboxenv
 
-# Ensure we have some basic env variables and prompt as base.
-rcfiles="
-	/etc/profile
-	/etc/bash.bashrc
-	/etc/bashrc
-	/etc/zshrc
-"
-for rcfile in ${rcfiles}; do
-	if [ -e "${rcfile}" ] && ! grep -q distrobox_profile.sh "${rcfile}"; then
-		echo "[ -e /etc/profile.d/distrobox_profile.sh ] && . /etc/profile.d/distrobox_profile.sh" >> "${rcfile}"
-	fi
-done
-mkdir -p /etc/profile.d
+# Ensure we have some basic env variables and prompt as base if /etc/profile.d is missing
+if [ ! -d /etc/profile.d ]; then
+	rcfiles="
+		/etc/profile
+		/etc/bash.bashrc
+		/etc/bashrc
+		/etc/zshrc
+	"
+	for rcfile in ${rcfiles}; do
+		if [ -e "${rcfile}" ] && ! grep -q 'distrobox_profile.sh' "${rcfile}"; then
+			echo "[ -e /etc/profile.d/distrobox_profile.sh ] && . /etc/profile.d/distrobox_profile.sh" >> "${rcfile}"
+		fi
+	done
+	mkdir -p /etc/profile.d
+fi
 cat << EOF > /etc/profile.d/distrobox_profile.sh
 test -z "\$USER" && export USER="\$(id -un 2> /dev/null)"
 test -z "\$UID"  && readonly UID="\$(id -ur 2> /dev/null)"


### PR DESCRIPTION
This v2 of the PR.

In previous version I assumed that the issue was absolute path
in SHELL variabe. Leaving only the basename eliminated the hanging on start
but subshell still didn't work.
After doing additional testing I figured that that wasn't the issue.

The issue of broekn shells seems to be related to duplicate inclusion of distrobox hooks
when profile.d available.
While provided patch works a more comprehensive solution might be required to cover all cases.

In general we should inject hooks only once (first start or creation).
Since injecting on every start prevents customization of the container by the user
and can make it very difficult to identify shell/profile related issues (ask me how I know ;-))