### PR TITLE
distrobox-enter: improve cmd composition speed

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -388,7 +388,7 @@ generate_enter_command()
 			--user=root"
 	else
 		result_command="${result_command}
-			--user ${USER}"
+			--user=${USER}"
 	fi
 
 	# For some usage, like use in service, or launched by non-terminal
@@ -421,11 +421,11 @@ generate_enter_command()
 	fi
 
 	result_command="${result_command}
-		--workdir ${workdir}"
+		--workdir=${workdir}"
 	result_command="${result_command}
-		--env CONTAINER_ID=${container_name}"
+		--env=CONTAINER_ID=${container_name}"
 	result_command="${result_command}
-		--env DISTROBOX_ENTER_PATH=${distrobox_enter_path}"
+		--env=DISTROBOX_ENTER_PATH=${distrobox_enter_path}"
 
 	# Loop through all the environment vars
 	# and export them to the container.
@@ -438,7 +438,7 @@ generate_enter_command()
 		# We also NEED to ignore the HOME variable, as this is set at create time
 		# and needs to stay that way to use custom home dirs.
 		result_command="${result_command}
-			--env ${i}"
+			--env=${i}"
 	done
 
 	# Start with the $PATH set in the container's config
@@ -476,7 +476,7 @@ generate_enter_command()
 	fi
 
 	result_command="${result_command}
-		--env PATH=${container_paths}"
+		--env=PATH=${container_paths}"
 
 	# Ensure the standard FHS program paths are in XDG_DATA_DIRS environment
 	standard_paths="/usr/local/share /usr/share"
@@ -491,16 +491,16 @@ generate_enter_command()
 		fi
 	done
 	result_command="${result_command}
-		--env XDG_DATA_DIRS=${container_paths}"
+		--env=XDG_DATA_DIRS=${container_paths}"
 
 	# This correctly sets the XDG_* dirs to the container_home
 	# it will be $HOME if using regular home dirs
 	# if will be $container_home if using a custom home during create
 	result_command="${result_command}
-		--env XDG_CACHE_HOME=${container_home}/.cache
-		--env XDG_CONFIG_HOME=${container_home}/.config
-		--env XDG_DATA_HOME=${container_home}/.local/share
-		--env XDG_STATE_HOME=${container_home}/.local/state"
+		--env=XDG_CACHE_HOME=${container_home}/.cache
+		--env=XDG_CONFIG_HOME=${container_home}/.config
+		--env=XDG_DATA_HOME=${container_home}/.local/share
+		--env=XDG_STATE_HOME=${container_home}/.local/state"
 
 	# Ensure the standard FHS program paths are in XDG_CONFIG_DIRS environment
 	standard_paths="/etc/xdg"
@@ -515,7 +515,7 @@ generate_enter_command()
 		fi
 	done
 	result_command="${result_command}
-		--env XDG_CONFIG_DIRS=${container_paths}"
+		--env=XDG_CONFIG_DIRS=${container_paths}"
 
 	# re-enable logging if it was enabled previously.
 	if [ "${verbose}" -ne 0 ]; then
@@ -523,10 +523,13 @@ generate_enter_command()
 	fi
 
 	# Add additional flags
-	if [ -n "${container_manager_additional_flags}" ]; then
+	IFS='
+	'
+	for flag in ${container_manager_additional_flags}; do
+		# ensure the flag name is separated from the value with an '=' (not a ' ')
 		result_command="${result_command}
-			${container_manager_additional_flags}"
-	fi
+			$(echo "${flag}" | sed -e 's,^\( *[^= ]*\)[= ],\1=,')"
+	done
 
 	# Run selected container with specified command.
 	result_command="${result_command}
@@ -715,11 +718,7 @@ cmd="$(generate_enter_command | tac)"
 IFS='
 '
 for arg in ${cmd}; do
-	if echo "${arg}" | grep -q " "; then
-		set - "$(echo "${arg}" | cut -d' ' -f1)" "$(echo "${arg}" | cut -d' ' -f2-)" "$@"
-	else
-		set - "${arg}" "$@"
-	fi
+	set - "${arg}" "$@"
 done
 
 # Prepend the container manager command


