### PR TITLE
enter: better control over copied host envvars

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -107,6 +107,8 @@ headless=0
 # There's no need for them to pass the --root flag option in such cases.
 [ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
 skip_workdir=0
+no_envvars=0
+additional_envvars=""
 verbose=0
 clean_path=0
 version="1.8.1.2.1"
@@ -188,6 +190,9 @@ Options:
 	--clean-path:		reset PATH inside container to FHS standard
 	--no-tty/-T:		do not instantiate a tty
 	--no-workdir/-nw:	always start the container from container's home directory
+	--no-envvars:		don't copy host environment variables (default is to copy whenever reasonable)
+	--additional-envvars:	comma-separated list of additional host environment variables to copy
+							(overrides --no-envvars)
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--root/-r:		launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred
@@ -230,6 +235,17 @@ while :; do
 		-nw | --no-workdir)
 			shift
 			skip_workdir=1
+			;;
+		--no-envvars)
+			shift
+			no_envvars=1
+			;;
+		--additional-envvars)
+			if [ -n "$2" ]; then
+				additional_envvars="$2"
+				shift
+				shift
+			fi
 			;;
 		-n | --name)
 			if [ -n "$2" ]; then
@@ -429,14 +445,21 @@ generate_enter_command()
 
 	# Loop through all the environment vars
 	# and export them to the container.
-	set +o xtrace
-	# disable logging for this snippet, or it will be too talkative.
-	for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
-		grep -Ev '^(CONTAINER_ID|FPATH|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
-		# We filter the environment so that we do not have strange variables,
-		# multiline or containing spaces.
-		# We also NEED to ignore the HOME variable, as this is set at create time
-		# and needs to stay that way to use custom home dirs.
+	if [ "${no_envvars}" -eq 0 ]; then
+		set +o xtrace
+		# disable logging for this snippet, or it will be too talkative.
+		for i in $(printenv | grep '=' | grep -Ev ' |"|`|\$' |
+					   grep -Ev '^(CONTAINER_ID|FPATH|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)'); do
+			# We filter the environment so that we do not have strange variables,
+			# multiline or containing spaces.
+			# We also NEED to ignore the HOME variable, as this is set at create time
+			# and needs to stay that way to use custom home dirs.
+			result_command="${result_command}
+			--env=${i}"
+		done
+	fi
+	# Export all environment variables passed via --additional-envvars
+	for i in $(echo "$additional_envvars" | sed 's/,/ /g'); do
 		result_command="${result_command}
 			--env=${i}"
 	done

--- a/docs/usage/distrobox-enter.md
+++ b/docs/usage/distrobox-enter.md
@@ -18,8 +18,12 @@ If using it inside a script, an application, or a service, you can specify the
 
 	--name/-n:		name for the distrobox						default: my-distrobox
 	--/-e:			end arguments execute the rest as command to execute at login	default: default ${USER}'s shell
+	--clean-path:		reset PATH inside container to FHS standard
 	--no-tty/-T:		do not instantiate a tty
 	--no-workdir/-nw:	always start the container from container's home directory
+	--no-envvars:		don't copy host environment variables (default is to copy whenever reasonable)
+	--additional-envvars:	comma-separated list of additional host environment variables to copy
+							(overrides --no-envvars)
 	--additional-flags/-a:	additional flags to pass to the container manager command
 	--help/-h:		show this message
 	--root/-r:		launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred


### PR DESCRIPTION
Currently, all host environment variables are copied into the container, except for a hardcoded few that are ignored:
https://github.com/89luca89/distrobox/blob/3b9f0e8d3d8bd102e1636a22afffafe00777d30b/distrobox-enter#L434

This is not always the desired behavior, particularly on host distros like NixOS or Guix that break from the FHS and need to set a lot of environment variables to work around the resulting issues: https://github.com/89luca89/distrobox/issues/1516

Therefore, provide a `--no-envvars` option to disable the default copying of environment variables, and an `--additional-envvars` option to copy specific ones.

It was suggested to use `env -u distrobox` in order to unset specific environment variables:
https://github.com/89luca89/distrobox/issues/656
However, there are usually too many copied environment variables to unset them all individually.
`env -i distrobox` will unset environment variables, but that includes PATH and other things needed for distrobox to execute correctly on the host.

Other instances of this feature being requested:
https://github.com/89luca89/distrobox/issues/508
https://github.com/89luca89/distrobox/issues/743
https://github.com/89luca89/distrobox/discussions/1173