### PR TITLE
use doas and doas-sudo-shim in alpine

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -709,7 +709,8 @@ setup_apk()
 		pigz
 		rsync
 		shadow
-		sudo
+		doas
+		doas-sudo-shim
 		tcpdump
 		tree
 		tzdata


### PR DESCRIPTION
Alpine defaults to 'doas' and the 'doas-sudo-shim' package is more than just a symlink. Since these are distro defaults, and most users won't notice a difference, this should be preferred.