### PR TITLE
Multiline volume decleration support for `distrobox-assemble`

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -437,9 +437,11 @@ run_distrobox()
 	fi
 	if [ -n "${volume}" ]; then
 		IFS="¤"
+		args=""
 		for vol in ${volume}; do
-			result_command="${result_command} --volume $(sanitize_variable "${vol}")"
+			args="${args} ${vol}"
 		done
+			result_command="${result_command} --volume $(sanitize_variable "${args}")"
 	fi
 	if [ -n "${additional_flags}" ]; then
 		IFS="¤"

--- a/docs/usage/distrobox-assemble.md
+++ b/docs/usage/distrobox-assemble.md
@@ -168,3 +168,7 @@ each option corresponds to one of the `create` flags.
 	exported_apps="htop"
 	exported_bins="/usr/bin/htop /usr/bin/git"
 	exported_bins_path="~/.local/bin"
+	volume="/games:/games"
+	volume="/usr/games:/usr/games /usr/local/games:/usr/local/games"
+
+\* _Note :_ Multi-line volume decleration is available from (ToDo: Mention version)


### PR DESCRIPTION
Like `additional_packages` can be decleared in multiple line, it can't be done for volumes. For reference, running distrobox assemble dry run on the example.ini file:
```txt
[example]
additional_packages="package1"
additional_packages="package2"
additional_packages="package3"
hostname=debian
image=docker.io/library/debian:latest
entry=false
home=$HOME/.distros/debian
volume="$HOME/path1:/path1 $HOME/path2:/path2"
volume="$HOME/path3:/path3"
volume="$HOME/path4:/path4"
``` 
Current version gives: 
```bash
$ distrobox assemble create -d --file example.ini 
 - Creating example...
/home/abulusky/.local/bin/distrobox-create --yes --name example --image docker.io/library/debian:latest --no-entry --home /home/abulusky/.distros/debian --hostname debian --additional-packages " package1  package2  package3" --volume "/home/abulusky/path1:/path1 /home/abulusky/path2:/path2" --volume  --volume /home/abulusky/path3:/path3 --volume  --volume /home/abulusky/path4:/path4
```

This update intends to fix this by taking them all as a arg of `--volume` command

After modification:
```bash
$ distrobox assemble create -d --file example.ini 
 - Creating example...
/home/abulusky/.local/bin/distrobox-create --yes --name example --image docker.io/library/debian:latest --no-entry --home /home/abulusky/.distros/debian --hostname debian --additional-packages " package1  package2  package3" --volume " /home/abulusky/path1:/path1 /home/abulusky/path2:/path2  /home/abulusky/path3:/path3  /home/abulusky/path4:/path4"
```

**Please Note** : There is a line in documentation which needs mention of the version no. from which the feature will be available