### PR TITLE
docs: add deepin 23 docker image

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -141,7 +141,7 @@ Distrobox guests tested successfully with the following container images:
 | Debian | 7 <br> 8 <br> 9 <br> 10 <br> 11 <br> 12 | docker.io/debian/eol:wheezy <br> docker.io/library/debian:buster <br> docker.io/library/debian:bullseye-backports <br> docker.io/library/debian:bookworm-backports <br> docker.io/library/debian:stable-backports |
 | Debian | Testing    | docker.io/library/debian:testing  <br>  docker.io/library/debian:testing-backports    |
 | Debian | Unstable | docker.io/library/debian:unstable    |
-| deepin | 20 (apricot) <br> 23 (beige) | docker.io/linuxdeepin/apricot |
+| deepin | 20 (apricot) <br> 23 (beige) | docker.io/linuxdeepin/apricot <br> docker.io/linuxdeepin/deepin:beige |
 | Fedora | 36 <br> 37 <br> 38 <br> 39 <br> 40 <br> Rawhide | quay.io/fedora/fedora:36 <br> quay.io/fedora/fedora:37 <br> quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 <br> quay.io/fedora/fedora:40 <br> quay.io/fedora/fedora:rawhide  |
 | Gentoo Linux | rolling | docker.io/gentoo/stage3:latest |
 | KDE neon | Latest | invent-registry.kde.org/neon/docker-images/plasma:latest |


### PR DESCRIPTION
url: https://hub.docker.com/r/linuxdeepin/deepin/tags