### PR TITLE
init: fix wrong $HOME when using --init

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1927,12 +1927,15 @@ host_sockets="$(find /run/host/run \
 	-name 'nscd' -prune -o \
 	-name 'schroot' -prune -o \
 	-name 'system_bus_socket' -prune -o \
+	-name 'io.systemd.Multiplexer' -prune -o \
+	-name 'io.systemd.DropIn' -prune -o \
+	-name 'io.systemd.NameServiceSwitch' -prune -o \
 	-type s -print \
 	2> /dev/null || :)"
 
-# we're excluding system dbus socket and nscd socket here. Including them will
+# we're excluding system dbus socket, nscd socket and systemd-userdbd sockets here. Including them will
 # create many problems with package managers thinking they have access to
-# system dbus or user auth cache misused.
+# system dbus, user auth cache misused or query wrong user information.
 for host_socket in ${host_sockets}; do
 	container_socket="$(printf "%s" "${host_socket}" | sed 's|/run/host||g')"
 	# Check if the socket already exists or the symlink already exists


### PR DESCRIPTION
Do not pass io.systemd.Multiplexer, and its symlinks, from host to container. Systemd, inside the container, used this socket to query for user information from the host, setting the $HOME from the host.

Fixes #1865.