### PR TITLE
init: exclude schroot mountpoint from socket search, improve performance.

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1925,6 +1925,7 @@ host_sockets="$(find /run/host/run \
 	-name 'user' -prune -o \
 	-name 'bees' -prune -o \
 	-name 'nscd' -prune -o \
+	-name 'schroot' -prune -o \
 	-name 'system_bus_socket' -prune -o \
 	-type s -print \
 	2> /dev/null || :)"


### PR DESCRIPTION
This fixes minute long start-up hangs when using distrobox on a host that has active schroot mounts, which I saw on my machine.