### PR TITLE
link typo steamdeck_guide.md

### DIFF
--- a/docs/posts/steamdeck_guide.md
+++ b/docs/posts/steamdeck_guide.md
@@ -70,7 +70,7 @@ inside the `$HOME` so that containers will survive updates.
 
 ## Install Podman
 
-To install podman, [refer to the install guide](install_podman_static.md#):
+To install podman, [refer to the install guide](install_podman_static.md):
 
 - Download the latest release of `podman-launcher` and place it in your home and rename it to `podman`,
   this example will use `~/.local/bin`


### PR DESCRIPTION
-minor typo: fix broken link to https://github.com/89luca89/distrobox/blob/main/docs/posts/install_podman_static.md

current link brings to page:
> Document Not Found
> The requested page could not be found. If you feel this is not normal, then you create an issue on the Gitlab.