### PR TITLE
Fix issue with user not having permissions to write containers.conf

### DIFF
--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -349,7 +349,7 @@ Inside it install podman, and add subuids for the user:
 ```sh
 sudo usermod --add-subuids 10000-65536 $USER
 sudo usermod --add-subgids 10000-65536 $USER
-cat << EOF > /etc/containers/containers.conf
+cat << EOF | sudo tee /etc/containers/containers.conf
 [containers]
 netns="host"
 userns="host"


### PR DESCRIPTION
This is a simple fix, I just replaced a redirection with a pipe to `sudo tee`, because the command as-is does not work unless you run it as root (which doesn't seem to be the intended usage for that step-by-step).