### PR TITLE
Add missing dependencies for fedora and wolfi.

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -640,7 +640,9 @@ setup_apk()
 			man-db
 			mesa
 			openssh-client
+			pinentry
 			posix-libc-utils
+			script
 		"
 	elif apk add alpine-base; then
 		deps="


### PR DESCRIPTION
Add missing dependencies for Fedora and Wolfi.

- Fedora: `wget2-wget`
- Wolfi: `pinentry`, `script`