### PR TITLE
fix: nvidia library resolution on merged-lib guests (e.g. Arch)

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2106,7 +2106,8 @@ if [ "${nvidia}" -eq 1 ]; then
 	if [ -e "/usr/lib/x86_64-linux-gnu" ]; then
 		lib64_dir="/usr/lib/x86_64-linux-gnu/"
 		lib32_dir="/usr/lib/i386-linux-gnu/"
-	elif [ -e "/usr/lib64" ]; then
+	elif [ -e "/usr/lib64" ] && [ ! -L "/usr/lib64" ]; then
+		# /usr/lib64 is a real, separate directory (RPM-based guest distros)
 		lib64_dir="/usr/lib64/"
 	fi
 	if [ -e "/usr/lib32" ]; then
@@ -2119,7 +2120,17 @@ if [ "${nvidia}" -eq 1 ]; then
 	#
 	# /usr/lib64 is common in Arch or RPM based distros, while /usr/lib/x86_64-linux-gnu is
 	# common on Debian derivatives, so we need to adapt between the two nomenclatures.
-	NVIDIA_LIBS="$(find /run/host/usr/lib*/ -not -type d \
+	#
+	# We search lib64 before lib so that on merged-lib guests (e.g. Arch,
+	# where /usr/lib64 is a symlink to /usr/lib), 64-bit host libraries are
+	# mounted first and the "file exists" check below skips the 32-bit
+	# duplicates from the host's /usr/lib/.
+	host_lib_search_paths=""
+	for _hlsp in /run/host/usr/lib64 /run/host/usr/lib32 /run/host/usr/lib; do
+		[ -d "$_hlsp" ] && host_lib_search_paths="${host_lib_search_paths} ${_hlsp}/"
+	done
+	# shellcheck disable=SC2086
+	NVIDIA_LIBS="$(find ${host_lib_search_paths} -not -type d \
 		-iname "*lib*nvidia*.so*" \
 		-o -iname "*nvidia*.so*" \
 		-o -iname "libcuda*.so*" \


### PR DESCRIPTION
## Summary

- Fixes `nvidia-smi` (and other 64-bit nvidia tools) failing with `incompatible ELF class` inside Arch Linux distroboxes on Fedora/Bazzite hosts with `--nvidia`
- The root cause is that Fedora puts 32-bit nvidia libs in `/usr/lib/` and 64-bit in `/usr/lib64/`, but Arch has `/usr/lib64` → `/usr/lib` (merged-lib layout), so both map to the same directory and the 32-bit versions win
- Two changes: (1) don't treat `/usr/lib64` as a separate directory when it's a symlink, (2) search host `lib64` before `lib` so 64-bit libs are mounted first and the existing "file exists" check skips 32-bit duplicates

## Reproducer

```bash
# On Bazzite (or any Fedora immutable with nvidia)
distrobox create --name test --init --image archlinux:latest --nvidia
distrobox enter test -- nvidia-smi
# NVIDIA-SMI couldn't find libnvidia-ml.so library in your system.
```

Root cause visible with `LD_DEBUG`:
```
trying file=/usr/lib/libnvidia-ml.so.1
    (incompatible ELF class)
```

The file at `/usr/lib/libnvidia-ml.so.1` is 32-bit (from host's `/usr/lib/`) while `nvidia-smi` is 64-bit.

## Test plan

- [ ] Verify `nvidia-smi` works in Arch distrobox on Fedora/Bazzite host with `--nvidia`
- [ ] Verify nvidia integration still works on Fedora guest (real `/usr/lib64/` directory)
- [ ] Verify nvidia integration still works on Debian/Ubuntu guest (`x86_64-linux-gnu` layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)