### PR TITLE
Stop importing zsh FPATH into container

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -432,7 +432,7 @@ generate_enter_command()
 	set +o xtrace
 	# disable logging for this snippet, or it will be too talkative.
 	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
-		grep -Ev '^(CONTAINER_ID|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
+		grep -Ev '^(CONTAINER_ID|FPATH|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
 		# We filter the environment so that we do not have strange variables,
 		# multiline or containing spaces.
 		# We also NEED to ignore the HOME variable, as this is set at create time


### PR DESCRIPTION
FPATH shell variable is used by zsh for looking up shell function definitions. 
Proposed change stops importing host FPATH environment variable into container. FPATH is supposed to be shell variable only and should not even be exported into shell environment in the first place. But in a case where it was exported this will stop propagating host FPATH value into container where it might collide with and overwrite proper guest FPATH contents.