### PR TITLE
docs: systemd unit example to mount root as a shared mount

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -99,11 +99,13 @@ To make it permanent, you can place it in `/etc/rc.local`.
 
 `/etc/rc.local` may be missing in your system.
 
-If your system uses `systemd`, here is how you can create and activate a systemd Service unit with the same functionality.
+If your system uses `systemd`, here is how you can create and activate a systemd Service unit with the same
+functionality.
 
 ##### Create the Service unit file
 
-Create `/etc/systemd/system/mount-root-shared.service` file using your favorite text editor (e.g. `sudo nano /etc/systemd/system/mount-root-shared.service`), with the following contents:
+Create `/etc/systemd/system/mount-root-shared.service` file using your favorite text editor (e.g. `sudo nano
+/etc/systemd/system/mount-root-shared.service`), with the following contents:
 
 ```systemd
 [Unit]
@@ -124,7 +126,8 @@ WantedBy=multi-user.target
 
 ##### Enable and start the Service
 
-The following command registers the service so it runs on every boot, and starts it immediately so you don't have to reboot for it to take effect:
+The following command registers the service so it runs on every boot, and starts it immediately so you don't have to
+reboot for it to take effect:
 
 ```sh
 sudo systemctl enable --now mount-root-shared.service


### PR DESCRIPTION
Hi.

Recently I decided to set up Distrobox on my (more-or-less) vanilla Ubuntu 24.04 host, and I ran into the "root filesystem is not mounted as a shared mount" problem.

The current compatibility page suggests to run `mount --make-rshared /` command and to add it to `/etc/rc.local` "to make it permanent". While `mount --make-rshared /` absolutely works, "add it to `/etc/rc.local`" does not. `/etc/rc.local` was not present on my system, and just creating it was not enough (it did nothing).

If I understand correctly, `/etc/rc.local` is considered deprecated (in Ubuntu, at least) in favor of systemd units, and to make it work you need to create some kind of `rc-local.service` - and there was no such service in my system.

If you need to interact with systemd anyway, you may as well create a proper service for the task. I believe this approach is more "in line" with what most distros consider "up to date".

Here I propose an addition to the compatibility page that explains how it can be done.

This solution is tested by me on my machine. But the service is quite simple, and I can't think of a reason why shouldn't it work on any other systemd-enabled system.