### PR TITLE
feat: add --unshare-home flag for isolated home directories

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,23 @@
+# Add --unshare-home flag for isolated containers
+
+## What this does
+
+Adds a new `--unshare-home` flag that creates containers without mounting your host home directory. The container gets its own isolated home instead.
+
+## How it works
+
+- New flag in `distrobox create --unshare-home`
+- Container gets labeled so `distrobox enter` knows it's unshared
+- Home directory mounting is skipped during creation
+- Container creates its own home directory on first entry
+- `--unshare-all` now includes this flag automatically
+
+## Why you'd want this
+
+I've been working with AI agents and realized I needed better isolation. These tools can be unpredictable and might access files they shouldn't. With `--unshare-home`, I can run potentially dangerous code knowing it can't touch my personal files, configs, or SSH keys.
+
+It's also useful for testing untrusted software or creating clean development environments.
+
+## Testing
+
+I'll attach detailed testing docs in the next message showing how to verify this works correctly across different distros and use cases.

--- a/completions/zsh/_distrobox-create
+++ b/completions/zsh/_distrobox-create
@@ -23,6 +23,7 @@ _distrobox-create() {
         '--nvidia[Try to integrate host nVidia drivers into the guest]'
         '--unshare-devsys[Do not share host devices and sysfs dirs from host]'
         '--unshare-groups[Do not forward users additional groups into the container]'
+        '--unshare-home[Do not share host home directory with container]'
         '--unshare-ipc[Do not share ipc namespace with host]'
         '--unshare-netns[Do not share the net namespace with host]'
         '--unshare-process[Do not share process namespace with host]'

--- a/completions/zsh/_distrobox-ephemeral
+++ b/completions/zsh/_distrobox-ephemeral
@@ -23,6 +23,7 @@ _distrobox-ephemeral() {
         '--nvidia[Try to integrate host nVidia drivers into the guest]'
         '--unshare-devsys[Do not share host devices and sysfs dirs from host]'
         '--unshare-groups[Do not forward users additional groups into the container]'
+        '--unshare-home[Do not share host home directory with container]'
         '--unshare-ipc[Do not share ipc namespace with host]'
         '--unshare-netns[Do not share the net namespace with host]'
         '--unshare-process[Do not share process namespace with host]'

--- a/completions/zsh/_distrobox-host-exec
+++ b/completions/zsh/_distrobox-host-exec
@@ -6,4 +6,5 @@ _arguments \
   '(--help -h)'{-h,--help}'[show this message]' \
   '(--verbose -v)'{-v,--verbose}'[show more verbosity]' \
   '(--version -V)'{-V,--version}'[show version]' \
-  '(--yes -Y)'{-Y,--yes}'[Automatically answer yes to prompt host-spawn will be installed on the guest system if not detected]'
+  '(--yes -Y)'{-Y,--yes}'[Automatically answer yes to prompt host-spawn will be installed on the guest system if not detected]' \
+  '(--current-work-dir -cwd)'{--current-work-dir=-,-cwd=}'[Set working directory on the host]:path:_files'

--- a/distrobox-create
+++ b/distrobox-create
@@ -714,6 +714,7 @@ generate_create_command()
 		--env \"container=${container_manager}\"
 		--env \"TERMINFO_DIRS=/usr/share/terminfo:/run/host/usr/share/terminfo\"
 		--env \"CONTAINER_ID=${container_name}\"
+		--env \"DISTROBOX_UNSHARE_HOME=${unshare_home}\"
 		--volume /tmp:/tmp:rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro

--- a/distrobox-create
+++ b/distrobox-create
@@ -81,6 +81,7 @@ init=0
 non_interactive=0
 nvidia=0
 nopasswd=0
+unshare_home=0
 unshare_ipc=0
 unshare_groups=0
 unshare_netns=0
@@ -218,6 +219,7 @@ Options:
 	--platform:		specify which platform to use, eg: linux/arm64
 	--unshare-devsys:          do not share host devices and sysfs dirs from host
 	--unshare-groups:          do not forward user's additional groups into the container
+	--unshare-home:            do not share host home directory with container
 	--unshare-ipc:          do not share ipc namespace with host
 	--unshare-netns:        do not share the net namespace with host
 	--unshare-process:          do not share process namespace with host
@@ -334,10 +336,15 @@ while :; do
 			shift
 			unshare_devsys=1
 			;;
+		--unshare-home)
+			shift
+			unshare_home=1
+			;;
 		--unshare-all)
 			shift
 			unshare_devsys=1
 			unshare_groups=1
