### PR TITLE
fix: switchup in distrobox-export canon_dirs lookup

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -426,8 +426,8 @@ export_application()
 	else
 		IFS=":"
 		if [ -n "${XDG_DATA_DIRS}" ]; then
-			for xdg_data_home in ${XDG_DATA_HOME}; do
-				[ -d "${xdg_data_home}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_home}/applications"
+			for xdg_data_dir in ${XDG_DATA_DIRS}; do
+				[ -d "${xdg_data_dir}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_dir}/applications"
 			done
 		else
 			[ -d /usr/share/applications ] && canon_dirs="/usr/share/applications"
@@ -435,9 +435,7 @@ export_application()
 			[ -d /var/lib/flatpak/exports/share/applications ] && canon_dirs="${canon_dirs} /var/lib/flatpak/exports/share/applications"
 		fi
 		if [ -n "${XDG_DATA_HOME}" ]; then
-			for xdg_data_dir in ${XDG_DATA_DIRS}; do
-				[ -d "${xdg_data_dir}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_dir}/applications"
-			done
+			[ -d "${XDG_DATA_HOME}/applications" ] && canon_dirs="${canon_dirs} ${XDG_DATA_HOME}/applications"
 		else
 			[ -d "${HOME}/.local/share/applications" ] && canon_dirs="${canon_dirs} ${HOME}/.local/share/applications"
 		fi


### PR DESCRIPTION
Idk what to put here, the changes should be obvious...
Checking for one variable and then using another isn't ideal :p