### PR TITLE
init: fix stat syntax error in rootful detection

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -235,7 +235,7 @@ fi
 # a good thing, users behold!
 if stat /run/host/etc/shadow > /dev/null &&
 	{
-	        [ "$(stat -c "%u" /run/host/etc/shadow)" = "0" ] || [ "$(stat -f "%u" /run/host/etc/shadow 2>/dev/null)" = "0" ]
+		[ "$(stat -c "%u" /run/host/etc/shadow)" = "0" ] || [ "$(stat -f "%u" /run/host/etc/shadow 2> /dev/null)" = "0" ]
 	} &&
 	[ ! -e /run/.nopasswd ]; then
 	rootful=1


### PR DESCRIPTION
## Description
This fixes a logic bug that causes the error `stat: cannot read file system information for '%u'` to appear when initializing or entering a rootless container on Linux.

## The Issue
The rootful detection logic uses a lazy `||` operator to support both Linux (`stat -c`) and BSD/macOS (`stat -f`).

```bash
[ "$(stat -c "%u" ...)" = "0" ] || [ "$(stat -f "%u" ...)" = "0" ]
```

If a user is on Linux but is **not** root (e.g., UID 1000), the first check returns `False` (because 1000 != 0). Consequently, the shell executes the second command (the BSD syntax fallback).

On GNU `stat` (Linux), the `-f` flag stands for "file system status," not format. It interprets `%u` as a filename, fails to find it, and prints an error to stderr.

## The Fix

I added `2>/dev/null` to the BSD fallback command.

- On BSD/macOS: The command succeeds and prints the UID to stdout (logic holds).
- On Linux: The command fails, but the error message is suppressed, preventing the "No such file or directory" noise in the logs.

## Reference
A PR for this [bug](https://github.com/89luca89/distrobox/issues/1906)