### PR TITLE
init: fix runtime sync fallback

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1777,8 +1777,9 @@ for host_mount_ro in ${HOST_MOUNTS_RO}; do
 		printf "Warning: %s integration with the host failed, runtime sync for %s disabled.\n" "${host_mount_ro}" "${host_mount_ro}"
 		# Fallback options for files, we do a hard copy of it
 		if [ -f /run/host"${host_mount_ro}" ]; then
-			rm -f "${host_mount_ro}"
-			cp -f /run/host"${host_mount_ro}" "${host_mount_ro}"
+			if ! (rm -f "${host_mount_ro}" && cp -f /run/host"${host_mount_ro}" "${host_mount_ro}"); then
+				printf "Warning: Hard copy failed. Error: %s\n" "$(cp -f /run/host"${host_mount_ro}" "${host_mount_ro}" 2>&1)"
+			fi
 		fi
 	fi
 done


### PR DESCRIPTION
Example: distrobox create -i ubuntu:18.04 -n ubuntu18

Closes: #1621