### PR TITLE
feat: set compopt filenames for --file in bash completion

### DIFF
--- a/completions/bash/distrobox
+++ b/completions/bash/distrobox
@@ -29,6 +29,7 @@ _generate_from_help() {
 
 	if [[ ${prev} =~ ${fileopts} ]]; then
 		COMPREPLY=($(compgen -f -- ${cur}))
+		compopt -o filenames
 		return 0
 	fi
 	if [[ ${prev} == "assemble" ]]; then


### PR DESCRIPTION
Currently it treats directories as filenames, so it puts a space after them, forcing you to replace the space with a slash to get completions in it.