### PR TITLE
Add Hyprland setup instructions to Distrobox guide

### DIFF
--- a/docs/posts/run_latest_gnome_kde_on_distrobox.md
+++ b/docs/posts/run_latest_gnome_kde_on_distrobox.md
@@ -7,6 +7,7 @@
       - [Running Latest Plasma](#running-latest-plasma)
         - [Generate session file - Plasma](#generate-session-file---plasma)
         - [Add a couple of fixes](#add-a-couple-of-fixes)
+      - [Running Latest Hyprland](#running-latest-hyprland)
     - [Using other GUIs](#using-other-guis)
     - [Using apps from host](#using-apps-from-host)
 
@@ -156,6 +157,33 @@ Let's log out and voilá!
 
 We now are in latest KDE Plasma session inside Fedora Rawhide while our main OS remains
 Centos.
+
+## Running Latest Hyprland
+
+Hyprland is a bit tricky because of how it is implemented. We will need to 
+create a container with access to `dri` and `input` devices, along with the dbus 
+socket that Wayland will use. Simply use this as a template:
+
+```shell
+distrobox-create -n hyprbox -i archlinux:latest \
+   --additional-flags "--device /dev/dri --device /dev/input -v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket"
+```
+
+Install Hyprland inside the container and then use the following line to start Hyprland:
+
+```shell
+distrobox-enter hyprbox -- bash -c '
+  #export XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
+  #export WAYLAND_DISPLAY=$WAYLAND_DISPLAY
+
+  exec Hyprland
+'
+```
+This will require you to not have any other Wayland sessions running. 
+
+If you want to run Hyprland on a second tty, set the `XDG_RUNTIME_DIR` and the 
+`WAYLAND_DISPLAY` variables to something unique. Otherwise, applications
+launched from the container will display on the first Wayland Display they see.
 
 # Using other GUIs
 


### PR DESCRIPTION
Added instructions for running the latest Hyprland session in Distrobox, including container creation and environment variable setup. I did not add any images, as I am unsure if they are needed.