### PR TITLE
fix: remove the error in case dependencies are not fully met

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1815,8 +1815,7 @@ if [ "${upgrade}" -ne 0 ] || [ ! -e /.containersetupdone ]; then
 	fi
 	if [ ! -e /.containersetupdone ]; then
 		if ! check_missing_packages; then
-			printf "Error: could not set up base dependencies.\n"
-			exit 128
+			printf "Warning: some dependencies are missing.\n"
 		fi
 		touch /.containersetupdone
 	fi


### PR DESCRIPTION
Introduced in #1932 as part of an effort to speed up the distrobox start. Erroring is too much, we noticed a lot of errors in the CI that were actually skippable, so removing the newly introduced error is an attempt to ease the pain on that side.

Following this approach, if a distrobox was "badly setup" it stays like that. Dependencies that are not found don't block the distrobox creation and don't cause any trouble. We just print a warning out of that.