### PR TITLE
Removed broken link in "Useful tips" section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,6 @@ graphical apps (X11/Wayland), and audio.
   - [Export to the host](useful_tips.md#export-to-the-host)
   - [Execute commands on the host](useful_tips.md#execute-commands-on-the-host)
   - [Resolve "Error cannot open display: :0"](useful_tips.md#resolve-error-cannot-open-display-0)
-  - [Enable SSH X-Forwarding when SSH-ing in a distrobox](useful_tips.md#enable-ssh-x-forwarding-when-ssh-ing-in-a-distrobox)
   - [Using init system inside a distrobox](useful_tips.md#using-init-system-inside-a-distrobox)
   - [Using Docker inside a Distrobox](useful_tips.md#using-docker-inside-a-distrobox)
   - [Using Podman inside a Distrobox](useful_tips.md#using-podman-inside-a-distrobox)


### PR DESCRIPTION
"Enable SSH X-Forwarding when SSH-ing in a distrobox" section no longer exists on the "Useful tips" page, thus removing broken link.