### PR TITLE
fix(enter): su argument order in unshare_groups path (legacy)

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -611,12 +611,12 @@ fi
 if [ "${unshare_groups:-0}" -eq 1 ]; then
 	# shellcheck disable=SC2089,SC2016
 	set -- "-c" '"$0" "$@"' -- "$@"
+	set -- "${container_command_user}" "$@"
 	set -- "-s" "/bin/sh" "$@"
 	if [ "${headless}" -eq 0 ]; then
 		set -- "--pty" "$@"
 	fi
 	set -- "-m" "$@"
-	set -- "${container_command_user}" "$@"
 	set -- "su" "$@"
 fi
 


### PR DESCRIPTION
## Summary

Fix the `su` argument order used by `distrobox-enter` in the `unshare_groups` path.

The current code builds:

```sh
su USER -m --pty -s /bin/sh -c ...
```

This is fragile because `su` documents its syntax as:

```sh
su [options] [-] [user|UID [argument...]]
```

When `user` is specified, additional arguments may be passed to the target shell. In practice, this makes the argument order significant.

This patch changes the generated order to:

```sh
su -m --pty -s /bin/sh USER -c ...
```

without changing the existing argument-wrapping strategy.

## Why this matters

This became user-visible for me on Arch in the `--init` / `unshare_groups` path when the target shell was `zsh`.

Minimal reproducer:

```sh
su USER -m --pty -s /bin/sh -c 'echo OK'
```

Observed on Arch:

* util-linux 2.41.3-2: works
* util-linux 2.42-1: fails with `zsh: no such option: pty`

There is also an external Debian report showing a related util-linux 2.42 regression in `su` shell / argument handling:

* [Debian Bug#1132610](https://www.mail-archive.com/debian-bugs-dist%40lists.debian.org/msg2093584.html): `su <user> -s /bin/sh -c ...` behavior changed in 2.42

I am not claiming distrobox should depend on permissive parsing here. The fix is simply to emit `su` arguments in a robust order.

## Reproducer

The problem is visible in the current ordering:

```sh
su USER -m --pty -s /bin/sh -c 'echo OK'
```

and is fixed by the equivalent robust ordering:

```sh
su -m --pty -s /bin/sh USER -c 'echo OK'
```

## Fix

Move `container_command_user` so that all `su` options are emitted before the username.

## Notes

This is a minimal fix:

* no behavior change outside the `unshare_groups` path
* no rewrite of the existing `set -- ... "$@"` strategy
* only argument ordering is corrected
