### PR TITLE
add iputils in setup_pacman

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1200,6 +1200,7 @@ setup_pacman()
 		findutils
 		glibc
 		gnupg
+		iputils
 		inetutils
 		keyutils
 		less


### PR DESCRIPTION
I tried running SteamOS using distrobox, but I found that every time I entered, distrobox-init would attempt to `Installing basic packages`. Without a network connection, SteamOS couldn't start. I eventually discovered the cause: the `ping` command was always unavailable, because the `iputils` package, which provides the `ping` command, was not installed.