### PR TITLE
docs: leverage PAT again for gen_man action

### DIFF
--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -49,8 +49,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
 
       # Fetch from compatibility table all the distros supported
       - id: generate


### PR DESCRIPTION
In order to bypass branch protection we need to leverage PATs.