### PR TITLE
docs: update command for GNOME installation

### DIFF
--- a/docs/posts/run_latest_gnome_kde_hyprland_on_distrobox.md
+++ b/docs/posts/run_latest_gnome_kde_hyprland_on_distrobox.md
@@ -46,7 +46,7 @@ distrobox enter fedora-rawhide
 First we need to install GNOME in the container:
 
 ```shell
-user@fedora-rawhide:~$ sudo dnf groupinstall GNOME
+user@fedora-rawhide:~$ sudo dnf group install gnome-desktop
 ```
 
 And let's grab a coffee while it finishes :-)


### PR DESCRIPTION
The current command used to install GNOME inside of Distrobox is incorrect, as the dnf command as well as the group name have changed.

Running `dnf group list --hidden` shows GNOME listed under `gnome-desktop`, which I have updated the group name to.

Also `groupinstall` was not a recognised argument in dnf.