### PR TITLE
init: setup correct chimera base-full-man dep

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -669,7 +669,7 @@ setup_apk()
 		apk add chimera-repo-user
 		apk update
 		deps="
-			base-core-man
+			base-full-man
 			bash-completion
 			bc-gh
 			gtar


### PR DESCRIPTION
[`base-core-man`](https://github.com/chimera-linux/cports/blob/8f4bf92/main/base-full/template.py#L120-L121) has been transitional provider of this for a while and will eventually be dropped; I must've still copied this over from a much earlier version of the #1778 patch when I was experimenting long ago