### PR TITLE
Fix: Correct file path resolution for symlinks in NixOS

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2406,7 +2406,7 @@ if [ "${init}" -eq 0 ]; then
 			# host in some cases like /etc/localtime, so ignore findmnt errors
 			mount_source="$(findmnt -no SOURCE "${file_watch}")" || :
 			if [ -n "${mount_source}" ] && ! echo "${mount_source}" | grep -q "${id}"; then
-				file_watch_src="/run/host${file_watch}"
+				file_watch_src="readlink -f /run/host${file_watch}"
 				# check if the target file exists
 				if ls -l "${file_watch_src}" 2> /dev/null > /dev/null; then
 					# if it's a symlink and take the source


### PR DESCRIPTION
The issue happens in NixOS, where the file /etc/hostname is a symlink to /etc/static/hostname which is itself another symlink to a file in /nix/store.

This causes the variable file_watch_src to be set to an incorrect path.

By using 'readlink -f', we can ensure that file_watch_src points to the correct file location describing the hostname.

This change ensures that the path resolution works correctly for both regular files and symlinks.

This issues was described in #1482 