### PR TITLE
create: Support --userns=keep-id:size=

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -934,6 +934,11 @@ generate_create_command()
 			result_command="${result_command}
 				--userns keep-id"
 		fi
+
+		# Add :size=65536 if possible
+		if podman run --rm --userns=keep-id:size=65536 ${container_image} /bin/true 2>/dev/null || [ "$?" -eq 127 ] ; then
+			result_command="${result_command}:size=65536"
+		fi
 	fi
 
 	# Add additional flags


### PR DESCRIPTION
Currently distrobox will reserve all subuids/subgids available. This has the unfortunate effect of blocking other containers from running that require their own set of subuids/subgids.

podman has added a feature that lets us restrict the amount of subuids/subgids we request. If available, set the amount to 65536 which is the standard amount needed for a typical Linux single container.

This breaks the ability to run nested containers.

---

To use this feature you must compile and run the git version of podman. Without it this happens with regular distrobox use:

```
$ podman run --rm -it --userns=auto archlinux /bin/echo "hello world"
hello world
$ distrobox create --image archlinux test1
...
$ podman run --rm -it --userns=auto archlinux /bin/echo "hello world"
Error: creating container storage: not enough unused IDs in user namespace
$ distrobox rm test1
...
$ podman run --rm -it --userns=auto archlinux /bin/echo "hello world"
hello world
```

An alternative solution to this could be an option flag to allow specifying the userns type and flags.