### PR TITLE
Fix distrobox-enter and distrobox-rm to handle containers that have environment variables shoter than 5 symbols

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -541,8 +541,8 @@ container_status="unknown"
 eval "$(${container_manager} inspect --type container --format \
 	'container_status={{.State.Status}};
 	unshare_groups={{ index .Config.Labels "distrobox.unshare_groups" }};
-	{{range .Config.Env}}{{if slice . 0 5 | eq "HOME="}}container_home={{slice . 5 | printf "%q"}};{{end}}{{end}}
-	{{range .Config.Env}}{{if slice . 0 5 | eq "PATH="}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
+	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "HOME=")}}container_home={{slice . 5 | printf "%q"}}{{end}}{{end}};
+	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "PATH=")}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
 	"${container_name}")"
 
 # dry run mode, just generate the command and print it. No execution.

--- a/distrobox-rm
+++ b/distrobox-rm
@@ -359,7 +359,7 @@ delete_container()
 	# Retrieve container's HOME, and check if it's different from host's one. In
 	# this case we prompt for deletion of the custom home.
 	container_home=$(${container_manager} inspect --type container --format \
-		'{{range .Config.Env}}{{if slice . 0 5 | eq "HOME="}}{{slice . 5}}{{end}}{{end}}' "${container_name}")
+		'{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "HOME=")}}{{slice . 5 | printf "%q"}}{{end}}{{end}}' "${container_name}")
 	# Prompt for confirmation
 	if [ "${container_home}" != "${HOME}" ]; then
 		if [ "${non_interactive}" -eq 0 ] &&


### PR DESCRIPTION
When I was trying to use distrobox with rocm/pytorch:latest I've noticed the following error 
```
Error: template: inspect:3:27: executing "inspect" at <slice . 0 5>: error calling slice: index out of range: 5
```

It turns out this image has an environmental variable CI=1, that causes an exception when distrobox-enter / distrobox-rm is used with this docker image

Added some additional ifs to the corresponding commands to handle this case