### PR TITLE
fix(providers): execute correct binary for podman-launcher provider

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -106,7 +106,7 @@ func beforeAction(ctx context.Context, cmd *cli.Command) (context.Context, error
 
 func printMissingContainerManager(p *ui.Printer) {
 	p.Println("Missing dependency: we need a container manager.")
-	p.Println("Please install one of podman or docker.")
+	p.Println("Please install one of podman, podman-launcher, or docker.")
 	p.Println("You can follow the documentation on:")
 	p.Println("\tman distrobox-compatibility")
 	p.Println("or:")
@@ -115,7 +115,7 @@ func printMissingContainerManager(p *ui.Printer) {
 
 func printInvalidContainerManager(p *ui.Printer, containerManagerType string) {
 	p.Println("Invalid input %s.", containerManagerType)
-	p.Println("The available choices are: 'autodetect', 'podman', 'docker'")
+	p.Println("The available choices are: 'autodetect', 'podman', 'podman-launcher', 'docker'")
 }
 
 func validateSudo(ctx context.Context) error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,7 +84,7 @@ func beforeAction(ctx context.Context, cmd *cli.Command) (context.Context, error
 	case "podman":
 		containerManager = providers.NewPodman(root, sudoCommand, verbose)
 	case "podman-launcher":
-		containerManager = providers.NewPodman(root, sudoCommand, verbose)
+		containerManager = providers.NewPodmanLauncher(root, sudoCommand, verbose)
 	case "autodetect", "":
 		var err error
 		containerManager, err = providers.NewAutoDetect(root, sudoCommand, verbose)

--- a/pkg/containermanager/providers/autodetect.go
+++ b/pkg/containermanager/providers/autodetect.go
@@ -17,7 +17,7 @@ func NewAutoDetect(root bool, sudoCommand string, verbose bool) (containermanage
 		return NewPodman(root, sudoCommand, verbose), nil
 	}
 	if _, err := exec.LookPath("podman-launcher"); err == nil {
-		return NewPodman(root, sudoCommand, verbose), nil
+		return NewPodmanLauncher(root, sudoCommand, verbose), nil
 	}
 	if _, err := exec.LookPath("docker"); err == nil {
 		return NewDocker(root, sudoCommand, verbose), nil

--- a/pkg/containermanager/providers/autodetect_test.go
+++ b/pkg/containermanager/providers/autodetect_test.go
@@ -36,7 +36,7 @@ func TestNewAutoDetect(t *testing.T) {
 		{
 			name:         "podman-launcher only",
 			binaries:     []string{"podman-launcher"},
-			expectedName: "podman",
+			expectedName: "podman-launcher",
 		},
 		{
 			name:        "nothing available",

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -54,7 +54,7 @@ func NewPodmanLauncher(root bool, sudoCommand string, verbose bool) *Podman {
 }
 
 func (p *Podman) Name() string {
-	return "podman"
+	return string(p.command)
 }
 
 // podmanContainer represents the JSON output from `podman ps --format json`.
@@ -155,8 +155,6 @@ func (p *Podman) makeCreateCommand(
 	distroboxExportPath string,
 	distroboxHostexecPath string,
 ) []string {
-	containerManager := p.Name()
-
 	containerUserHome := userEnv.Home
 	containerUserName := userEnv.User
 	containerUserUID := userEnv.UserID
@@ -207,7 +205,7 @@ func (p *Podman) makeCreateCommand(
 	)
 	options = append(options, "--env", fmt.Sprintf("SHELL=%s", shellFilepath))
 	options = append(options, "--env", fmt.Sprintf("HOME=%s", containerUserHome))
-	options = append(options, "--env", fmt.Sprintf("container=%s", containerManager))
+	options = append(options, "--env", "container=podman")
 	options = append(
 		options,
 		"--env",

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -20,19 +20,37 @@ import (
 )
 
 type Podman struct {
+	command     podmanCommand
 	root        bool
 	sudoCommand string
 	verbose     bool
 }
 
+// podmanCommand represents the executable name for the Podman provider.
+type podmanCommand string
+
+const (
+	podmanCommandPodman   podmanCommand = "podman"
+	podmanCommandLauncher podmanCommand = "podman-launcher"
+)
+
 var _ containermanager.ContainerManager = &Podman{}
 
-func NewPodman(root bool, sudoCommand string, verbose bool) *Podman {
+func newPodman(command podmanCommand, root bool, sudoCommand string, verbose bool) *Podman {
 	return &Podman{
+		command:     command,
 		sudoCommand: sudoCommand,
 		root:        root,
 		verbose:     verbose,
 	}
+}
+
+func NewPodman(root bool, sudoCommand string, verbose bool) *Podman {
+	return newPodman(podmanCommandPodman, root, sudoCommand, verbose)
+}
+
+func NewPodmanLauncher(root bool, sudoCommand string, verbose bool) *Podman {
+	return newPodman(podmanCommandLauncher, root, sudoCommand, verbose)
 }
 
 func (p *Podman) Name() string {
@@ -436,7 +454,7 @@ func (p *Podman) Exists(ctx context.Context, containerName string) bool {
 }
 
 func (p *Podman) run(ctx context.Context, args []string, opts runOptions) (string, error) {
-	command := p.Name()
+	command := string(p.command)
 	if p.root {
 		args = append([]string{command}, args...)
 		command = p.sudoCommand

--- a/pkg/containermanager/providers/podman_internal_test.go
+++ b/pkg/containermanager/providers/podman_internal_test.go
@@ -612,6 +612,11 @@ func TestPodman_Name(t *testing.T) {
 	if podman.Name() != "podman" {
 		t.Errorf("Expected Name() to return 'podman', got '%s'", podman.Name())
 	}
+
+	launcher := NewPodmanLauncher(false, "sudo", false)
+	if launcher.Name() != "podman-launcher" {
+		t.Errorf("Expected Name() to return 'podman-launcher', got '%s'", launcher.Name())
+	}
 }
 
 func TestParsePodmanContainerList(t *testing.T) {

--- a/pkg/containermanager/providers/podman_internal_test.go
+++ b/pkg/containermanager/providers/podman_internal_test.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -704,6 +706,54 @@ func TestParsePodmanContainerListEmptyNames(t *testing.T) {
 			}
 			if containers[0].ID != tt.wantID {
 				t.Errorf("Expected ID %q, got %q", tt.wantID, containers[0].ID)
+			}
+		})
+	}
+}
+
+func TestPodman_runUsesCorrectBinary(t *testing.T) {
+	tests := []struct {
+		name           string
+		constructor    func() *Podman
+		expectedPrefix string
+	}{
+		{
+			name:           "NewPodman uses podman binary",
+			constructor:    func() *Podman { return NewPodman(false, "sudo", false) },
+			expectedPrefix: "podman ",
+		},
+		{
+			name:           "NewPodmanLauncher uses podman-launcher binary",
+			constructor:    func() *Podman { return NewPodmanLauncher(false, "sudo", false) },
+			expectedPrefix: "podman-launcher ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := tt.constructor()
+
+			// Capture stdout during DryRun
+			origStdout := os.Stdout
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("failed to create pipe: %v", err)
+			}
+			os.Stdout = w //nolint:reassign // redirect stdout to capture dry-run output in test
+
+			_, _ = p.run(t.Context(), []string{"info"}, runOptions{DryRun: true})
+
+			w.Close()
+			os.Stdout = origStdout //nolint:reassign // restore original stdout
+
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(r); err != nil {
+				t.Fatalf("failed to read captured output: %v", err)
+			}
+			got := buf.String()
+
+			if !strings.HasPrefix(got, tt.expectedPrefix) {
+				t.Errorf("expected output to start with %q, got %q", tt.expectedPrefix, got)
 			}
 		})
 	}


### PR DESCRIPTION
 Add `command` field to the `Podman` provider to select between `podman` and `podman-launcher` executables. 
 
 Introduce `NewPodmanLauncher` constructor so autodetect and CLI both invoke the right binary at runtime.
 
 
 Leftover of: #2046 