### PR TITLE
create: keep $SHELL directory prefix

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -690,7 +690,7 @@ generate_create_command()
 	result_command="${result_command}
 		--label \"manager=distrobox\"
 		--label \"distrobox.unshare_groups=${unshare_groups}\"
-		--env \"SHELL=$(basename "${SHELL:-"/bin/bash"}")\"
+		--env \"SHELL=${SHELL:-"/bin/bash"}\"
 		--env \"HOME=${container_user_home}\"
 		--env \"container=${container_manager}\"
 		--env \"TERMINFO_DIRS=/usr/share/terminfo:/run/host/usr/share/terminfo\"


### PR DESCRIPTION
When $SHELL variable does not contain directory prefix like 'zsh', the 'script ...' command run via python may failed, causing compatibiltiy dropping.

This bug was found while using Petalinux 2020.1 SDK, running 'petalinux-config -c kernel'.