### PR TITLE
ci: ignore Neon and SteamOS when testing images

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -60,7 +60,7 @@ jobs:
       # Fetch from compatibility table all the distros supported
       - id: set-matrix
         run: |
-            skip_list="bazzite|slackware|stream8|ublue"
+            skip_list="bazzite|slackware|stream8|ublue|neon|steamos"
 
             echo "::set-output name=targets::$(sed -n -e '/| Alma/,/| Void/ p' docs/compatibility.md |
             cut -d'|' -f 4 |


### PR DESCRIPTION
Since these images tend to be _very_ flaky with distrobox we declare them compatible but we don't want to have a red CI just because of them :innocent: 