### PR TITLE
Replace tac with awk to be more portable

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -709,8 +709,8 @@ if [ "${unshare_groups:-0}" -eq 1 ]; then
 fi
 
 # Generate the exec command and run it
-cmd="$(generate_enter_command | tac)"
-# Reverse it with tac so we can reverse loop and prepend the command's arguments
+cmd="$(generate_enter_command | awk '{a[i++]=$0} END {for (j=i-1; j>=0;) print a[j--]}')"
+# Reverse it so we can reverse loop and prepend the command's arguments
 # to our positional parameters
 IFS='
 '


### PR DESCRIPTION
Since the latest release distrobox-enter does not work on system without tac command, this should make it more portable.

`tac` is GNU coreutils specific command - it is not present in bsd utils. There is also `tail -r`, but the parameter is not POSIX compliant.

