### PR TITLE
fix:repeat trigger update locale when locale exists

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -825,7 +825,7 @@ setup_apt()
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8
 	if [ -e /etc/locale.gen ] && {
-		! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"
+		! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"
 	}; then
 		sed -i "s|#.*en_US.UTF-8|en_US.UTF-8|g" /etc/locale.gen
 		sed -i "s|#.*${HOST_LOCALE}|${HOST_LOCALE}|g" /etc/locale.gen
@@ -951,7 +951,7 @@ setup_dnf()
 	if [ ! -e /usr/share/i18n/charmaps ]; then
 		${manager} reinstall -y glibc-common
 	fi
-	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"; then
+	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"; then
 		LANG="${HOST_LOCALE}" localedef -i "${HOST_LOCALE_LANG}" -f "${HOST_LOCALE_ENCODING}" "${HOST_LOCALE}"
 	fi
 
@@ -1028,7 +1028,7 @@ setup_emerge()
 
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8
-	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"; then
+	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"; then
 		sed -i "s|#.*en_US.UTF-8|en_US.UTF-8|g" /etc/locale.gen
 		sed -i "s|#.*${HOST_LOCALE}|${HOST_LOCALE}|g" /etc/locale.gen
 		locale-gen
@@ -1139,7 +1139,7 @@ setup_microdnf()
 	if [ ! -e /usr/share/zoneinfo/UTC ]; then
 		microdnf reinstall -y tzdata || microdnf install -y glibc-common
 	fi
-	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"; then
+	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"; then
 		LANG="${HOST_LOCALE}" localedef -i "${HOST_LOCALE_LANG}" -f "${HOST_LOCALE_ENCODING}" "${HOST_LOCALE}"
 	fi
 
@@ -1253,7 +1253,7 @@ setup_pacman()
 
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8
-	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"; then
+	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"; then
 		sed -i "s|#.*en_US.UTF-8|en_US.UTF-8|g" /etc/locale.gen
 		sed -i "s|#.*${HOST_LOCALE}|${HOST_LOCALE}|g" /etc/locale.gen
 		locale-gen -a
@@ -1487,7 +1487,7 @@ setup_xbps()
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8
 	if command -v locale && {
-		! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"
+		! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"
 	}; then
 		sed -i "s|#.*en_US.UTF-8|en_US.UTF-8|g" /etc/default/libc-locales
 		sed -i "s|#.*${HOST_LOCALE}|${HOST_LOCALE}|g" /etc/default/libc-locales
@@ -1599,7 +1599,7 @@ setup_zypper()
 
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8
-	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "${HOST_LOCALE}"; then
+	if ! locale -a | grep -qi en_us.utf8 || ! locale -a | grep -qi "$(echo ${HOST_LOCALE} | tr -d '-' )"; then
 		LANG="${HOST_LOCALE}" localedef -i "${HOST_LOCALE_LANG}" -f "${HOST_LOCALE_ENCODING}" "${HOST_LOCALE}" || true
 	fi
 


### PR DESCRIPTION
Description:

The $HOST_LOCALE contains the '-' symbol, but the output of locale -a does not include this symbol, which leads to repeated updates when updating the locale.

Log:

fixed can correctly skip over these duplicates update.
 
```
 + [ -e /etc/locale.gen ]
 + locale -a
 + grep -qi en_us.utf8 
 + locale -a
 + echo zh_CN.UTF-8
 + tr -d - 
 + grep -qi zh_CN.UTF8 
```