### PR TITLE
distrobox-init: add newline when appending user via printf

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2358,7 +2358,7 @@ if ! grep -q "^${container_user_name}:" /etc/group; then
 	if ! groupadd --force --gid "${container_user_gid}" "${container_user_name}"; then
 		# It may occur that we have users with unsupported user name (eg. on LDAP or AD)
 		# So let's try and force the group creation this way.
-		printf "%s:x:%s:" "${container_user_name}" "${container_user_gid}" >> /etc/group
+		printf "%s:x:%s:\n" "${container_user_name}" "${container_user_gid}" >> /etc/group
 	fi
 fi
 ###############################################################################
@@ -2420,7 +2420,7 @@ if ! grep -q "^$(printf '%s' "${container_user_name}" | tr '\\' '.'):" /etc/pass
 
 		printf "Warning: There was a problem setting up the user with usermod, trying manual addition\n"
 
-		printf "%s:x:%s:%s:%s:%s:%s" \
+		printf "%s:x:%s:%s:%s:%s:%s\n" \
 			"${container_user_name}" "${container_user_uid}" \
 			"${container_user_gid}" "${container_user_name}" \
 			"${container_user_home}" "${SHELL:-"/bin/bash"}" >> /etc/passwd
@@ -2452,7 +2452,7 @@ elif [ ! -e /etc/passwd.done ]; then
 		# Modify the user
 		printf "distrobox: Setting up existing user: /etc/passwd...\n"
 		sed -i "s|^${container_user_name}.*||g" /etc/passwd
-		printf "%s:x:%s:%s:%s:%s:%s" \
+		printf "%s:x:%s:%s:%s:%s:%s\n" \
 			"${container_user_name}" "${container_user_uid}" \
 			"${container_user_gid}" "${container_user_name}" \
 			"${container_user_home}" "${SHELL:-"/bin/bash"}" >> /etc/passwd


### PR DESCRIPTION
The manual write of a user via printf to /etc/passwd and /etc/group is missing a newline at the end of file.
That results in a failure in useradd parsing the content of the file in the __getdelim function.

For details, see: https://bugzilla.suse.com/show_bug.cgi?id=1257302