### PR TITLE
export: Actually fix XDG_DATA_DIRS and XDG_DATA_HOME handling

### DIFF
--- a/distrobox-export
+++ b/distrobox-export
@@ -425,19 +425,17 @@ export_application()
 		desktop_files="${exported_app}"
 	else
 		IFS=":"
-		if [ -n "${XDG_DATA_HOME}" ]; then
-			for xdg_data_home in ${XDG_DATA_HOME}; do
-				[ -d "${xdg_data_home}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_home}/applications"
+		if [ -n "${XDG_DATA_DIRS}" ]; then
+			for xdg_data_dir in ${XDG_DATA_DIRS}; do
+				[ -d "${xdg_data_dir}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_dir}/applications"
 			done
 		else
 			[ -d /usr/share/applications ] && canon_dirs="/usr/share/applications"
 			[ -d /usr/local/share/applications ] && canon_dirs="${canon_dirs} /usr/local/share/applications"
 			[ -d /var/lib/flatpak/exports/share/applications ] && canon_dirs="${canon_dirs} /var/lib/flatpak/exports/share/applications"
 		fi
-		if [ -n "${XDG_DATA_DIRS}" ]; then
-			for xdg_data_dir in ${XDG_DATA_DIRS}; do
-				[ -d "${xdg_data_dir}/applications" ] && canon_dirs="${canon_dirs} ${xdg_data_dir}/applications"
-			done
+		if [ -n "${XDG_DATA_HOME}" ]; then
+			[ -d "${XDG_DATA_HOME}/applications" ] && canon_dirs="${canon_dirs} ${XDG_DATA_HOME}/applications"
 		else
 			[ -d "${HOME}/.local/share/applications" ] && canon_dirs="${canon_dirs} ${HOME}/.local/share/applications"
 		fi


### PR DESCRIPTION
This fixes the use of `XDG_DATA_DIRS` and `XDG_DATA_HOME` in accordance to the specification.
As per the [specification](https://specifications.freedesktop.org/basedir-spec/0.8/#basics)
> There is a set of preference ordered base directories relative to which data files should be searched. This set of directories is defined by the environment variable `$XDG_DATA_DIRS`.

and
> There is a single base directory relative to which user-specific data files should be written. This directory is defined by the environment variable `$XDG_DATA_HOME`.

This change now uses the correct fallbacks for each variable (was swapped) and does not try to iterate over `XDG_DATA_HOME` as it should only contain a single directory.