### PR TITLE
Seperate curl and wget commands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -363,7 +363,9 @@ you can trust me and simply run this in your terminal:
 
 ```sh
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
-# or using wget
+```
+or using wget
+```
 wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
 ```
 
@@ -371,7 +373,9 @@ or if you want to select a custom directory to install without sudo:
 
 ```sh
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local
-# or using wget
+```
+or using wget
+```
 wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local
 ```
 
@@ -379,7 +383,9 @@ If you want to install the last development version, directly from the last comm
 
 ```sh
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh -s -- --next
-# or using wget
+```
+or using wget
+```
 wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh -s -- --next
 ```
 
@@ -387,7 +393,9 @@ or:
 
 ```sh
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
-# or using wget
+```
+or using wget
+```
 wget -qO- https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
 ```
 


### PR DESCRIPTION
This separates the `curl` and `wget` install commands in the readme to make it easier to use the github copy button on the code view to copy the command.