### PR TITLE
ci: persist credentials in order to allow for manpages commit

### DIFF
--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -49,6 +49,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          persist-credentials: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Fetch from compatibility table all the distros supported


### PR DESCRIPTION
As above, we need to be able to commit using previously stored credentials.