### PR TITLE
create: fix failing to create containers from images that print to stdout with no input

### DIFF
--- a/distrobox-create
+++ b/distrobox-create
@@ -946,7 +946,7 @@ generate_create_command()
 				--userns keep-id"
 
 			# Test if podman supports keep-id:size=
-			if podman run --rm --userns=keep-id:size=65536 "${container_image}" /bin/true 2> /dev/null || [ "$?" -eq 127 ]; then
+			if podman run --rm --userns=keep-id:size=65536 "${container_image}" /bin/true > /dev/null 2>&1 || [ "$?" -eq 127 ]; then
 				has_keepid_size=1
 			else
 				has_keepid_size=0


### PR DESCRIPTION
I was trying to create a distrobox from a container that I've built locally for a specific project, one that is intended to run as a standalone container and which prints to `stdout` even with no input. This means the command 
```
podman run --rm --userns=keep-id:size=65536 cl_sim /bin/true 2> /dev/null
echo $?
```
results in
```
No display found. Using Agg backend for matplotlib.
2
```
which is a problem, as `No display found. Use Agg backend for matplotlib.` ends up being placed at the top of the output for the `generate_create_command` output, resulting in something like this:

`+ cmd=$'No display found. Using Agg backend for matplotlib.\npodman --log-level debug create \n\t\t--hostname "apollo"\n\t\t--name "cl_sim"\n\t\t--privileged\n\t\t--security-opt label=disable\n\t\t--security-opt apparmor=unconfined\n\t\t--pids-limit=-1\n\t\t--user root:root\n\t\t\t--ipc host\n\t\t\t--network host\n\t\t\t--pid host\n\t\t--label "manager=distrobox"\n\t\t--label "distrobox.unshare_groups=0"\n\t\t--env "SHELL=zsh"\n\t\t--env "HOME=/home/brandon"\n\t\t--env "container=podman --log-level debug"\n\t\t--env "TERMINFO_DIRS=/usr/share/terminfo:/run/host/usr/share/terminfo"\n\t\t--env "CONTAINER_ID=cl_sim"\n\t\t--volume /tmp:/tmp:rslave\n\t\t--volume "/usr/bin/distrobox-init":/usr/bin/entrypoint:ro\n\t\t--volume "/usr/bin/distrobox-export":/usr/bin/distrobox-export:ro\n\t\t--volume "/usr/bin/distrobox-host-exec":/usr/bin/distrobox-host-exec:ro\n\t\t--volume "/home/brandon":"/home/brandon":rslave\n\t\t\t--volume /:/run/host/:rslave\n\t\t\t--volume /dev:/dev:rslave\n\t\t\t--volume /sys:/sys:rslave\n\t\t\t--volume /dev/pts\n\t\t\t--volume /dev/null:/dev/ptmx\n\t\t\t--volume /sys/fs/selinux\n\t\t\t--volume /var/log/journal\n\t\t\t--volume "/var/home/brandon":"/var/home/brandon":rslave\n\t\t\t--volume /run/user/1000:/run/user/1000:rslave\n\t\t\t\t\t--volume /etc/hosts:/etc/hosts:ro\n\t\t\t\t\t--volume /etc/resolv.conf:/etc/resolv.conf:ro\n\t\t\t\t\t--volume /etc/hostname:/etc/hostname:ro\n\t\t\t\t--runtime=crun\n\t\t\t--annotation run.oci.keep_original_groups=1\n\t\t\t--ulimit host\n\t\t\t\t--userns keep-id\n\t\t\n\t--entrypoint /usr/bin/entrypoint\n\tcl_sim\n\t\t--verbose\n\t\t--name "brandon"\n\t\t--user 1000\n\t\t--group 1000\n\t\t--home "/home/brandon"\n\t\t--init "0"\n\t\t--nvidia "0"\n\t\t--pre-init-hooks ""\n\t\t--additional-packages ""\n\t\t-- \'\'\n\t'`

This pull request modifies this line to silence both `stderror` and `stdout` in a way that should be safe for all systems, with
```
podman run --rm --userns=keep-id:size=65536 cl_sim /bin/true > /dev/null 2>&1
echo $?
```
now resulting in
```
2
```
and the script works without issues.