### PR TITLE
feat: Implement "Remove" action on exported apps to delete them

### DIFF
--- a/distrobox-enter
+++ b/distrobox-enter
@@ -100,7 +100,7 @@ non_interactive=0
 # We're not using "realpath" here so that symlinks are not resolved this way
 # "realpath" would break situations like Nix or similar symlink based package
 # management.
-distrobox_enter_path="$(cd "$(dirname "$0")" && pwd)/distrobox-enter"
+distrobox_path="$(cd "$(dirname "$0")" && pwd)/distrobox"
 dryrun=0
 headless=0
 # If the user runs this script as root in a login shell, set rootful=1.
@@ -363,7 +363,7 @@ fi
 #   skip_workdir: bool skip workdir
 #   verbose: bool verbose
 #   unshare_groups
-#   distrobox_enter_path
+#   distrobox_path
 # Expected env variables:
 #   PATH
 #   USER
@@ -427,7 +427,7 @@ generate_enter_command()
 	result_command="${result_command}
 		--env=CONTAINER_ID=${container_name}"
 	result_command="${result_command}
-		--env=DISTROBOX_ENTER_PATH=${distrobox_enter_path}"
+		--env=DISTROBOX_PATH=${distrobox_path}"
 
 	# Loop through all the environment vars
 	# and export them to the container.

--- a/distrobox-export
+++ b/distrobox-export
@@ -564,37 +564,38 @@ export_application()
 		# Add closing quote
 		# If a TryExec is present, we have to fake it as it will not work
 		# through the container separation
+		host_desktop_file="${host_home}/.local/share/applications/${desktop_home_file}"
 		sed "s|^Exec=\(.*\)|Exec=${container_command_prefix} \1 |g" "${desktop_file}" |
 			sed "s|\(%.*\)|${extra_flags} \1|g" |
 			sed "/^TryExec=.*/d" |
 			sed "/^DBusActivatable=true/d" |
 			sed "s|Name.*|&${exported_app_label}|g" \
-				> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+				> "/run/host${host_desktop_file}"
 		# in the end we add the final quote we've opened in the "container_command_prefix"
 
-		if ! grep -q "StartupWMClass" "/run/host${host_home}/.local/share/applications/${desktop_home_file}"; then
+		if ! grep -q "StartupWMClass" "/run/host${host_desktop_file}"; then
 			printf "StartupWMClass=%s\n" "${exported_app}" >> "\
-/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+/run/host${host_desktop_file}"
 		fi
 
 		# Add a desktop action to remove this exported launcher from host menus.
-		if grep -q "^Actions=" "/run/host${host_home}/.local/share/applications/${desktop_home_file}"; then
+		if grep -q "^Actions=" "/run/host${host_desktop_file}"; then
 			sed -i "s|^Actions=.*|&Remove;|g" \
-				"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+				"/run/host${host_desktop_file}"
 		else
-			printf "Actions=Remove;\n" >> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+			printf "Actions=Remove;\n" >> "/run/host${host_desktop_file}"
 		fi
-		cat << EOF >> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+		cat << EOF >> "/run/host${host_desktop_file}"
 [Desktop Action Remove]
 Name=Remove exported app shortcut
-Exec=sh -c 'if distrobox list "${container_name}"; then distrobox-enter -n "${container_name}" -- distrobox-export --app "${exported_app}" --delete; else rm -f "\$1"; fi' sh %k
+Exec=sh -c 'if distrobox list "${container_name}"; then distrobox-enter -n "${container_name}" -- distrobox-export --app "${exported_app}" --delete; else rm -f "${host_desktop_file}"; fi'
 EOF
 
 		# In case of an icon in a non canonical path, we need to replace the path
 		# in the desktop file.
 		if [ -n "${icon_file_absolute_path}" ]; then
 			sed -i "s|Icon=.*|Icon=${icon_file_absolute_path}|g" \
-				"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+				"/run/host${host_desktop_file}"
 			# we're done, go to next
 			continue
 		fi
@@ -602,9 +603,9 @@ EOF
 		# In case of an icon in a canonical path, but specified as an absolute
 		# we need to replace the path in the desktop file.
 		sed -i "s|Icon=/usr/share/|Icon=/run/host${host_home}/.local/share/|g" \
