### PR TITLE
fix:[#1525] handle container creation failure

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -1047,6 +1047,8 @@ if eval ${cmd} > /dev/null; then
 			"${distrobox_genentry_path}" "${container_name}"
 		fi
 	fi
-	exit $?
+else
+	error="$?"
+	printf >&2 "\033[31m [ ERR ]\033[0m failed to create container.\n"
+	exit ${error}
 fi
-printf >&2 "\033[31m [ ERR ]\n\033[0m"


### PR DESCRIPTION
distrobox fumbles the error handling for container creation.  the exit command is nested inside of the creation success conditional statement.  this PR adds an else statement and handles the subprocess error by passing it up

changes:
- print error message and exit with subprocess return code

here's the output now that the error is handled:
```
jardon@lagann:~/Projects/distrobox$ ./distrobox create --additional-flags jammy      --image docker.io/library/ubuntu:jammy --name apx-test --no-entry --yes --pull 
Trying to pull docker.io/library/ubuntu:jammy...
Getting image source signatures
Copying blob 857cc8cb19c0 skipped: already exists  
Copying config 53a843653c done   | 
Writing manifest to image destination
53a843653cbcd9e10be207e951d907dc2481d9c222de57d24cfcac32e5165188
Creating 'apx-test' using image docker.io/library/ubuntu:jammy	Resolving "jammy" using unqualified-search registries (/etc/containers/registries.conf)
Trying to pull docker.io/library/jammy:latest...
Error: initializing source docker://jammy:latest: reading manifest latest in docker.io/library/jammy: requested access to the resource is denied
 [ ERR ] failed to create container.
jardon@lagann:~/Projects/distrobox$ echo $?
125
```

Closes #1525 