### PR TITLE
Exclude repos from bind-mounting

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1865,6 +1865,7 @@ if [ "${nvidia}" -eq 1 ]; then
 		-path "/run/host/usr/lib32/*" -prune -o \
 		-path "/run/host/usr/lib64/*" -prune -o \
 		-path "/run/host/usr/lib/*" -prune -o \
+		-path "*.repo" -prune -o \
 		-iname "*nvidia*" -not -type d -print 2> /dev/null || :)"
 	for nvidia_file in ${NVIDIA_FILES}; do
 		dest_file="$(printf "%s" "${nvidia_file}" | sed 's|/run/host||g')"


### PR DESCRIPTION
When used on a Universal Blue OS like bluefin, the repo configurations are available at `/run/host/etc/yum.repos.d/`. Repos that contain the name nvidia are incorrectly bind-mounted into the container and causes weird errors on boxes using yum and dnf.

See the issue at https://github.com/ublue-os/bluefin/issues/1552