### PR TITLE
fix: workaround podman stop/rm timeout in rootless mode with --pid host

### DIFF
--- a/distrobox-rm
+++ b/distrobox-rm
@@ -398,13 +398,14 @@ delete_container()
 	# create child cgroups. On systemd systems, systemd-logind automatically delegates
 	# user slices (e.g., /sys/fs/cgroup/user.slice/user-1000.slice/) to users.
 	# On non-systemd systems (OpenRC/elogind), this delegation is NOT automatic -
-	# users lack write permission to /sys/fs/cgroup, so rootless podman cannot create
-	# cgroups for containers.
+	# users lack write permission to /sys/fs/cgroup, so podman cannot create
+	# cgroups for containers. Similarly, if cgroup support is disabled entirely,
+	# even root cannot create cgroups.
 	#
-	# Root cause: Without cgroup delegation, crun cannot create a cgroup for the
-	# container. When cgroup-path is empty, "crun kill --all" cannot enumerate
-	# processes via cgroup, causing podman rm --force to timeout waiting for the
-	# container to stop.
+	# Root cause: Without available cgroup, crun cannot create a cgroup for the
+	# container. When cgroup-path is empty (or null), "crun kill --all" cannot
+	# enumerate processes via cgroup, causing podman rm --force to timeout waiting
+	# for the container to stop.
 	#
 	# Solution: Check if crun's cgroup-path is empty. If so, use "podman kill"
 	# first, which sends signal directly to the container's init process PID,
@@ -420,13 +421,17 @@ delete_container()
 	# Use --unshare-process when creating the container for full process cleanup.
 	# See: https://github.com/containers/podman/issues/11888
 	#
-	# To fix this properly on non-systemd systems, configure cgroup delegation:
+	# To fix this properly, configure cgroup delegation:
 	# https://github.com/89luca89/distrobox/issues/1939
 	#
 	# distrobox-rm does not call distrobox-stop by design; a similar fix exists there.
-	if [ "${container_status}" = "running" ] && [ "${rootful}" -eq 0 ] && echo "${container_manager}" | grep -q "podman"; then
+	if [ "${container_status}" = "running" ] && echo "${container_manager}" | grep -q "podman"; then
 		container_id=$(${container_manager} inspect --format '{{.Id}}' "${container_name}" 2> /dev/null)
-		crun_status="/run/user/$(id -u)/crun/${container_id}/status"
+		if [ "${rootful}" -eq 0 ]; then
+			crun_status="/run/user/$(id -u)/crun/${container_id}/status"
+		else
+			crun_status="/run/crun/${container_id}/status"
+		fi
 		if [ -f "${crun_status}" ]; then
 			cgroup_path=$(sed -n 's/.*"cgroup-path": "\([^"]*\)".*/\1/p' "${crun_status}" 2> /dev/null)
 			if [ -z "${cgroup_path}" ]; then

--- a/distrobox-stop
+++ b/distrobox-stop
@@ -299,13 +299,14 @@ case "${response}" in
 			# create child cgroups. On systemd systems, systemd-logind automatically delegates
 			# user slices (e.g., /sys/fs/cgroup/user.slice/user-1000.slice/) to users.
 			# On non-systemd systems (OpenRC/elogind), this delegation is NOT automatic -
-			# users lack write permission to /sys/fs/cgroup, so rootless podman cannot create
-			# cgroups for containers.
+			# users lack write permission to /sys/fs/cgroup, so podman cannot create
+			# cgroups for containers. Similarly, if cgroup support is disabled entirely,
+			# even root cannot create cgroups.
 			#
-			# Root cause: Without cgroup delegation, crun cannot create a cgroup for the
-			# container. When cgroup-path is empty, "crun kill --all" cannot enumerate
-			# processes via cgroup, causing podman stop to timeout waiting for the container
-			# to stop.
+			# Root cause: Without available cgroup, crun cannot create a cgroup for the
+			# container. When cgroup-path is empty (or null), "crun kill --all" cannot
+			# enumerate processes via cgroup, causing podman stop to timeout waiting for
+			# the container to stop.
 			#
 			# Solution: Check if crun's cgroup-path is empty. If so, use "podman kill"
 			# first, which sends signal directly to the container's init process PID,
@@ -321,11 +322,15 @@ case "${response}" in
 			# Use --unshare-process when creating the container for full process cleanup.
 			# See: https://github.com/containers/podman/issues/11888
 			#
-			# To fix this properly on non-systemd systems, configure cgroup delegation:
+			# To fix this properly, configure cgroup delegation:
 			# https://github.com/89luca89/distrobox/issues/1939
-			if [ "${rootful}" -eq 0 ] && echo "${container_manager}" | grep -q "podman"; then
+			if echo "${container_manager}" | grep -q "podman"; then
 				container_id=$(${container_manager} inspect --format '{{.Id}}' "${container_name}" 2> /dev/null)