+			unshare_home=1
 			unshare_ipc=1
 			unshare_netns=1
 			unshare_process=1
@@ -701,6 +708,7 @@ generate_create_command()
 	result_command="${result_command}
 		--label \"manager=distrobox\"
 		--label \"distrobox.unshare_groups=${unshare_groups}\"
+		--label \"distrobox.unshare_home=${unshare_home}\"
 		--env \"SHELL=$(basename "${SHELL:-"/bin/bash"}")\"
 		--env \"HOME=${container_user_home}\"
 		--env \"container=${container_manager}\"
@@ -709,8 +717,13 @@ generate_create_command()
 		--volume /tmp:/tmp:rslave
 		--volume \"${distrobox_entrypoint_path}\":/usr/bin/entrypoint:ro
 		--volume \"${distrobox_export_path}\":/usr/bin/distrobox-export:ro
-		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro
-		--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+		--volume \"${distrobox_hostexec_path}\":/usr/bin/distrobox-host-exec:ro"
+
+	# Mount the user's home directory unless --unshare-home is set
+	if [ "${unshare_home}" -eq 0 ]; then
+		result_command="${result_command}
+			--volume \"${container_user_home}\":\"${container_user_home}\":rslave"
+	fi
 
 	# Due to breaking change in https://github.com/opencontainers/runc/commit/d4b670fca6d0ac606777376440ffe49686ce15f4
 	# now we cannot mount /:/run/host as before, as it will try to mount RO partitions as RW thus breaking things.
@@ -873,8 +886,8 @@ generate_create_command()
 	fi
 
 	# Mount also the /var/home dir on ostree based systems
-	# do this only if $HOME was not already set to /var/home/username
-	if [ "${container_user_home}" != "/var/home/${container_user_name}" ] &&
+	# do this only if $HOME was not already set to /var/home/username and --unshare-home is not set
+	if [ "${unshare_home}" -eq 0 ] && [ "${container_user_home}" != "/var/home/${container_user_name}" ] &&
 		[ -d "/var/home/${container_user_name}" ]; then
 
 		result_command="${result_command}
@@ -883,8 +896,8 @@ generate_create_command()
 
 	# Mount also the XDG_RUNTIME_DIR to ensure functionality of the apps.
 	# This is skipped in case of initful containers, so that a dedicated
-	# systemd user session can be used.
-	if [ -d "/run/user/${container_user_uid}" ] && [ "${init}" -eq 0 ]; then
+	# systemd user session can be used. Also skip if --unshare-home is set.
+	if [ "${unshare_home}" -eq 0 ] && [ -d "/run/user/${container_user_uid}" ] && [ "${init}" -eq 0 ]; then
 		result_command="${result_command}
 			--volume /run/user/${container_user_uid}:/run/user/${container_user_uid}:rslave"
 	fi

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -553,10 +553,38 @@ eval "$(${container_manager} inspect --type container --format \
 	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "PATH=")}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
 	"${container_name}")"
 
-# If container was created with --unshare-home, automatically skip workdir
-# since the host's home directory paths are not available in the container
+# If container was created with --unshare-home, we try to preserve  workdir it is under HOME and is mounted.
+# Otherwise, we skip workdir
 if [ "${unshare_home:-0}" -eq 1 ]; then
