### PR TITLE
fix: init package in Gentoo Stage3 image

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -774,22 +774,22 @@ if [ "${upgrade}" -ne 0 ] ||
 			shell_pkg="bash"
 		fi
 		deps="
-			${shell_pkg}
+			app-shells/${shell_pkg}
 			app-crypt/gnupg
-			bash-completion
-			diffutils
-			findutils
-			less
-			ncurses
+			app-shells/bash-completion
+			sys-apps/diffutils
+			sys-apps/findutils
+			sys-apps/less
+			sys-libs/ncurses
 			net-misc/curl
 			app-crypt/pinentry
-			procps
-			shadow
-			sudo
+			sys-process/procps
+			sys-apps/shadow
+			app-admin/sudo
 			sys-devel/bc
 			sys-process/lsof
-			util-linux
-			wget
+			sys-apps/util-linux
+			net-misc/wget
 		"
 		install_pkg=""
 		for dep in ${deps}; do


### PR DESCRIPTION
For fix error like below:
```
+ deps='
			bash
			app-crypt/gnupg
			diffutils
			findutils
			less
			ncurses
			net-misc/curl
			pinentry
			procps
			shadow
			sudo
			sys-devel/bc
			sys-process/lsof
			util-linux
			wget
		'
+ install_pkg=
+ for dep in ${deps}
++ emerge --search bash
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' '2
0' -gt 0 ']'
/usr/bin/entrypoint: line 553: [: 2
0: integer expression expected
+ for dep in ${deps}
++ emerge --search app-crypt/gnupg
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 2 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg'
+ for dep in ${deps}
++ emerge --search diffutils
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 2 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils'
+ for dep in ${deps}
++ emerge --search findutils
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 7 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils'
+ for dep in ${deps}
++ emerge --search less
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' '1
7' -gt 0 ']'
/usr/bin/entrypoint: line 553: [: 1
7: integer expression expected
+ for dep in ${deps}
++ emerge --search ncurses
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' '1
1' -gt 0 ']'
/usr/bin/entrypoint: line 553: [: 1
1: integer expression expected
+ for dep in ${deps}
++ emerge --search net-misc/curl
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 1 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl'
+ for dep in ${deps}
++ grep 'Applications found'
++ emerge --search pinentry
++ grep -Eo '[0-9]'
+ '[' 3 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry'
+ for dep in ${deps}
++ grep 'Applications found'
++ emerge --search procps
++ grep -Eo '[0-9]'
+ '[' 3 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps'
+ for dep in ${deps}
++ grep 'Applications found'
++ emerge --search shadow
++ grep -Eo '[0-9]'
+ '[' 8 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow'
+ for dep in ${deps}
++ grep 'Applications found'
++ emerge --search sudo
++ grep -Eo '[0-9]'
+ '[' 8 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo'
+ for dep in ${deps}
++ emerge --search sys-devel/bc
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 1 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo sys-devel/bc'
+ for dep in ${deps}
++ emerge --search sys-process/lsof
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 1 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo sys-devel/bc sys-process/lsof'
+ for dep in ${deps}
++ emerge --search util-linux
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 1 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo sys-devel/bc sys-process/lsof util-linux'
+ for dep in ${deps}
++ emerge --search wget
++ grep 'Applications found'
++ grep -Eo '[0-9]'
+ '[' 6 -gt 0 ']'
+ install_pkg=' app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo sys-devel/bc sys-process/lsof util-linux wget'
+ emerge --ask=n --autounmask-continue --noreplace --quiet-build app-crypt/gnupg diffutils findutils net-misc/curl pinentry procps shadow sudo sys-devel/bc sys-process/lsof util-linux wget
Calculating dependencies  
 * IMPORTANT: 15 news items need reading for repository 'gentoo'.
 * Use eselect news read to view new items.



  
[ Results for search key : pinentry ]
*  app-crypt/pinentry
      Latest version available: 1.2.1-r7
      Latest version installed: 1.2.1-r7
      Size of files: 535 KiB
      Homepage:      https://gnupg.org/related_software/pinentry/
      Description:   Simple passphrase entry dialogs which utilize the Assuan protocol
      License:       GPL-2

*  app-emacs/pinentry
      Latest version available: 0.1_p20231126
      Latest version installed: [ Not Installed ]
      Size of files: 6 KiB
      Homepage:      https://github.com/ueno/pinentry-el https://www.emacswiki.org/emacs/EasyPG
      Description:   GnuPG Pinentry server implementation for Emacs
      License:       GPL-3+

[ Applications found : 2 ]

!!! The short ebuild name "pinentry" is ambiguous. Please specify
!!! one of the above fully-qualified ebuild names instead.

... done!
Dependency resolution took 2.06 s (backtrack: 0/20).

Error: An error occurred
+ '[' 1 -ne 0 ']'
+ printf 'Error: An error occurred\n'
```