-				crun_status="/run/user/$(id -u)/crun/${container_id}/status"
+				if [ "${rootful}" -eq 0 ]; then
+					crun_status="/run/user/$(id -u)/crun/${container_id}/status"
+				else
+					crun_status="/run/crun/${container_id}/status"
+				fi
 				if [ -f "${crun_status}" ]; then
 					cgroup_path=$(sed -n 's/.*"cgroup-path": "\([^"]*\)".*/\1/p' "${crun_status}" 2> /dev/null)
 					if [ -z "${cgroup_path}" ]; then


### PR DESCRIPTION
## Summary

`podman stop` / `podman rm --force` times out when crun's cgroup-path is empty. This commonly happens on non-systemd systems (OpenRC/elogind) where cgroup delegation is not automatically configured. The issue can affect both rootless and rootful modes when cgroup is unavailable.

## Background: cgroup delegation

In cgroup v2, only root can create sub-cgroups by default. "Delegation" means granting a non-root user write access to a cgroup subtree, allowing them to create child cgroups.

- **systemd systems**: systemd-logind automatically delegates user slices (e.g., `/sys/fs/cgroup/user.slice/user-1000.slice/`) to users.
- **non-systemd systems** (OpenRC/elogind): Delegation is NOT automatic - users lack write permission to `/sys/fs/cgroup`, so podman cannot create cgroups for containers.
- **cgroup disabled**: If cgroup support is disabled entirely, even root cannot create cgroups.

**To fix this properly**, configure cgroup delegation:
See: https://github.com/89luca89/distrobox/issues/1939

## Why `--pid host` is problematic but `--unshare-process` is not

This is due to Linux kernel's PID namespace behavior:

### With PID namespace isolation (default / `--unshare-process`)

When a container has its own PID namespace, the Linux kernel provides **automatic process cleanup**. According to [pid_namespaces(7)](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html):

> If the "init" process of a PID namespace terminates, the kernel terminates all of the processes in the namespace via a SIGKILL signal.

This is a **kernel-level guarantee** that doesn't depend on cgroup:
- Container's entry process is PID 1 in its namespace
- When PID 1 exits (or is killed), kernel automatically `SIGKILL`s all processes in that namespace
- This cleanup is mandatory and cannot be bypassed

### With `--pid host`

Container processes share the host's PID namespace:
- Container's entry process is NOT PID 1 (e.g., PID 12345 on host)
- No automatic kernel cleanup when the main process exits
- Child processes become orphans, adopted by host's init (systemd)
- **Must rely on cgroup** to track and kill all container processes

### Process cleanup mechanisms comparison

| Mode | Cleanup Mechanism | Depends on cgroup | Reliable |
|------|-------------------|-------------------|----------|
| PID namespace (default) | Kernel `zap_pid_ns_processes()` | No | ✅ Always |
| `--pid host` + cgroup available | `cgroup.kill` / `cgroup.procs` | Yes | ✅ Yes |
| `--pid host` + no cgroup | Signal to main process only | Yes (but broken) | ❌ No |

This PR provides a workaround for the last case (no reliable cleanup method exists).

## Root Cause

Without available cgroup, crun cannot create a cgroup for the container. When cgroup-path is empty (or null), `crun kill --all` cannot enumerate processes via cgroup, causing podman stop to timeout.

```
# Verification: cgroup-path is empty (no cgroup available)
$ podman create --name test --pid host alpine sleep infinity
$ cat /run/user/$(id -u)/crun/$(podman inspect test --format '{{.Id}}')/status | grep cgroup-path
    "cgroup-path": "",

# With proper cgroup delegation or on systemd systems, cgroup-path is NOT empty
    "cgroup-path": "/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-xxx.scope/container",
```

## Solution

Check if crun's cgroup-path is actually empty. If so, call `podman kill` before `stop`/`rm --force`, which sends signals directly to the container's init process PID, bypassing the cgroup lookup issue.

The workaround:
- Applies to both rootless (`/run/user/UID/crun/`) and rootful (`/run/crun/`) modes
- Is applied proactively (before stop/rm) rather than as a fallback, to avoid masking other potential failures
- Handles cgroup-path being empty string or null in JSON

## Limitation

This workaround only kills the init process, not orphaned child processes:
- Processes started via `podman exec` (e.g., distrobox-enter) run in separate process groups
- Daemonized processes (setsid/double-fork) have different PGIDs (https://github.com/containers/podman/issues/11888)

This is a known limitation without proper cgroup (see containers/podman#11888). To ensure all processes are cleaned up, use `--unshare-process` when creating the container.

A warning is displayed when the workaround is applied, with a link to the fix documentation.

## Changes

- `distrobox-stop`: Check crun cgroup-path; if empty, call `podman kill` first and show warning
- `distrobox-rm`: Check crun cgroup-path; if empty, call `podman kill` first and show warning
- Support both rootless and rootful crun status paths

## Test Results

| Environment | cgroup-path | Workaround | Result |
|-------------|-------------|------------|--------|
| Gentoo rootless (no delegation) | empty | ✅ applied | 0.25s ✅ |
| Gentoo rootless (with delegation) | valid | ❌ not needed | 0.21s ✅ |
| Gentoo rootful | valid | ❌ not needed | 0.29s ✅ |
| Fedora (systemd) | valid | ❌ not needed | 0.23s ✅ |

Closes #1939
See also: https://github.com/chimera-linux/cports/issues/1718