### PR TITLE
init: do not fail in "Setting up read-only mounts" if findmnt does not exist

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -246,6 +246,11 @@ get_locked_mount_flags()
 	prev=""
 	locked_flags=""
 
+	# If findmnt does not exist, exit
+	if ! command -v findmnt 2> /dev/null > /dev/null; then
+		return 0
+	fi
+
 	# If we can't read the file/directory, exit
 	if ! ls "${src}" 2> /dev/null > /dev/null; then
 		return 0


### PR DESCRIPTION
If `findmnt` does not exist (or returns an error), "Setting up read-only mounts" in `distrobox-init` fails with "Error: An error occurred".

Treat missing `findmnt` the same way as if the file/directory cannot be read.

It seems like some error handling for failing `findmnt` was already forseen:
```
flags="$(findmnt --noheadings --output OPTIONS --target "${src}" || :)"
```
However, the code apparently cannot handle `flags=":"`.

I'm completely unsure if my approach is reasonable or which implications it might have but it allows to at least enter the distrobox.