### PR TITLE
init: chmod shadow files to 0400 for container storage compatibility

### DIFF
--- a/distrobox-init
+++ b/distrobox-init
@@ -2621,6 +2621,13 @@ fi
 
 # Now we're done
 touch /etc/passwd.done
+
+# Ensure shadow files are readable by root without relying on CAP_DAC_OVERRIDE,
+# which may not be effective on all container storage drivers (e.g. fuse-overlayfs
+# in rootless mode, or VMs like Docker Desktop / Colima on macOS).
+# Fedora/Arch ship these as mode 000, expecting the capability to bypass DAC.
+chmod 0400 /etc/shadow 2> /dev/null || :
+chmod 0400 /etc/gshadow 2> /dev/null || :
 ###############################################################################
 
 ###############################################################################


### PR DESCRIPTION
On container storage drivers where CAP_DAC_OVERRIDE is not effective (e.g. fuse-overlayfs in rootless mode, or VMs like Docker Desktop / Colima on macOS), root cannot read files with mode 000 despite having the capability in its effective set. This causes pam_unix.so account management to fail with "Authentication service cannot retrieve authentication info" when calling getspnam(), because glibc's NSS files backend cannot open /etc/shadow.

Fedora and Arch ship /etc/shadow and /etc/gshadow as mode 000, relying on CAP_DAC_OVERRIDE to grant root access. Set them to 0400 (owner-read) after password setup so that standard POSIX owner checks suffice.