### PR TITLE
docs: fix markdown lint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,11 +27,12 @@ Run the commands with `--verbose` and post the log here as a file upload
 Attach also the output of `podman logs` or `docker logs`, possibly with `--latest` flag
 
 **Desktop (please complete the following information):**
- - Are you using podman, docker or lilipod?
- - Which version or podman, docker or lilipod?
- - Which version of distrobox?
- - Which host distribution?
- - How did you install distrobox?
+
+- Are you using podman, docker or lilipod?
+- Which version or podman, docker or lilipod?
+- Which version of distrobox?
+- Which host distribution?
+- How did you install distrobox?
 
 **Additional context**
 Add any other context about the problem here.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,6 +5,8 @@ MD013:
   tables: false
   headings: false
   headers: false
+MD025: false
 MD033: false
 MD041: false
 MD045: false
+MD059: false

--- a/docs/useful_tips.md
+++ b/docs/useful_tips.md
@@ -9,6 +9,7 @@
   - [Duplicate an existing distrobox](#duplicate-an-existing-distrobox)
   - [Export to the host](#export-to-the-host)
   - [Execute commands on the host](#execute-commands-on-the-host)
+  <!-- markdownlint-disable-next-line MD051 -->
   - [Resolve "Error cannot open display: :0"](#resolve-error-cannot-open-display-0)
   - [Using init system inside a distrobox](#using-init-system-inside-a-distrobox)
   - [Using Docker inside a Distrobox](#using-docker-inside-a-distrobox)


### PR DESCRIPTION
Since `markdownlint` added new rules that are rendering the CI red, I felt like fixing it :heart: 