### PR TITLE
distrobox-init: extract fish prompt to autoloaded function

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2151,10 +2151,13 @@ if status --is-interactive
 		passwd && rm -f /var/tmp/.\$USER.passwd.initialize
 		trap - INT
 	end
-	function fish_prompt
-		set current_dir (basename (pwd))
-		echo "📦[\$USER@\$CONTAINER_ID \$current_dir]> "
-	end
+end
+EOF
+	mkdir -p /etc/fish/functions
+	cat <<EOF > /etc/fish/functions/fish_prompt.fish
+function fish_prompt
+	set current_dir (basename (pwd))
+	echo "📦[\$USER@\$CONTAINER_ID \$current_dir]> "
 end
 EOF
 fi


### PR DESCRIPTION
A prepared autoloaded fish_prompt function in /etc will override the default prompt configured by fish but not a prompt configured by the user themselves.

fixes #1671
