### PR TITLE
distrobox-generate-entry: Ignore the case of os-release.ID

### DIFF
--- a/distrobox-generate-entry
+++ b/distrobox-generate-entry
@@ -325,6 +325,7 @@ if [ "${icon}" = "auto" ]; then
 		cut -d'=' -f2- |
 		sed "s|linux||g" |
 		tr -d ' ' |
+		tr '[:upper:]' '[:lower:]' |
 		tr -d '"')"
 
 	if [ "${rootful}" -ne 0 ]; then


### PR DESCRIPTION
Some Linux distributions have non-standardized release.IDs, resulting in Distrobox failing to correctly recognize and match icons.