-			"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+			"/run/host${host_desktop_file}"
 		sed -i "s|pixmaps|icons|g" \
-			"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+			"/run/host${host_desktop_file}"
 	done
 
 	# Update the desktop files database to ensure exported applications will

--- a/distrobox-export
+++ b/distrobox-export
@@ -576,6 +576,20 @@ export_application()
 			printf "StartupWMClass=%s\n" "${exported_app}" >> "\
 /run/host${host_home}/.local/share/applications/${desktop_home_file}"
 		fi
+
+		# Add a desktop action to remove this exported launcher from host menus.
+		if grep -q "^Actions=" "/run/host${host_home}/.local/share/applications/${desktop_home_file}"; then
+			sed -i "s|^Actions=.*|&Remove;|g" \
+				"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+		else
+			printf "Actions=Remove;\n" >> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+		fi
+		cat << EOF >> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+[Desktop Action Remove]
+Name=Remove exported app shortcut
+Exec=sh -c 'if distrobox list "${container_name}"; then distrobox-enter -n "${container_name}" -- distrobox-export --app "${exported_app}" --delete; else rm -f "\$1"; fi' sh %k
+EOF
+
 		# In case of an icon in a non canonical path, we need to replace the path
 		# in the desktop file.
 		if [ -n "${icon_file_absolute_path}" ]; then

--- a/distrobox-export
+++ b/distrobox-export
@@ -22,7 +22,7 @@
 # Expected env variables:
 #	HOME
 #	USER
-#	DISTROBOX_ENTER_PATH
+#	DISTROBOX_PATH
 #	DISTROBOX_HOST_HOME
 
 # Ensure we have our env variables correctly set
@@ -288,7 +288,7 @@ if [ "${is_sudo}" -ne 0 ]; then
 fi
 
 # Prefix to add to an existing command to work through the container
-container_command_prefix="${DISTROBOX_ENTER_PATH:-"distrobox-enter"} ${rootful} -n ${container_name} ${enter_flags} -- ${sudo_prefix} "
+container_command_prefix="${DISTROBOX_PATH:-"distrobox"}-enter ${rootful} -n ${container_name} ${enter_flags} -- ${sudo_prefix} "
 
 if [ -n "${rootful}" ]; then
 	container_command_prefix="env SUDO_ASKPASS=\"${sudo_askpass_path}\" DBX_SUDO_PROGRAM=\"sudo --askpass\" ${container_command_prefix}"
@@ -329,7 +329,7 @@ generate_script()
 # distrobox_binary
 # name: ${container_name}
 if [ -z "\${CONTAINER_ID}" ]; then
-	exec "${DISTROBOX_ENTER_PATH:-"distrobox-enter"}" ${rootful} -n ${container_name} ${enter_flags} -- ${sudo_prefix} ${container_command_suffix}
+	exec "${DISTROBOX_PATH:-"distrobox"}-enter" ${rootful} -n ${container_name} ${enter_flags} -- ${sudo_prefix} ${container_command_suffix}
 elif [ -n "\${CONTAINER_ID}" ] && [ "\${CONTAINER_ID}" != "${container_name}" ]; then
 	exec distrobox-host-exec '${dest_path}/$(basename "${exported_bin}")' "\$@"
 else
@@ -461,7 +461,7 @@ export_application()
 			# shellcheck disable=SC2086
 			find ${canon_dirs} -type f -print -o -type l -print | sed 's/./\\&/g' |
 				xargs -I{} grep -l -e "Exec=.*${exported_app}.*" -e "Name=.*${exported_app}.*" "{}" | sed 's/./\\&/g' |
-				xargs -I{} grep -L -e "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox.*enter"}.*" "{}" | sed 's/./\\&/g' |
+				xargs -I{} grep -L -e "Exec=.*${DISTROBOX_PATH:-"distrobox"}.*enter.*" "{}" | sed 's/./\\&/g' |
 				xargs -I{} printf "%s¤" "{}"
 		)
 	fi
@@ -588,7 +588,7 @@ export_application()
 		cat << EOF >> "/run/host${host_desktop_file}"
 [Desktop Action Remove]
 Name=Remove exported app shortcut
