### PR TITLE
assemble: add unshare-groups support

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -54,6 +54,7 @@ pre_init_hooks=""
 pull=""
 root=""
 start_now=""
+unshare_groups=""
 unshare_ipc=""
 unshare_netns=""
 unshare_process=""
@@ -281,6 +282,7 @@ run_distrobox()
 	pull=""
 	root=""
 	start_now=""
+	unshare_groups=""
 	unshare_ipc=""
 	unshare_netns=""
 	unshare_process=""
@@ -364,6 +366,9 @@ run_distrobox()
 	fi
 	if [ -n "${unshare_netns}" ] && [ "${unshare_netns}" -eq 1 ]; then
 		result_command="${result_command} --unshare-netns"
+	fi
+	if [ -n "${unshare_groups}" ] && [ "${unshare_groups}" -eq 1 ]; then
+		result_command="${result_command} --unshare-groups"
 	fi
 	if [ -n "${unshare_ipc}" ] && [ "${unshare_ipc}" -eq 1 ]; then
 		result_command="${result_command} --unshare-ipc"

--- a/docs/usage/distrobox-assemble.md
+++ b/docs/usage/distrobox-assemble.md
@@ -138,6 +138,7 @@ declared multiple times to be compounded:
 | nvidia | bool | Specify if you want to enable NVidia drivers integration (default: false) |
 | pull | bool | Specify if you want to pull the image every time (default: false) |
 | root | bool | Specify if the container is rootful (default: false) |
+| unshare_groups | bool | Specify if the container should unshare users additional groups (default: false) |
 | unshare_ipc | bool | Specify if the container should unshare the ipc namespace (default: false) |
 | unshare_netns | bool | Specify if the container should unshare the network namespace (default: false) |
 | unshare_process | bool | Specify if the container should unshare the process (pid) namespace (default: false) |


### PR DESCRIPTION
Added support for the `unshare-groups` option in `distrobox assemble`