### PR TITLE
Eval the call to $container_manager rm instead of a plain call

### DIFF
--- a/distrobox-rm
+++ b/distrobox-rm
@@ -390,7 +390,7 @@ delete_container()
 	# Remove the container
 	printf "Removing container...\n"
 	# shellcheck disable=SC2086,SC2248
-	${container_manager} rm ${force_flag} --volumes "${container_name}"
+	eval "${container_manager} rm ${force_flag} --volumes \"${container_name}\""
 
 	# Remove exported apps and bins
 	cleanup_exports "${container_name}"


### PR DESCRIPTION
The shell tries to execute `$container_manager` directly, which fails if it is a composite command like `sudo podman` as that is not a valid binary. By instead evaluating the whole command, we circumvent this issue.

This fixes https://github.com/89luca89/distrobox/issues/1542