-Exec=sh -c 'if distrobox list "${container_name}"; then distrobox-enter -n "${container_name}" -- distrobox-export --app "${exported_app}" --delete; else rm -f "${host_desktop_file}"; fi'
+Exec=sh -c 'if ${DISTROBOX_PATH:-"distrobox"}-list "${container_name}"; then ${DISTROBOX_PATH:-"distrobox"}-enter -n "${container_name}" -- distrobox-export --app "${exported_app}" --delete; else rm -f "${host_desktop_file}"; fi'
 EOF
 
 		# In case of an icon in a non canonical path, we need to replace the path
@@ -639,11 +639,11 @@ list_exported_applications()
 {
 	# In this phase we search for applications exported.
 	# First find command will grep through all files in the canonical directories
-	# and only list files that contain the $DISTROBOX_ENTER_PATH.
+	# and only list files that contain distrobox-enter.
 	desktop_files=$(
 		# shellcheck disable=SC2086
 		find "/run/host${host_home}/.local/share/applications" -type f -print -o -type l -print 2> /dev/null | sed 's/./\\&/g' |
-			xargs -I{} grep -l -e "Exec=.*${DISTROBOX_ENTER_PATH:-"distrobox.*enter"}.*" "{}" | sed 's/./\\&/g' |
+			xargs -I{} grep -l -e "Exec=.*${DISTROBOX_PATH:-"distrobox"}.*enter.*" "{}" | sed 's/./\\&/g' |
 			xargs -I{} printf "%s¤" "{}"
 	)
 

--- a/distrobox-list
+++ b/distrobox-list
@@ -45,6 +45,7 @@ fi
 
 # Defaults
 no_color=0
+query_container=""
 # If the user runs this script as root in a login shell, set rootful=1.
 # There's no need for them to pass the --root flag option in such cases.
 [ "$(id -ru)" -eq 0 ] && rootful=1 || rootful=0
@@ -163,6 +164,16 @@ while :; do
 	esac
 done
 
+if [ "$#" -gt 1 ]; then
+	printf >&2 "ERROR: Too many arguments.\n\n"
+	show_help
+	exit 1
+fi
+
+if [ "$#" -eq 1 ]; then
+	query_container="$1"
+fi
+
 set -o errexit
 set -o nounset
 # set verbosity
@@ -244,6 +255,7 @@ if [ -t 0 ] && [ -t 1 ] && [ "${no_color}" -ne 1 ]; then
 	CLEAR='\033[0m'
 fi
 # Header of the output
+query_container_found=0
 for container in ${container_list}; do
 	# Check if the current container has a custom mount point for distrobox.
 	if [ -z "${container##*distrobox*}" ]; then
@@ -253,6 +265,14 @@ for container in ${container_list}; do
 		container_image="$(printf "%s" "${container}" | cut -d'|' -f2)"
 		container_name="$(printf "%s" "${container}" | cut -d'|' -f3)"
 		container_status="$(printf "%s" "${container}" | cut -d'|' -f4)"
+
+		# If we queried a specific container, match against it
+		if [ -n "${query_container}" ]; then
+			if [ "${container_name}" != "${query_container}" ]; then
+				continue
+			fi
+			query_container_found=1
+		fi
 
 		IFS=' '
 
@@ -274,3 +294,7 @@ for container in ${container_list}; do
 		printf "${CLEAR}\n"
 	fi
 done
+
+if [ -n "${query_container}" ] && [ "${query_container_found}" -eq 0 ]; then
+	exit 1
+fi

--- a/distrobox-list
+++ b/distrobox-list
@@ -112,7 +112,7 @@ distrobox version: ${version}
 
 Usage:
 
-	distrobox-list
+	distrobox-list [container]
 
 Options:
 


### PR DESCRIPTION
This PR implements a "remove" action on exported apps, to be able to delete them.
<img width="496" height="210" alt="image" src="https://github.com/user-attachments/assets/85dc8013-9b64-4a3b-9aab-68f03657c4f0" />

Executing that action will either run `distrobox export --delete ...` inside the container, *or* rm the desktop file directly if the distrobox does not exist anymore (so the user can clean up old exported apps. This is the use-case that made me write this PR)
