### PR TITLE
fix: correct su argument order for unshare_groups containers

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -621,12 +621,12 @@ fi
 # command using su $container_command_user
 # if we're in a tty, also allocate one
 if [ "${unshare_groups:-0}" -eq 1 ]; then
-	# shellcheck disable=SC2089,SC2016
 	# su(1) expects: su [options] [-] [user [argument...]]
 	# All options must come before the user, or strict su implementations
 	# (e.g. util-linux 2.42) treat them as shell arguments.
 	set -- "${container_command_user}" "$@"
 	set -- "--" "$@"
+	# shellcheck disable=SC2089,SC2016
 	set -- "-c" '"$0" "$@"' "$@"
 	set -- "-s" "/bin/sh" "$@"
 	if [ "${headless}" -eq 0 ]; then

--- a/distrobox-enter
+++ b/distrobox-enter
@@ -579,6 +579,18 @@ container_home="${HOME}"
 container_path="${PATH}"
 unshare_groups=0
 
+# Inspect the container we're working with.
+# This must happen before the command setup below, because unshare_groups,
+# container_home and container_path are needed by both the su block and
+# generate_enter_command.
+container_status="unknown"
+eval "$(${container_manager} inspect --type container --format \
+	'container_status={{.State.Status}};
+	unshare_groups={{ index .Config.Labels "distrobox.unshare_groups" }};
+	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "HOME=")}}container_home={{slice . 5 | printf "%q"}}{{end}}{{end}};
+	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "PATH=")}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
+	"${container_name}")"
+
 ################################################################################
 # In this section we will manipulate the positional parameters
 # in order to generate our long docker/podman/lilipod command to execute.
@@ -610,13 +622,17 @@ fi
 # if we're in a tty, also allocate one
 if [ "${unshare_groups:-0}" -eq 1 ]; then
 	# shellcheck disable=SC2089,SC2016
-	set -- "-c" '"$0" "$@"' -- "$@"
+	# su(1) expects: su [options] [-] [user [argument...]]
+	# All options must come before the user, or strict su implementations
+	# (e.g. util-linux 2.42) treat them as shell arguments.
+	set -- "${container_command_user}" "$@"
+	set -- "--" "$@"
+	set -- "-c" '"$0" "$@"' "$@"
 	set -- "-s" "/bin/sh" "$@"
 	if [ "${headless}" -eq 0 ]; then
 		set -- "--pty" "$@"
 	fi
 	set -- "-m" "$@"
-	set -- "${container_command_user}" "$@"
 	set -- "su" "$@"
 fi
 
@@ -630,15 +646,6 @@ if [ "${dryrun}" -ne 0 ]; then
 	printf "%s %s\n" "${cmd}" "$*"
 	exit 0
 fi
-
-# Now inspect the container we're working with.
-container_status="unknown"
-eval "$(${container_manager} inspect --type container --format \
-	'container_status={{.State.Status}};
-	unshare_groups={{ index .Config.Labels "distrobox.unshare_groups" }};
-	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "HOME=")}}container_home={{slice . 5 | printf "%q"}}{{end}}{{end}};
-	{{range .Config.Env}}{{if and (ge (len .) 5) (eq (slice . 0 5) "PATH=")}}container_path={{slice . 5 | printf "%q"}}{{end}}{{end}}' \
-	"${container_name}")"
 
 # Check if the container is even there
 if [ "${container_status}" = "unknown" ]; then


### PR DESCRIPTION
## Summary

Two related bugs when entering containers with `--unshare-groups` (or `--init`):

1. **Container inspect ran after the su block** — `unshare_groups` was always 0, so the `su` user switch never executed, entering as root instead of the host user.

2. **su argument order was wrong** — the username was placed before options like `--pty`, `-s` and `-c`. Strict `su` implementations (e.g. util-linux 2.42 on Arch Linux) stop option parsing at the first non-option argument, treating the remaining flags as shell arguments. This causes `zsh: no such option: pty` or `bash: --: invalid option`.

## Fix

- Move container inspect before the command setup so `unshare_groups` is read from the container label in time.
- Place the user after `--` so all su options are parsed correctly:
  Before: `su user -m --pty -s /bin/sh -c ...`
  After: `su -m --pty -s /bin/sh -c ... -- user ...`

Fixes #2011