### PR TITLE
init: also clean empty unversioned .so stubs during nvidia setup

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -2004,7 +2004,9 @@ if [ "${nvidia}" -eq 1 ]; then
 	# Refresh ldconfig cache, also detect if there are empty files remaining
 	# and clean them.
 	# This could happen when upgrading drivers and changing versions.
-	find /usr/lib* -empty -iname "*.so.*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
+	# Use "*.so*" instead of "*.so.*" to also match unversioned .so stubs
+	# (e.g. libcuda.so, libnvcuvid.so) that block CUDA detection. See #1764.
+	find /usr/lib* -empty -iname "*.so*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
 	find /usr/ /etc/ -empty -iname "*nvidia*" -exec sh -c 'rm -rf "$1" || umount "$1" && rm -rf "$1"' sh {} ';' || :
 
 	# First we find all generic config files we might need


### PR DESCRIPTION
Port of #2024 to the `next` branch.

## Summary

- Fixes empty unversioned `.so` stubs (e.g. `libcuda.so`, `libnvcuvid.so`) not being cleaned up during `--nvidia` initialization
- The existing glob `*.so.*` only matches versioned libraries but misses unversioned ones, which remain as 0-byte files after driver upgrades
- Applications that `dlopen()` the unversioned name (e.g. DaVinci Resolve for CUDA) load the empty stub and silently fall back to OpenCL
- Widens the glob from `*.so.*` to `*.so*` so both versioned and unversioned empty stubs are removed before host driver bind-mounts
- We use this fix to run DaVinci Resolve Studio inside distrobox with `--nvidia` — without it, Resolve silently loses CUDA support after every driver update and freezes on the Edit page

Fixes #1764

## Test plan

- [x] Create a distrobox with `--nvidia` on a host with NVIDIA drivers
- [x] Verify `ls -la /usr/lib64/libcuda.so` is not a 0-byte file after container restart
- [x] Verify CUDA-dependent applications (e.g. DaVinci Resolve, `nvidia-smi`) detect CUDA correctly
- [x] Verify no regression: non-empty `.so` files are not affected (the `find` uses `-empty`)
- [x] Tested with DaVinci Resolve Studio in davincibox on Fedora Atomic (Bazzite) with RTX 4080 and NVIDIA driver 595.58.03