### PR TITLE
Support Chimera Linux guests

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -658,6 +658,30 @@ setup_apk()
 			$(apk search -q mesa-dri)
 			$(apk search -q mesa-vulkan)
 		"
+	elif apk add base-bootstrap; then
+		# Prevent "ADB schema error" while installing tzdb in rootful container on currently old image
+		apk upgrade -Ua
+		# Prevent "fchownat() of /tmp failed: Operation not permitted" from sd-tools trigger script
+		sed -i '' '/^q \/tmp/ s/^/#/' /usr/lib/tmpfiles.d/tmp.conf
+		# Setup rest of packages while also allowing install of extras from user repo
+		apk add chimera-repo-user
+		apk update
+		deps="
+			base-core-man
+			bash-completion
+			bc-gh
+			gtar
+			libarchive-progs
+			libcap-progs
+			lsof
+			mesa-dri
+			ncurses-term
+			opendoas
+			openssh
+			util-linux-mount
+			vte
+			wget2
+		"
 	fi
 	deps="${deps:-}
 		${shell_pkg}

--- a/distrobox-init
+++ b/distrobox-init
@@ -234,7 +234,7 @@ fi
 # if /run/.nopasswd is present, let's treat the init as rootless, this is not
 # a good thing, users behold!
 if stat /run/host/etc/shadow > /dev/null &&
-	[ "$(stat -c "%u" /run/host/etc/shadow)" = "0" ] &&
+	{ [ "$(stat -c "%u" /run/host/etc/shadow)" = "0" ] || [ "$(stat -f "%u" /run/host/etc/shadow)" = "0" ]; } &&
 	[ ! -e /run/.nopasswd ]; then
 	rootful=1
 fi

--- a/distrobox-init
+++ b/distrobox-init
@@ -2201,6 +2201,15 @@ Defaults !fqdn
 %sudo ALL=(ALL:ALL) ALL
 %root ALL=(ALL:ALL) ALL
 EOF
+# ditto for doas
+if [ -e /etc/doas.conf ]; then
+	cat << EOF > /etc/doas.conf
+permit persist :root
+permit persist :wheel
+permit nopass root
+permit nopass keepenv setenv { PATH } root as root
+EOF
+fi
 
 # PAM config for "su" command
 if [ ! -e /etc/pam.d/su ]; then
@@ -2226,6 +2235,10 @@ fi
 if [ "${container_user_uid}" -ne 0 ] && [ "${rootful}" -eq 0 ]; then
 	# Ensure passwordless sudo is set up for user
 	printf "\"%s\" ALL = (root) NOPASSWD:ALL\n" "${container_user_name}" >> /etc/sudoers.d/sudoers
+	# ditto for doas
+	if [ -e /etc/doas.conf ]; then
+		printf "permit %s\n" "${container_user_name}" >> /etc/doas.conf
+	fi
 fi
 ###############################################################################
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -53,6 +53,7 @@ Distrobox has been successfully tested on:
 | Arch Linux | | `distrobox` is available in the `extra` repository and `distrobox-git` is available in the AUR (thanks [M0Rf30](https://github.com/M0Rf30)!). <br> To setup rootless podman, look [HERE](https://wiki.archlinux.org/title/Podman) |
 | Bazzite | 38 | `distrobox-git` is preinstalled. |
 | CentOS | 8 <br> 8 Stream <br> 9 Stream | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
+| Chimera Linux | | `distrobox` is available in `chimera-repo-user`. |
 | ChromeOS | Debian 11 (docker with make-shared workaround #non-shared-mounts) <br> Debian 12 (podman) | using built-in Linux on ChromeOS mode which is debian-based, which can be [upgraded](https://wiki.debian.org/DebianUpgrade) from 11 bullseye to 12 bookworm (in fact 12 is recommended) |
 | Debian | 11 <br> 12 <br> Testing <br> Unstable | `distrobox` is available in default repos starting from version 12 (thanks [michel-slm!](https://github.com/michel-slm!)!) |
 | deepin | 23 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` |
@@ -136,6 +137,7 @@ Distrobox guests tested successfully with the following container images:
 | Blackarch     | | docker.io/blackarchlinux/blackarch:latest    |
 | CentOS Stream | 8 <br> 9 | quay.io/centos/centos:stream8 <br> quay.io/centos/centos:stream9  |
 | Chainguard Wolfi | | cgr.dev/chainguard/wolfi-base:latest |
+| Chimera Linux | | docker.io/chimeralinux/chimera:latest |
 | ClearLinux |      | docker.io/library/clearlinux:latest <br> docker.io/library/clearlinux:base    |
 | Crystal Linux | | registry.gitlab.com/crystal-linux/misc/docker:latest  |
 | Debian | 7 <br> 8 <br> 9 <br> 10 <br> 11 <br> 12 | docker.io/debian/eol:wheezy <br> docker.io/library/debian:buster <br> docker.io/library/debian:bullseye-backports <br> docker.io/library/debian:bookworm-backports <br> docker.io/library/debian:stable-backports |


### PR DESCRIPTION
At last adds proper support for https://chimera-linux.org guests via https://hub.docker.com/r/chimeralinux/chimera.

I don't really like how `/etc/doas.conf` (or `/etc/sudoers.d/sudoers` for that matter) are being rewritten on every fresh enter of the container: is there some technical reason for this? I've duplicated it over to the `doas` logic but it didn't necessarily seem required; required stuff could be appended conditionally if missing but oh well.

Closes #1166.