### PR TITLE
docs: Remove --name argument from distrobox-stop usage docs

### DIFF
--- a/distrobox-stop
+++ b/distrobox-stop
@@ -125,7 +125,6 @@ distrobox version: ${version}
 
 Usage:
 
-	distrobox-stop --name container-name
 	distrobox-stop container-name
 
 Options:


### PR DESCRIPTION
Noticed this while doing some completions for Fish.  Looks like the `--name` argument was removed, but this usage example stayed the same.