### PR TITLE
fix: make sure PWD matches workdir

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -423,6 +423,8 @@ generate_enter_command()
 	result_command="${result_command}
 		--workdir=${workdir}"
 	result_command="${result_command}
+		--env=PWD=${workdir}"
+	result_command="${result_command}
 		--env=CONTAINER_ID=${container_name}"
 	result_command="${result_command}
 		--env=DISTROBOX_ENTER_PATH=${distrobox_enter_path}"
@@ -437,7 +439,7 @@ generate_enter_command()
 	# and needs to stay that way to use custom home dirs. or it will be too talkative.
 	result_command="${result_command}
 		$(printenv | grep '=' | grep -Ev '"|`|\$' |
-		grep -Ev '^(CONTAINER_ID|FPATH|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)' |
+		grep -Ev '^(CONTAINER_ID|FPATH|HOST|HOSTNAME|HOME|PATH|PROFILEREAD|PWD|SHELL|XDG_SEAT|XDG_VTNR|XDG_.*_DIRS|^_)' |
 		sed 's/ /\ /g' | sed 's/^\(.*\)$/--env=\1/g')"
 
 	# Start with the $PATH set in the container's config


### PR DESCRIPTION
`--env PWD` can cause issues when it doesn't match the kernel pwd (set with `--workdir`).  Currently, this can happen when using a custom home directory.

closes #1951