### PR TITLE
enter: Fix support for Active Directory usernames including backslashes pt. 2

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -89,7 +89,7 @@ fi
 container_command=""
 # by default we use getent to get the login shell of the user and use that
 container_command_user="$(echo "${USER}" | sed 's|\\|\\\\|g')"
-container_command_login="/bin/sh -c \"\\\$(getent passwd ${container_command_user} | cut -f 7 -d :) -l\""
+container_command_login="/bin/sh -c \"\\\$(getent passwd '${container_command_user}' | cut -f 7 -d :) -l\""
 container_image_default="registry.fedoraproject.org/fedora-toolbox:latest"
 container_manager="autodetect"
 container_manager_additional_flags=""


### PR DESCRIPTION
When the `container_command_user` contains a backslash, it must be quoted for `getent passwd` (otherwise `getent passwd` returns nothing).

see https://github.com/89luca89/distrobox/commit/7473298ee692e5ac2e331fab4fac856c99d6e768