### PR TITLE
docs: fix manpages generation by setting contents: write permissions

### DIFF
--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.distrobox_changed == 'True'
+    permissions:
+      contents: write
     steps:
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
Fixing permissions for the gen_man workflow.