### PR TITLE
fix: indentation for --root usage in distrobox-create

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -200,7 +200,7 @@ Options:
 	--pull/-p:		pull the image even if it exists locally (implies --yes)
 	--yes/-Y:		non-interactive, pull images without asking
 	--root/-r:		launch podman/docker/lilipod with root privileges. This is the only supported way to run with root
-                privileges. Do not use "sudo distrobox". If you need to specify a different program (e.g. 'doas') for root privileges,
+				privileges. Do not use "sudo distrobox". If you need to specify a different program (e.g. 'doas') for root privileges,
 				use the DBX_SUDO_PROGRAM environment variable or the 'distrobox_sudo_program' config variable.
 	--clone/-c:		name of the distrobox container to use as base for a new container
 				this will be useful to either rename an existing distrobox or have multiple copies


### PR DESCRIPTION
In https://github.com/89luca89/distrobox/pull/1845 my editor accidentally replaced some tabs with spaces. This pull request fixes this mistake.