### PR TITLE
fix: passing root correctly to create and generate-entry command

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -65,13 +65,6 @@ Examples:
 				Aliases: []string{"Y"},
 				Usage:   "non-interactive, pull images without asking",
 			},
-			&cli.BoolFlag{
-				Name:    "root",
-				Aliases: []string{"r"},
-				Usage: `launch podman/docker/lilipod with root privileges. This is the only supported way to run with root
-privileges. Do not use "sudo distrobox". If you need to specify a different program (e.g. 'doas') for root privileges,
-use the DBX_SUDO_PROGRAM environment variable or the 'distrobox_sudo_program' config variable.`,
-			},
 			&cli.StringFlag{
 				Name:    "clone",
 				Aliases: []string{"c"},

--- a/internal/cli/generate-entry.go
+++ b/internal/cli/generate-entry.go
@@ -35,11 +35,6 @@ func newGenerateEntryCommand(cfg *config.Values) *cli.Command {
 				Aliases: []string{"a"},
 				Usage:   "perform for all distroboxes",
 			},
-			&cli.BoolFlag{
-				Name:    "root",
-				Aliases: []string{"r"},
-				Usage:   "perform on rootful distroboxes",
-			},
 		},
 		ArgsUsage: "container-name",
 		Action: func(ctx context.Context, cmd *cli.Command) error {


### PR DESCRIPTION
The `root` flag is handled in the root cli command. if we re-declare the
flag here we shadow it, resulting in a contaner manager initializated as
non-root.

Before this commit, these two commands produce respectively one root and
one non-root execution
```
distrobox --root create # root
distrobox create --root # non-root

distrobox --root generate-entry # root
distrobox generate-entry --root # non-root
```