-	skip_workdir=1
+	case "${PWD:-}" in
+		"${HOME}"|"${HOME}"/*)
+			covered=0
+			mount_dests="$(${container_manager} inspect --type container --format '{{range .Mounts}}{{println .Destination}}{{end}}' "${container_name}" 2>/dev/null || true)"
+			if [ -n "${PWD:-}" ] && [ -n "${mount_dests}" ]; then
+				# iterate through mount destinations using printf
+				# Note: we can't use a pipeline here because it creates a subshell
+				# and the 'covered' variable won't be updated in the parent shell
+				while IFS= read -r dest; do
+					[ -z "${dest}" ] && continue
+					# Ignore generic /run/host mount when checking same-path availability
+					case "${dest}" in
+						/run/host|/run/host/*) continue ;;
+					esac
+					case "${PWD}" in
+						"${dest}"|"${dest}"/*)
+							covered=1
+							break
+							;;
+				esac
+				done <<EOF
+${mount_dests}
+EOF
+			fi
+			# If not covered by a mount, skip workdir
+			if [ "${covered}" -eq 0 ]; then
+				skip_workdir=1
+			fi
+	esac
 fi
 
 # dry run mode, just generate the command and print it. No execution.

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -410,6 +410,7 @@ generate_enter_command()
 	# Since user $HOME is very likely present in container, enter there directly
 	# to avoid confusing the user about shifted paths.
 	# pass distrobox-enter path, it will be used in the distrobox-export tool.
+	#
 	if [ "${skip_workdir}" -eq 0 ]; then
 		workdir="${PWD:-${container_home:-"/"}}"
 		if [ -n "${workdir##*"${container_home}"*}" ]; then
@@ -541,14 +542,22 @@ generate_enter_command()
 container_home="${HOME}"
 container_path="${PATH}"
 unshare_groups=0
+unshare_home=0
 # Now inspect the container we're working with.
 container_status="unknown"
 eval "$(${container_manager} inspect --type container --format \
 	'container_status={{.State.Status}};
 	unshare_groups={{ index .Config.Labels "distrobox.unshare_groups" }};
+	unshare_home={{ index .Config.Labels "distrobox.unshare_home" }};
 	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "HOME=")}}container_home={{slice . 5 | printf "%q"}}{{end}}{{end}};
 	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "PATH=")}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
 	"${container_name}")"
+
+# If container was created with --unshare-home, automatically skip workdir
+# since the host's home directory paths are not available in the container
+if [ "${unshare_home:-0}" -eq 1 ]; then
+	skip_workdir=1
+fi
 
 # dry run mode, just generate the command and print it. No execution.
 if [ "${dryrun}" -ne 0 ]; then

--- a/distrobox-host-exec
+++ b/distrobox-host-exec
@@ -26,6 +26,7 @@
 # Defaults
 host_command=""
 non_interactive=0
+current_work_dir=""
 # If we're in a non-interactive shell, let's act accordingly
 if [ ! -t 1 ] ||
 	! tty > /dev/null 2>&1; then
@@ -70,6 +71,15 @@ Options:
                                 host-spawn will be installed on the guest system
                                 if host-spawn is not detected.
                                 This behaviour is default when running in a non-interactive shell.
+	--current-work-dir=PATH, -cwd PATH:
+				Set working directory on the host before executing the command.
+				Useful when the current directory in the container does not exist on the host.
+
+Notes:
+	If the current working directory inside the container does not exist on the host
+	(e.g., you are in ~/test in the container but ~/test does not exist on the host),
+	invoking distrobox-host-exec from that directory may fail. 
+	Consider specifying --current-work-dir to an existing path on the host.
 EOF
 }
 
@@ -98,6 +108,31 @@ if [ -z "${host_command}" ]; then
 				;;
 			-Y | --yes)
 				non_interactive=1
+				shift
+				;;
+			--current-work-dir)
+				# Next argument is the path
+				shift
+				if [ -z "${1:-}" ]; then
+					printf >&2 "ERROR: --current-work-dir requires a path argument\n\n"
+					show_help
+					exit 1
+				fi
+				current_work_dir="$1"
+				shift
+				;;
+			--current-work-dir=*)
+				current_work_dir="${1#*=}"
+				shift
+				;;
+			-cwd)
+				shift
+				if [ -z "${1:-}" ]; then
+					printf >&2 "ERROR: -cwd requires a path argument\n\n"
+					show_help
+					exit 1
+				fi
+				current_work_dir="$1"
 				shift
 				;;
 			--) # End of all options.
@@ -207,6 +242,19 @@ fi
 XDG_RUNTIME_DIR="/run/host/${XDG_RUNTIME_DIR}"
 DBUS_SESSION_BUS_ADDRESS="unix:path=/run/host/$(echo "${DBUS_SESSION_BUS_ADDRESS}" | cut -d '=' -f2-)"
 
+# Warn if PWD inside the container does not exist on the host when no explicit cwd was provided
+if [ -z "${current_work_dir}" ]; then
+	if [ -n "${PWD:-}" ] && [ ! -e "/run/host${PWD}" ]; then
+		printf >&2 "Warning: current working directory '%s' does not exist on the host.\n" "${PWD}"
+		printf >&2 "         Consider using --current-work-dir to set an existing host path.\n"
+	fi
+else
+	# If user provided an explicit cwd, warn if it doesn't exist on host
+	if [ ! -e "/run/host${current_work_dir}" ]; then
+		printf >&2 "Warning: specified --current-work-dir '%s' does not exist on the host.\n" "${current_work_dir}"
+	fi
+fi
+
 ###
 # This workaround is needed because of a bug in gio (used by xdg-open) where
 # a race condition happens when allocating a pty, leading to the command
@@ -224,11 +272,19 @@ if [ "$(basename "${host_command}")" = "xdg-open" ] ||
 	[ ! -t 1 ] ||
 	! tty > /dev/null 2>&1; then
 
-	host-spawn --no-pty "${host_command}" "$@"
+	if [ -n "${current_work_dir}" ]; then
+		host-spawn --no-pty --cwd "${current_work_dir}" "${host_command}" "$@"
+	else
+		host-spawn --no-pty "${host_command}" "$@"
+	fi
 	# Exit here, we don't continue execution
 	exit $?
 fi
 
-host-spawn "${host_command}" "$@"
+if [ -n "${current_work_dir}" ]; then
+	host-spawn --cwd "${current_work_dir}" "${host_command}" "$@"
+else
+	host-spawn "${host_command}" "$@"
+fi
 # Exit here, we don't continue execution
 exit $?

--- a/distrobox-init
+++ b/distrobox-init
@@ -1796,9 +1796,15 @@ printf "distrobox: Setting up read-write mounts...\n"
 # On some ostree systems, home is in /var/home, but most of the software expects
 # it to be in /home. In the hosts systems this is fixed by using a symlink.
 # Do something similar here with a bind mount.
+# Skip this if --unshare-home was used during container creation.
 if [ -e "/var/home/${container_user_name}" ]; then
-	if ! mount_bind "/run/host/var/home/${container_user_name}" "/home/${container_user_name}"; then
-		printf "Warning: Cannot bind mount %s to /run/host%s\n" "/var/home" "/home"
+	unshare_home="${DISTROBOX_UNSHARE_HOME:-0}"
+	if [ "${unshare_home:-0}" -eq 0 ]; then
+		if ! mount_bind "/run/host/var/home/${container_user_name}" "/home/${container_user_name}"; then
+			printf "Warning: Cannot bind mount %s to /run/host%s\n" "/var/home" "/home"
+		fi
+	else
+		printf "distrobox: Skipping /var/home bind mount due to --unshare-home flag\n"
 	fi
 fi
 

--- a/distrobox-init
+++ b/distrobox-init
@@ -2401,6 +2401,16 @@ fi
 
 # Now we're done
 touch /etc/passwd.done
+
+# Ensure the user's home directory exists and has correct ownership
+# This is especially important for --unshare-home containers where
+# the home directory is not mounted from the host
+if [ ! -d "${container_user_home}" ]; then
+	printf "distrobox: Creating user home directory...\n"
+	mkdir -p "${container_user_home}"
+	chown "${container_user_uid}:${container_user_gid}" "${container_user_home}"
+	chmod 755 "${container_user_home}"
+fi
 ###############################################################################
 
 ###############################################################################

--- a/distrobox-init
+++ b/distrobox-init
@@ -2411,12 +2411,10 @@ touch /etc/passwd.done
 # Ensure the user's home directory exists and has correct ownership
 # This is especially important for --unshare-home containers where
 # the home directory is not mounted from the host
-if [ ! -d "${container_user_home}" ]; then
-	printf "distrobox: Creating user home directory...\n"
-	mkdir -p "${container_user_home}"
-	chown "${container_user_uid}:${container_user_gid}" "${container_user_home}"
-	chmod 755 "${container_user_home}"
-fi
+printf "distrobox: Ensuring correct ownership of user home directory...\n"
+mkdir -p "${container_user_home}"
+chown "${container_user_uid}:${container_user_gid}" "${container_user_home}"
+chmod 755 "${container_user_home}"
 ###############################################################################
 
 ###############################################################################

--- a/docs/posts/execute_commands_on_host.md
+++ b/docs/posts/execute_commands_on_host.md
@@ -21,6 +21,10 @@ distrobox offers the `distrobox-host-exec` helper, that can be used exactly for 
 
 See [distrobox-host-exec](../usage/distrobox-host-exec.md).
 
+Note: If the directory you are currently in inside the container does not exist on the host,
+`distrobox-host-exec` will warn you and still attempt execution. You can override the host
+working directory with `--current-work-dir` (or `-cwd`).
+
 ```console
 user@fedora-distrobox:~$ which podman
 /usr/bin/which: no podman in [...]

--- a/docs/usage/distrobox-assemble.md
+++ b/docs/usage/distrobox-assemble.md
@@ -142,6 +142,8 @@ declared multiple times to be compounded:
 | unshare_netns | bool | Specify if the container should unshare the network namespace (default: false) |
 | unshare_process | bool | Specify if the container should unshare the process (pid) namespace (default: false) |
 | unshare_devsys | bool | Specify if the container should unshare /dev (default: false) |
+| unshare_groups | bool | Specify if the container should not forward user's additional groups (default: false) |
+| unshare_home | bool | Specify if the container should not share host home directory (default: false) |
 | unshare_all | bool | Specify if the container should unshare all the previous options (default: false) |
 
 For further explanation of each of the option in the list, take a look at the [distrobox create usage](distrobox-create.md#synopsis),

--- a/docs/usage/distrobox-create.md
+++ b/docs/usage/distrobox-create.md
@@ -39,6 +39,7 @@ graphical apps (X11/Wayland), and audio.
 	--platform:		specify which platform to use, eg: linux/arm64
 	--unshare-devsys:          do not share host devices and sysfs dirs from host
 	--unshare-groups:          do not forward user's additional groups into the container
+	--unshare-home:            do not share host home directory with container
 	--unshare-ipc:          do not share ipc namespace with host
 	--unshare-netns:        do not share the net namespace with host
 	--unshare-process:          do not share process namespace with host
@@ -113,7 +114,11 @@ Do not use host's IP inside the container:
 
 	distrobox create --image ubuntu:latest --name test --unshare-netns
 
-Create a more isolated container, where only the $HOME, basic sockets and host's FS (in /run/host) is shared:
+Create a container with isolated home directory (host home is not mounted):
+
+	distrobox create --image ubuntu:latest --name test --unshare-home
+
+Create a more isolated container, where only basic sockets and host's FS (in /run/host) is shared:
 
 	distrobox create --name unshared-test --unshare-all
 
@@ -209,6 +214,12 @@ Inside you'll have a separate init, user-session, daemons and so on.
 The `--home` flag let's you specify a custom HOME for the container.
 Note that this will NOT prevent the mount of the host's home directory,
 but will ensure that configs and dotfiles will not litter it.
+
+The `--unshare-home` flag creates a container with an isolated home directory.
+When this flag is enabled, the host's home directory is not mounted into the container.
+
+This is useful for creating clean, isolated environments or when you want to prevent
+containers from accessing or modifying files in your host home directory.
 
 The `--root` flag will let you create a container with real root privileges. At
 first `enter` the user will be required to setup a password. This is done in order

--- a/docs/usage/distrobox-host-exec.md
+++ b/docs/usage/distrobox-host-exec.md
@@ -22,8 +22,18 @@ Just pass to "distrobox-host-exec" any command and all its arguments, if any.
                                 host-spawn will be installed on the guest system
                                 if host-spawn is not detected.
                                 This behaviour is default when running in a non-interactive shell.
+	--current-work-dir=PATH, -cwd PATH:
+				Set working directory on the host before executing the command.
+				Useful when the container's current directory does not exist on the host.
 
 If no command is provided, it will execute "$SHELL".
+
+Note about working directory mismatches:
+If the current working directory inside the container does not exist on the host
+(for example you are in ~/test in the container while ~/test is missing on the host),
+invoking distrobox-host-exec from that directory may fail on the host.
+In such cases the tool will print a warning but still attempt to execute using host-spawn.
+Consider specifying --current-work-dir to an existing path on the host.
 
 Alternatively, use symlinks to make `distrobox-host-exec` execute as that command:
 


### PR DESCRIPTION
# Add --unshare-home flag for isolated containers

## What this does

Adds a new `--unshare-home` flag that creates containers without mounting your host home directory. The container gets its own isolated home instead.

## How it works

- New flag in `distrobox create --unshare-home`
- Container gets labeled so `distrobox enter` knows it's unshared
- Home directory mounting is skipped during creation
- Container creates its own home directory on first entry
- `--unshare-all` now includes this flag automatically

## Why you'd want this

I've been working with AI agents and realized I needed better isolation. These tools can be unpredictable and might access files they shouldn't. With `--unshare-home`, I can run potentially dangerous code knowing it can't touch my personal files, configs, or SSH keys.

It's also useful for testing untrusted software or creating clean development environments.

## Testing

I'll attach detailed testing docs in the next message showing how to verify this works correctly across different distros and use cases.