### PR TITLE
fix: Pass -xdev to /bin/find

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -1937,6 +1937,7 @@ printf "distrobox: Setting up host's sockets integration...\n"
 # for example using `podman --remote` to control the host's podman from inside
 # the container or accessing docker and libvirt sockets.
 host_sockets="$(find /run/host/run \
+	-xdev \
 	-path /run/host/run/media -prune -o \
 	-path /run/host/run/timeshift -prune -o \
 	-name 'user' -prune -o \


### PR DESCRIPTION
I had mounted my Docker at `/run/home/docker`. Docker then mounted my home folder somewhere under an overlayfs folder there. Distrobox had appeared frozen at "Setting up host's sockets integration..." as it tried to traverse my entire home directory on a slow hard disk.

No relevant socket was found on any submount, so excluding the submounts should be OK.