### PR TITLE
fix: unintended print to stdout in assemble command

### DIFF
--- a/distrobox-assemble
+++ b/distrobox-assemble
@@ -789,5 +789,5 @@ replace_line()
 
 # Exec
 expanded_file=$(mktemp -u)
-resolve_includes "${input_file}" "${expanded_file}"
+resolve_includes "${input_file}" "${expanded_file}" > /dev/null
 parse_file "${expanded_file}"


### PR DESCRIPTION
The `resolve_includes` function _returns_ the used temporary file path. As the value is not used, it should be redirected to /dev/null to retain it to print on screen.

To reproduce, just `distrobox assemble create` against any manifest file. 

```sh
> distrobox assemble create --file manifest.ini
/tmp/tmp.BmKsHG5Kxy
# ^^^^^ unintended print
```