### PR TITLE
fix: add missing fedora dependency

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1073,6 +1073,7 @@ setup_dnf()
 		tzdata
 		unzip
 		util-linux
+		util-linux-script
 		vte-profile
 		wget
 		which


### PR DESCRIPTION
Add `util-linux-script` as dnf dependency because
since fedora 42 the `script` command is split
from `util-linux`.