### PR TITLE
init: restrict find pattern to libcuda so it doesn't pick up non-NVIDIA libs

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2081,7 +2081,7 @@ if [ "${nvidia}" -eq 1 ]; then
 	NVIDIA_LIBS="$(find /run/host/usr/lib*/ -not -type d \
 		-iname "*lib*nvidia*.so*" \
 		-o -iname "*nvidia*.so*" \
-		-o -iname "*cuda*.so*" \
+		-o -iname "libcuda*.so*" \
 		-o -iname "libnvcuvid*" \
 		-o -iname "libnvoptix*" || :)"
 	for nvidia_lib in ${NVIDIA_LIBS}; do


### PR DESCRIPTION
This patch restricts the find pattern to "libcuda*.so*", which matches the typical NVIDIA driver library names and prevents accidental matches such as libgstcuda-1.0.so.0 that can break package management inside the box.

ref: https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/internal/discover/symlinks.go#L111

## Example

```console
# before (will include libgstcuda, libicudata)
user@localhost:~$ find /usr/lib* -not -type d -iname '*cuda*.so*' -print
/usr/lib/libcuda.so
/usr/lib/libcuda.so.1
/usr/lib/libcuda.so.580.105.08
/usr/lib/libicudata.so.77 # <=============== icudata
/usr/lib/libicudata.so.77.1
/usr/lib64/libcuda.so
/usr/lib64/libcuda.so.1
/usr/lib64/libcuda.so.580.105.08
/usr/lib64/libcudadebugger.so.1
/usr/lib64/libcudadebugger.so.580.105.08
/usr/lib64/libgstcuda-1.0.so.0 # <========== gstreamer plugin
/usr/lib64/libgstcuda-1.0.so.0.2607.0
/usr/lib64/libicudata.so.77
/usr/lib64/libicudata.so.77.1

# after (should only show libcuda* driver libraries)
user@localhost:~$ find /usr/lib* -not -type d -iname 'libcuda*.so*' -print
/usr/lib/libcuda.so
/usr/lib/libcuda.so.1
/usr/lib/libcuda.so.580.105.08
/usr/lib64/libcuda.so
/usr/lib64/libcuda.so.1
/usr/lib64/libcuda.so.580.105.08
/usr/lib64/libcudadebugger.so.1
/usr/lib64/libcudadebugger.so.580.105.08
```

