### PR TITLE
ci: add commitlint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0, "always", Infinity], // disables the 100-char limit
+    "header-max-length": [0, "always", Infinity], // disables the 100-char limit
+  },
+};

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,3 +184,15 @@ jobs:
           for i in ${SHELL_SCRIPTS_DIR}/*; do
           ./shell-funcheck-amd64 check "$i"
           done
+
+  commitlint:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install commitlint
+        run: npm install -D @commitlint/cli@20.5.0 @commitlint/config-conventional@20.5.0
+      - name: Validate PR commits with commitlint
+        run: npx commitlint --config .github/commitlint.config.js --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
We decided to adopt the Conventional Commits specification ([https://www.conventionalcommits.org/en/v1.0.0/](https://www.conventionalcommits.org/en/v1.0.0/)).

This PR introduces commitlint to validate the commits in pull requests.
