### PR TITLE
create: add cached-image option

### DIFF
--- a/completions/zsh/_distrobox-create
+++ b/completions/zsh/_distrobox-create
@@ -10,6 +10,7 @@ _distrobox-create() {
         '(-n --name)'{-n,--name}'[Specify name for the distrobox]:distrobox name:'
         '--hostname[Specify hostname for the distrobox]:hostname:'
         '(-p --pull)'{-p,--pull}'[Pull the image even if it exists locally (implies --yes)]'
+        '(-ci --cached-image)'{-ci,--cached-image}'[Use cached image if it exists locally otherwise pull]'
         '(-Y --yes)'{-Y,--yes}'[Non-interactive, pull images without asking]'
         '(-r --root)'{-r,--root}'[Launch with root privileges using podman/docker/lilipod]'
         '(-c --clone)'{-c,--clone}'[Name of the distrobox container to use as base for a new container]:clone container name:'

--- a/completions/zsh/_distrobox-ephemeral
+++ b/completions/zsh/_distrobox-ephemeral
@@ -10,6 +10,7 @@ _distrobox-ephemeral() {
         '(-n --name)'{-n,--name}'[Specify name for the distrobox]:distrobox name:'
         '--hostname[Specify hostname for the distrobox]:hostname:'
         '(-p --pull)'{-p,--pull}'[Pull the image even if it exists locally (implies --yes)]'
+        '(-ci --cached-image)'{-ci,--cached-image}'[Use cached image if it exists locally otherwise pull]'
         '(-Y --yes)'{-Y,--yes}'[Non-interactive, pull images without asking]'
         '(-r --root)'{-r,--root}'[Launch with root privileges using podman/docker/lilipod]'
         '(-c --clone)'{-c,--clone}'[Name of the distrobox container to use as base for a new container]:clone container name:'

--- a/distrobox-create
+++ b/distrobox-create
@@ -198,6 +198,7 @@ Options:
 	--name/-n:		name for the distrobox          default: ${container_name_default}
 	--hostname:		hostname for the distrobox      default: $(uname -n)
 	--pull/-p:		pull the image even if it exists locally (implies --yes)
+	--cached-image/-ci:	use cached image if it exists locally otherwise pull
 	--yes/-Y:		non-interactive, pull images without asking
 	--root/-r:		launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,
@@ -384,6 +385,10 @@ while :; do
 			;;
 		-p | --pull)
 			container_always_pull=1
+			shift
+			;;
+		-ci | --cached-image)
+			container_always_pull=0
 			shift
 			;;
 		--nvidia)

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -19,6 +19,7 @@ graphical apps (X11/Wayland), and audio.
 	--name/-n:		name for the distrobox          default: ${container_name_default}
 	--hostname:		hostname for the distrobox      default: <container-name>.$(uname -n)
 	--pull/-p:		pull the image even if it exists locally (implies --yes)
+	--cached-image/-ci:	use cached image if it exists locally otherwise pull
 	--yes/-Y:		non-interactive, pull images without asking
 	--root/-r:		launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred
 				way over "sudo distrobox" (note: if using a program other than 'sudo' for root privileges is necessary,

--- a/man/man1/distrobox-create.1
+++ b/man/man1/distrobox-create.1
@@ -21,6 +21,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
 \-\-name/\-n:      name for the distrobox          default: ${container_name_default}
 \-\-hostname:     hostname for the distrobox      default: <container\-name>.$(uname \-n)
 \-\-pull/\-p:      pull the image even if it exists locally (implies \-\-yes)
+\-\-cached-image/\-ci:      use cached image if it exists locally otherwise pull
 \-\-yes/\-Y:       non\-interactive, pull images without asking
 \-\-root/\-r:      launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred
             way over \[dq]sudo distrobox\[dq] (note: if using a program other than \[aq]sudo\[aq] for root privileges is necessary,

--- a/man/man1/distrobox.1
+++ b/man/man1/distrobox.1
@@ -892,6 +892,7 @@ usb devices and graphical apps (X11/Wayland), and audio.
 \-\-name/\-n:      name for the distrobox          default: ${container_name_default}
 \-\-hostname:     hostname for the distrobox      default: <container\-name>.$(uname \-n)
 \-\-pull/\-p:      pull the image even if it exists locally (implies \-\-yes)
+\-\-cached-image/\-ci:      use cached image if it exists locally otherwise pull
 \-\-yes/\-Y:       non\-interactive, pull images without asking
 \-\-root/\-r:      launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred
             way over \[dq]sudo distrobox\[dq] (note: if using a program other than \[aq]sudo\[aq] for root privileges is necessary,


### PR DESCRIPTION
Add --cached-image/-ci flag to set container_always_pull to 0 when container_always_pull or DBX_CONTAINER_ALWAYS_PULL ENV variables are set to 1.

[#1554](https://github.com/89luca89/distrobox/issues/1554)