### PR DESCRIPTION
**TLDR:**
`distrobox-enter` is slow. I did some timing of the code using [the original but timed](https://github.com/TigerGorilla2/distrobox/blob/335a1586207b17185c7447f3e6486125e8faa51b/distrobox-enter) and [slightly modified](https://github.com/TigerGorilla2/distrobox/blob/d022acae9194d30211c78ccacaf3a216a90151fd/distrobox-enter#L727) but eventually came to the improvements proposed by this PR.

**Long version:**

I had noticed that my command to launch a terminal
> `distrobox-enter home -- foot`

has become slower but especially so on my laptop, taking multiple seconds.

I then eliminated `foot` by running `time distrobox-enter home -- true`. It was still slow. So I tried to launch the `podman-exec` manually and it only took ~250ms instead of 2-3 seconds.

Now I was pretty sure it was on distrobox' side and figured out which part of the `distrobox-enter` script is taking so much time using [the original but timed](https://github.com/TigerGorilla2/distrobox/blob/335a1586207b17185c7447f3e6486125e8faa51b/distrobox-enter)  . The slowest part is in [this loop](https://github.com/TigerGorilla2/distrobox/blob/335a1586207b17185c7447f3e6486125e8faa51b/distrobox-enter#L721)

My first idea was to replace the `grep -q " "` by e.g.
```
case ...
    *" "*) ...
    *) ...
esac
```

to check if a line had a space. [This](https://github.com/TigerGorilla2/distrobox/blob/d022acae9194d30211c78ccacaf3a216a90151fd/distrobox-enter#L727) did improve it to close to one second total runtime (-1sec)

<details>
  <summary>Timings from my machine</summary>

```
[david@david-laptop:/tmp/dbx-wuOy]$ git co slower
Switched to branch 'slower'

[david@david-laptop:/tmp/dbx-wuOy]$ time ./distrobox-enter home -- true
before gen-cmd took 300ms
gen-cmd took 116ms

composing cmd (bottleneck) took 1813ms
prepending container cmd took 33ms
launching the cmd in container took 289ms

real	0m2.597s
user	0m1.299s
sys	0m1.511s

[david@david-laptop:/tmp/dbx-wuOy]$ time ./distrobox-enter home -- true
before gen-cmd took 278ms
gen-cmd took 215ms

composing cmd (bottleneck) took 1994ms
prepending container cmd took 41ms
launching the cmd in container took 383ms

real	0m2.965s
user	0m1.464s
sys	0m1.728s

[david@david-laptop:/tmp/dbx-wuOy]$ git co faster
Switched to branch 'faster'

[david@david-laptop:/tmp/dbx-wuOy]$ time ./distrobox-enter home -- true
before gen-cmd took 136ms
gen-cmd took 103ms

composing cmd (bottleneck) took 644ms
prepending container cmd took 24ms
launching the cmd in container took 261ms

real	0m1.213s
user	0m0.591s
sys	0m0.677s

[david@david-laptop:/tmp/dbx-wuOy]$
```
</details>

I still wasn't fully satisfied and wanted to remove any `if`s and `case`s. Which resulted in this PR. This relies on the fact, that any container-manager flag can be given using `--flagname=VALUE` (note the `=`). The changes also have the side effect of making `--additional-flags` accepting both styles (using `=` or a space) of sepearting the flag name from the value.

<details>
  <summary>Some more timings including this PR  (branch 'even-faster')</summary>

```
[nix-shell:/tmp/dbx-wuOy]$ git checkout slower
Switched to branch slower

[nix-shell:/tmp/dbx-wuOy]$ hyperfine ./distrobox-enter home -- true
Benchmark 1: ./distrobox-enter home -- true
  Time (mean ± σ):      3.673 s ±  1.024 s    [User: 1.857 s, System: 2.190 s]
  Range (min … max):    2.053 s …  4.531 s    10 runs


[nix-shell:/tmp/dbx-wuOy]$ git checkout faster
Switched to branch faster

[nix-shell:/tmp/dbx-wuOy]$ hyperfine ./distrobox-enter home -- true
Benchmark 1: ./distrobox-enter home -- true
  Time (mean ± σ):      2.141 s ±  0.693 s    [User: 1.002 s, System: 1.343 s]
  Range (min … max):    1.389 s …  3.123 s    10 runs

[nix-shell:/tmp/dbx-wuOy]$ git checkout even-faster
Switched to branch even-faster
Your branch is up to date with origin/even-faster.

[nix-shell:/tmp/dbx-wuOy]$ hyperfine ./distrobox-enter home -- true
Benchmark 1: ./distrobox-enter home -- true
  Time (mean ± σ):     633.9 ms ± 173.3 ms    [User: 420.5 ms, System: 195.1 ms]
  Range (min … max):   417.9 ms … 802.6 ms    10 runs
```
</details>