### PR TITLE
fix: remove breaking spaces exported desktop files

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-export
+++ b/internal/inside-distrobox/assets/distrobox-export
@@ -288,7 +288,7 @@ if [ "${is_sudo}" -ne 0 ]; then
 fi
 
 # Prefix to add to an existing command to work through the container
-container_command_prefix="${DISTROBOX_PATH:-"distrobox"} enter ${rootful} -n ${container_name} ${enter_flags} -- ${sudo_prefix} "
+container_command_prefix="${DISTROBOX_PATH:-"distrobox"} enter${rootful:+ ${rootful}} -n ${container_name}${enter_flags:+ ${enter_flags}} --${sudo_prefix:+ ${sudo_prefix}} "
 
 if [ -n "${rootful}" ]; then
 	container_command_prefix="env SUDO_ASKPASS=\"${sudo_askpass_path}\" DBX_SUDO_PROGRAM=\"sudo --askpass\" ${container_command_prefix}"
@@ -564,8 +564,8 @@ export_application()
 		# Add closing quote
 		# If a TryExec is present, we have to fake it as it will not work
 		# through the container separation
-		sed "s|^Exec=\(.*\)|Exec=${container_command_prefix} \1 |g" "${desktop_file}" |
-			sed "s|\(%.*\)|${extra_flags} \1|g" |
+		sed "s|^Exec=\(.*\)|Exec=${container_command_prefix}\1|g" "${desktop_file}" |
+			sed "s|\(%.*\)|${extra_flags:+${extra_flags} }\1|g" |
 			sed "/^TryExec=.*/d" |
 			sed "/^DBusActivatable=true/d" |
 			sed "s|Name.*|&${exported_app_label}|g" \

--- a/pkg/commands/assets/desktop_entry.toml.tmpl
+++ b/pkg/commands/assets/desktop_entry.toml.tmpl
@@ -3,7 +3,7 @@ Name={{.entry_name}}
 GenericName=Terminal entering {{.entry_name}}
 Comment=Terminal entering {{.entry_name}}
 Categories=Distrobox;System;Utility
-Exec={{.distrobox_path}} enter {{.extra_flags}} {{.container_name}}
+Exec={{.distrobox_path}} enter{{if .extra_flags}} {{.extra_flags}}{{end}} {{.container_name}}
 Icon={{.icon}}
 Keywords=distrobox;
 NoDisplay=false
@@ -14,4 +14,4 @@ Actions=Remove;
 
 [Desktop Action Remove]
 Name=Remove {{.entry_name}} from system
-Exec={{.distrobox_path}} rm {{.extra_flags}} {{.container_name}}
+Exec={{.distrobox_path}} rm{{if .extra_flags}} {{.extra_flags}}{{end}} {{.container_name}}

--- a/pkg/commands/generate_entry_test.go
+++ b/pkg/commands/generate_entry_test.go
@@ -52,7 +52,7 @@ Name=Test-container
 GenericName=Terminal entering Test-container
 Comment=Terminal entering Test-container
 Categories=Distrobox;System;Utility
-Exec=/usr/bin/distrobox enter  test-container
+Exec=/usr/bin/distrobox enter test-container
 Icon=https://raw.githubusercontent.com/89luca89/distrobox/main/icons/terminal-distrobox-icon.svg
 Keywords=distrobox;
 NoDisplay=false
@@ -63,7 +63,8 @@ Actions=Remove;
 
 [Desktop Action Remove]
 Name=Remove Test-container from system
-Exec=/usr/bin/distrobox rm  test-container`
+Exec=/usr/bin/distrobox rm test-container
+`
 
 	content, err := os.ReadFile(expectedEntryPath)
 	if err != nil {
@@ -143,7 +144,8 @@ Actions=Remove;
 
 [Desktop Action Remove]
 Name=Remove Test-container from system
-Exec=/usr/bin/distrobox rm --root test-container`
+Exec=/usr/bin/distrobox rm --root test-container
+`
 
 	content, err := os.ReadFile(expectedEntryPath)
 	if err != nil {


### PR DESCRIPTION
I noticed some issues when exporting vscode to my host.

Due to not having any of the rootful/enter_flags/sudo_prefix options set, the Exec command of the exported desktop file had too many spaces, not following standards, and causing bemenu to be unable to launch them.
The same issue was present for the extra_flags.

The solution was to use shell parameter expansion instead of just listing the parameters.

Examples before the fix:
- Exporting an app.
`Exec=/usr/bin/distrobox-enter  -n devel  --   /usr/share/code/code  %F `
- Generating desktop entry
`Exec=/usr/bin/distrobox enter  devel`

After fix:
- Exporting an app.
`Exec=/usr/bin/distrobox-enter -n devel -- /usr/share/code/code %F`
- Generating desktop entry
`Exec=/usr/bin/distrobox enter devel`