### PR TITLE
fix(assemble): handle root for each entry 

### DIFF
--- a/internal/cli/assemble.go
+++ b/internal/cli/assemble.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/89luca89/distrobox/internal/rootful"
 	"github.com/89luca89/distrobox/pkg/commands"
 	"github.com/89luca89/distrobox/pkg/config"
 	"github.com/89luca89/distrobox/pkg/containermanager"
@@ -96,6 +97,16 @@ func assembleAction(ctx context.Context, cmd *cli.Command, cfg *config.Values, d
 	manifest, err := manifest.Parse(ctx, manifestFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse manifest file: %w", err)
+	}
+
+	// if at least one item in the manifest requires root, validate sudo before proceeding
+	for _, item := range manifest {
+		if item.Root {
+			if err := rootful.Validate(ctx); err != nil {
+				return fmt.Errorf("cannot run in root mode: %w", err)
+			}
+			break
+		}
 	}
 
 	opts := commands.AssembleOptions{

--- a/internal/cli/assemble.go
+++ b/internal/cli/assemble.go
@@ -102,7 +102,7 @@ func assembleAction(ctx context.Context, cmd *cli.Command, cfg *config.Values, d
 	// if at least one item in the manifest requires root, validate sudo before proceeding
 	for _, item := range manifest {
 		if item.Root {
-			if err := rootful.Validate(ctx); err != nil {
+			if err := rootful.Validate(ctx, cmd.String("sudo-command")); err != nil {
 				return fmt.Errorf("cannot run in root mode: %w", err)
 			}
 			break

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,53 +56,60 @@ func printInvalidContainerManager(p *ui.Printer, containerManagerType string) {
 }
 
 func subcommands(cfg *config.Values) []*cli.Command {
-	return []*cli.Command{
-		composeCommand(
-			newListCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newGenerateEntryCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newCreateCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newEnterCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newAssembleCommand,
-			withRootSupport,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newRmCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newStopCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(
-			newEphemeralCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-		composeCommand(newUpgradeCommand,
-			withRoot,
-			withContainerManager,
-		)(cfg),
-	}
-}
+	cc := &CommandComposer[config.Values]{cfg: cfg}
+
+	list := cc.apply(
+		newListCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	generateEntry := cc.apply(
+		newGenerateEntryCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	create := cc.apply(
+		newCreateCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	enter := cc.apply(
+		newEnterCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	assemble := cc.apply(
+		newAssembleCommand,
+		withContainerManager,
+	)
+
+	rm := cc.apply(
+		newRmCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	stop := cc.apply(
+		newStopCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	ephemeral := cc.apply(
+		newEphemeralCommand,
+		withRoot,
+		withContainerManager,
+	)
+
+	upgrade := cc.apply(
+		newUpgradeCommand,
+		withRoot,
+		withContainerManager,
+	)
 
 	return []*cli.Command{
 		list,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -146,7 +146,7 @@ func withRoot(_ *config.Values, cmd *cli.Command) *cli.Command {
 			}
 		}
 		if c.Bool("root") {
-			if err := rootful.Validate(ctx); err != nil {
+			if err := rootful.Validate(ctx, c.String("sudo-command")); err != nil {
 				return nil, fmt.Errorf("cannot run in root mode: %w", err)
 			}
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,11 +24,11 @@ func NewRootCommand(cfg *config.Values) *cli.Command {
 		Name:    "distrobox",
 		Version: "1.0.0",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:   "container-manager",
-				Usage:  "",
-				Hidden: true,
-				Value:  cfg.ContainerManagerType,
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Usage:   "show more verbosity",
+				Value:   cfg.Verbose,
 			},
 			&cli.StringFlag{
 				Name:   "sudo-command",
@@ -36,72 +36,9 @@ func NewRootCommand(cfg *config.Values) *cli.Command {
 				Hidden: true,
 				Value:  cfg.SudoProgram,
 			},
-			&cli.BoolFlag{
-				Name: "root",
-				Usage: "launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred\n" +
-					"way over \"sudo distrobox\" (note: if using a program other than 'sudo' for root privileges is necessary,\n" +
-					"specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)",
-				Aliases: []string{"r"},
-			},
-			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Usage:   "show more verbosity",
-				Value:   cfg.Verbose,
-			},
 		},
-		Before: beforeAction,
-		Commands: []*cli.Command{
-			newListCommand(cfg),
-			newGenerateEntryCommand(cfg),
-			newCreateCommand(cfg),
-			newEnterCommand(cfg),
-			newAssembleCommand(cfg),
-			newRmCommand(cfg),
-			newStopCommand(cfg),
-			newEphemeralCommand(cfg),
-			newUpgradeCommand(cfg),
-		},
+		Commands: subcommands(cfg),
 	}
-}
-
-func beforeAction(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-	root := cmd.Bool("root")
-	if root {
-		if err := validateSudo(ctx); err != nil {
-			return nil, fmt.Errorf("cannot run in root mode: %w", err)
-		}
-	}
-	sudoCommand := cmd.String("sudo-command")
-	containerManagerType := cmd.String("container-manager")
-	verbose := cmd.Bool("verbose")
-
-	errPrinter := ui.NewPrinter(os.Stderr, true)
-	var containerManager containermanager.ContainerManager
-	switch containerManagerType {
-	case "docker":
-		containerManager = providers.NewDocker(root, sudoCommand, verbose)
-	case "podman":
-		containerManager = providers.NewPodman(root, sudoCommand, verbose)
-	case "podman-launcher":
-		containerManager = providers.NewPodmanLauncher(root, sudoCommand, verbose)
-	case "autodetect", "":
-		var err error
-		containerManager, err = providers.NewAutoDetect(root, sudoCommand, verbose)
-		if err != nil {
-			if errors.Is(err, providers.ErrNoContainerManager) {
-				printMissingContainerManager(errPrinter)
-			}
-
-			return nil, fmt.Errorf("failed to auto-detect container manager: %w", err)
-		}
-	default:
-		printInvalidContainerManager(errPrinter, containerManagerType)
-
-		return nil, fmt.Errorf("invalid input %s", containerManagerType)
-	}
-
-	return context.WithValue(ctx, contextKey("containerManager"), containerManager), nil
 }
 
 func printMissingContainerManager(p *ui.Printer) {
@@ -129,4 +66,180 @@ func validateSudo(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func subcommands(cfg *config.Values) []*cli.Command {
+	return []*cli.Command{
+		composeCommand(
+			newListCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newGenerateEntryCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newCreateCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newEnterCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newAssembleCommand,
+			withRootSupport,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newRmCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newStopCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(
+			newEphemeralCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+		composeCommand(newUpgradeCommand,
+			withRoot,
+			withContainerManager,
+		)(cfg),
+	}
+}
+
+	return []*cli.Command{
+		list,
+		generateEntry,
+		create,
+		enter,
+		assemble,
+		rm,
+		stop,
+		ephemeral,
+		upgrade,
+	}
+}
+
+// withRoot declares the --root flag on a command and, when it is set,
+// validates that sudo is usable. The actual root-mode container manager is
+// built by withContainerManager, which reads the same flag.
+func withRoot(_ *config.Values, cmd *cli.Command) *cli.Command {
+	cmd.Flags = append(cmd.Flags, &cli.BoolFlag{
+		Name:    "root",
+		Aliases: []string{"r"},
+		Usage: "launch podman/docker/lilipod with root privileges. Note that if you need root this is the preferred\n" +
+			"way over \"sudo distrobox\" (note: if using a program other than 'sudo' for root privileges is necessary,\n" +
+			"specify it through the DBX_SUDO_PROGRAM env variable, or 'distrobox_sudo_program' config variable)",
+	})
+
+	prev := cmd.Before
+	cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
+		if prev != nil {
+			var err error
+			ctx, err = prev(ctx, c)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if c.Bool("root") {
+			if err := validateSudo(ctx); err != nil {
+				return nil, fmt.Errorf("cannot run in root mode: %w", err)
+			}
+		}
+		return ctx, nil
+	}
+	return cmd
+}
+
+// withContainerManager builds the container manager for a command and stores
+// it in the context. It reads --root from the command (zero value if the flag
+// is not declared), so commands without withRootSupport always get a rootless
+// manager.
+func withContainerManager(cfg *config.Values, cmd *cli.Command) *cli.Command {
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{
+		Name:   "container-manager",
+		Usage:  "",
+		Hidden: true,
+		Value:  cfg.ContainerManagerType,
+	})
+
+	prev := cmd.Before
+	cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
+		if prev != nil {
+			var err error
+			ctx, err = prev(ctx, c)
+			if err != nil {
+				return nil, err
+			}
+		}
+		cm, err := buildContainerManager(
+			ctx,
+			c.String("container-manager"),
+			c.String("sudo-command"),
+			c.Bool("verbose"),
+			c.Bool("root"),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return context.WithValue(ctx, containerManagerKey, cm), nil
+	}
+	return cmd
+}
+
+func buildContainerManager(
+	_ context.Context,
+	containerManagerType string,
+	sudoCommand string,
+	verbose bool,
+	root bool,
+) (containermanager.ContainerManager, error) {
+	errPrinter := ui.NewPrinter(os.Stderr, true)
+
+	switch containerManagerType {
+	case "docker":
+		return providers.NewDocker(root, sudoCommand, verbose), nil
+	case "podman":
+		return providers.NewPodman(root, sudoCommand, verbose), nil
+	case "podman-launcher":
+		return providers.NewPodmanLauncher(root, sudoCommand, verbose), nil
+	case "autodetect", "":
+		cm, err := providers.NewAutoDetect(root, sudoCommand, verbose)
+		if err != nil {
+			if errors.Is(err, providers.ErrNoContainerManager) {
+				printMissingContainerManager(errPrinter)
+			}
+			return nil, fmt.Errorf("failed to auto-detect container manager: %w", err)
+		}
+		return cm, nil
+	default:
+		printInvalidContainerManager(errPrinter, containerManagerType)
+		return nil, fmt.Errorf("invalid input %s", containerManagerType)
+	}
+}
+
+// CommandComposer is a helper for building commands with options.
+// It holds the config, so that options don't need to receive it as an argument.
+type CommandComposer[CFG any] struct {
+	cfg *CFG
+}
+
+// apply builds a command factory by applying options left-to-right.
+// Order matches Before execution: the first option's work runs first.
+func (cc *CommandComposer[CFG]) apply(factory func(*CFG) *cli.Command, options ...func(*CFG, *cli.Command) *cli.Command) *cli.Command {
+	cmd := factory(cc.cfg)
+	for _, option := range options {
+		cmd = option(cc.cfg, cmd)
+	}
+	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -112,14 +112,14 @@ func subcommands(cfg *config.Values) []*cli.Command {
 	)
 
 	return []*cli.Command{
-		list,
-		generateEntry,
+		assemble,
 		create,
 		enter,
-		assemble,
+		ephemeral,
+		generateEntry,
+		list,
 		rm,
 		stop,
-		ephemeral,
 		upgrade,
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/89luca89/distrobox/internal/rootful"
 	"github.com/89luca89/distrobox/pkg/config"
 	"github.com/89luca89/distrobox/pkg/containermanager"
 	"github.com/89luca89/distrobox/pkg/containermanager/providers"
@@ -53,19 +53,6 @@ func printMissingContainerManager(p *ui.Printer) {
 func printInvalidContainerManager(p *ui.Printer, containerManagerType string) {
 	p.Println("Invalid input %s.", containerManagerType)
 	p.Println("The available choices are: 'autodetect', 'podman', 'podman-launcher', 'docker'")
-}
-
-func validateSudo(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "sudo", "-v")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to validate sudo: %w", err)
-	}
-
-	return nil
 }
 
 func subcommands(cfg *config.Values) []*cli.Command {
@@ -152,7 +139,7 @@ func withRoot(_ *config.Values, cmd *cli.Command) *cli.Command {
 			}
 		}
 		if c.Bool("root") {
-			if err := validateSudo(ctx); err != nil {
+			if err := rootful.Validate(ctx); err != nil {
 				return nil, fmt.Errorf("cannot run in root mode: %w", err)
 			}
 		}

--- a/internal/rootful/rootful.go
+++ b/internal/rootful/rootful.go
@@ -1,5 +1,5 @@
 // Package rootful provides utilities for running operations that require
-// root privileges via sudo.
+// root privileges via a configurable sudo command.
 package rootful
 
 import (
@@ -12,22 +12,28 @@ import (
 
 //nolint:gochecknoglobals // singleton: process-wide memoization is the intent
 var (
-	validateOnce sync.Once
-	errValidate  error
+	validateOnce      sync.Once
+	errValidate       error
+	cachedSudoCommand string
 )
 
-// Validate ensures that sudo is available and the user can elevate.
-// It runs `sudo -v` at most once per process: the first call performs the
-// check and caches the result; subsequent calls return the cached result
-// without re-running the command.
-func Validate(ctx context.Context) error {
+// Validate ensures that sudoCommand is available and the user can elevate.
+// It runs `<sudoCommand> -v` at most once per process: the first call performs
+// the check and caches the result; subsequent calls return the cached result
+// without re-running the command. Passing a different sudoCommand after the
+// first call is a programming error and returns an explicit error.
+func Validate(ctx context.Context, sudoCommand string) error {
+	if cachedSudoCommand != "" && cachedSudoCommand != sudoCommand {
+		return fmt.Errorf("sudoCommand mismatch: already validated with %q, got %q", cachedSudoCommand, sudoCommand)
+	}
 	validateOnce.Do(func() {
-		cmd := exec.CommandContext(ctx, "sudo", "-v")
+		cachedSudoCommand = sudoCommand
+		cmd := exec.CommandContext(ctx, sudoCommand, "-v")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			errValidate = fmt.Errorf("failed to validate sudo: %w", err)
+			errValidate = fmt.Errorf("failed to validate %q: %w", sudoCommand, err)
 		}
 	})
 	return errValidate

--- a/internal/rootful/rootful.go
+++ b/internal/rootful/rootful.go
@@ -1,0 +1,34 @@
+// Package rootful provides utilities for running operations that require
+// root privileges via sudo.
+package rootful
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+//nolint:gochecknoglobals // singleton: process-wide memoization is the intent
+var (
+	validateOnce sync.Once
+	errValidate  error
+)
+
+// Validate ensures that sudo is available and the user can elevate.
+// It runs `sudo -v` at most once per process: the first call performs the
+// check and caches the result; subsequent calls return the cached result
+// without re-running the command.
+func Validate(ctx context.Context) error {
+	validateOnce.Do(func() {
+		cmd := exec.CommandContext(ctx, "sudo", "-v")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			errValidate = fmt.Errorf("failed to validate sudo: %w", err)
+		}
+	})
+	return errValidate
+}

--- a/internal/rootful/rootful_internal_test.go
+++ b/internal/rootful/rootful_internal_test.go
@@ -1,0 +1,54 @@
+package rootful
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetState() {
+	validateOnce = sync.Once{}
+	errValidate = nil
+	cachedSudoCommand = ""
+}
+
+func TestValidate_Success(t *testing.T) {
+	resetState()
+	t.Cleanup(resetState)
+
+	err := Validate(context.Background(), "true")
+	require.NoError(t, err)
+}
+
+func TestValidate_Failure(t *testing.T) {
+	resetState()
+	t.Cleanup(resetState)
+
+	err := Validate(context.Background(), "false")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"false"`)
+}
+
+func TestValidate_CachesResult(t *testing.T) {
+	resetState()
+	t.Cleanup(resetState)
+
+	require.NoError(t, Validate(context.Background(), "true"))
+	require.NoError(t, Validate(context.Background(), "true"))
+}
+
+func TestValidate_MismatchedCommand(t *testing.T) {
+	resetState()
+	t.Cleanup(resetState)
+
+	require.NoError(t, Validate(context.Background(), "true"))
+
+	err := Validate(context.Background(), "false")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatch")
+	assert.Contains(t, err.Error(), `"true"`)
+	assert.Contains(t, err.Error(), `"false"`)
+}

--- a/pkg/commands/assemble.go
+++ b/pkg/commands/assemble.go
@@ -28,12 +28,14 @@ type AssembleOptions struct {
 }
 
 type AssembleCommand struct {
-	cfg              *config.Values
-	containermanager containermanager.ContainerManager
-	createCmd        *CreateCommand
-	rmCmd            *RmCommand
-	enterCmd         *EnterCommand
-	progress         *ui.Progress
+	cfg           *config.Values
+	createCmd     *CreateCommand
+	rmCmd         *RmCommand
+	enterCmd      *EnterCommand
+	createCmdRoot *CreateCommand
+	rmCmdRoot     *RmCommand
+	enterCmdRoot  *EnterCommand
+	progress      *ui.Progress
 }
 
 func NewAssembleCommand(
@@ -43,13 +45,16 @@ func NewAssembleCommand(
 	progress *ui.Progress,
 	printer *ui.Printer,
 ) *AssembleCommand {
+	cmRoot := cm.CloneAsRoot()
 	return &AssembleCommand{
-		cfg:              cfg,
-		containermanager: cm,
-		createCmd:        NewCreateCommand(cfg, cm, ui.NewDevNullProgress(), prompter),
-		rmCmd:            NewRmCommand(cfg, cm, prompter),
-		enterCmd:         NewEnterCommand(cfg, cm, progress, printer),
-		progress:         progress,
+		cfg:           cfg,
+		createCmd:     NewCreateCommand(cfg, cm, ui.NewDevNullProgress(), prompter),
+		rmCmd:         NewRmCommand(cfg, cm, prompter),
+		enterCmd:      NewEnterCommand(cfg, cm, progress, printer),
+		createCmdRoot: NewCreateCommand(cfg, cmRoot, ui.NewDevNullProgress(), prompter),
+		rmCmdRoot:     NewRmCommand(cfg, cmRoot, prompter),
+		enterCmdRoot:  NewEnterCommand(cfg, cmRoot, progress, printer),
+		progress:      progress,
 	}
 }
 
@@ -97,7 +102,12 @@ func (ac *AssembleCommand) deleteItem(ctx context.Context, item manifest.Item, d
 		ContainerNames: []string{item.Name},
 	}
 
-	_, err := ac.rmCmd.Execute(ctx, opts)
+	rmCmd := ac.rmCmd
+	if item.Root {
+		rmCmd = ac.rmCmdRoot
+	}
+
+	_, err := rmCmd.Execute(ctx, opts)
 	if err != nil {
 		ac.progress.Fail()
 		return fmt.Errorf("failed to execute delete item '%s': %w", item.Name, err)
@@ -142,7 +152,11 @@ func (ac *AssembleCommand) createItem(ctx context.Context, item manifest.Item, d
 		ContainerAlwaysPull:     item.AlwaysPull,
 	}
 
-	_, err := ac.createCmd.Execute(ctx, opts)
+	createCmd := ac.createCmd
+	if item.Root {
+		createCmd = ac.createCmdRoot
+	}
+	_, err := createCmd.Execute(ctx, opts)
 	if err != nil {
 		ac.progress.Fail()
 		return err
@@ -183,8 +197,12 @@ func (ac *AssembleCommand) joinHooks(hooks []string) string {
 }
 
 func (ac *AssembleCommand) setupBox(ctx context.Context, item manifest.Item) error {
+	enterCmd := ac.enterCmd
+	if item.Root {
+		enterCmd = ac.enterCmdRoot
+	}
 	if item.StartNow {
-		_, err := ac.enterCmd.Execute(ctx, EnterOptions{
+		_, err := enterCmd.Execute(ctx, EnterOptions{
 			ContainerName: item.Name,
 			NoTTY:         true,
 			CustomCommand: []string{"true"}, // we just want to run the init hooks, so we can skip the shell
@@ -203,7 +221,7 @@ func (ac *AssembleCommand) setupBox(ctx context.Context, item manifest.Item) err
 		}
 	}
 	for _, app := range item.ExportedApps {
-		_, err := ac.enterCmd.Execute(ctx, EnterOptions{
+		_, err := enterCmd.Execute(ctx, EnterOptions{
 			ContainerName: item.Name,
 			NoTTY:         true,
 			CustomCommand: []string{"distrobox-export", "--app", app},
@@ -226,7 +244,7 @@ func (ac *AssembleCommand) setupBox(ctx context.Context, item manifest.Item) err
 		}
 	}
 	for _, bin := range item.ExportedBins {
-		_, err := ac.enterCmd.Execute(ctx, EnterOptions{
+		_, err := enterCmd.Execute(ctx, EnterOptions{
 			ContainerName: item.Name,
 			NoTTY:         true,
 			CustomCommand: []string{"distrobox-export", "--bin", bin, "--export-path", item.ExportedBinsPath},

--- a/pkg/commands/assemble_test.go
+++ b/pkg/commands/assemble_test.go
@@ -190,6 +190,53 @@ func TestAssembleCommand_SetupBox_ExportedBins_Invalid(t *testing.T) {
 	}
 }
 
+func TestAssembleCommand_RoutesCreateAndSetupByItemRoot(t *testing.T) {
+	mock := &testutil.MockContainerManager{}
+	cmd := newTestAssembleCommand(mock)
+
+	require.NotNil(t, mock.RootClone, "AssembleCommand constructor should call CloneAsRoot")
+
+	err := cmd.Execute(context.Background(), commands.AssembleOptions{
+		Items: []manifest.Item{
+			{Name: "rootless-box", Image: "ubuntu:latest", Root: false, StartNow: true},
+			{Name: "rootful-box", Image: "ubuntu:latest", Root: true, StartNow: true},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.Spy.Create, 1, "rootless mock should receive exactly one Create")
+	createOpts := mock.Spy.Create[0][0].(containermanager.CreateOptions)
+	assert.Equal(t, "rootless-box", createOpts.ContainerName)
+
+	require.Len(t, mock.RootClone.Spy.Create, 1, "root mock should receive exactly one Create")
+	createOptsRoot := mock.RootClone.Spy.Create[0][0].(containermanager.CreateOptions)
+	assert.Equal(t, "rootful-box", createOptsRoot.ContainerName)
+
+	require.Len(t, mock.Spy.Enter, 1, "rootless mock should receive exactly one Enter (StartNow)")
+	assert.Equal(t, "rootless-box", getEnterOptions(mock.Spy, 0).ContainerName)
+
+	require.Len(t, mock.RootClone.Spy.Enter, 1, "root mock should receive exactly one Enter (StartNow)")
+	assert.Equal(t, "rootful-box", getEnterOptions(mock.RootClone.Spy, 0).ContainerName)
+}
+
+func TestAssembleCommand_RootlessOnlyManifest_DoesNotInvokeRootMock(t *testing.T) {
+	mock := &testutil.MockContainerManager{}
+	cmd := newTestAssembleCommand(mock)
+
+	err := cmd.Execute(context.Background(), commands.AssembleOptions{
+		Items: []manifest.Item{
+			{Name: "a", Image: "ubuntu:latest", Root: false},
+			{Name: "b", Image: "ubuntu:latest", Root: false},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, mock.Spy.Create, 2)
+	require.NotNil(t, mock.RootClone, "constructor still calls CloneAsRoot eagerly")
+	assert.Empty(t, mock.RootClone.Spy.Create, "root mock should not receive Create for rootless items")
+	assert.Empty(t, mock.RootClone.Spy.Enter, "root mock should not receive Enter for rootless items")
+}
+
 func TestAssembleCommand_SetupBox_ExportedBins_InvalidExportPath(t *testing.T) {
 	invalidPaths := []string{
 		"",

--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -86,6 +86,9 @@ type ContainerManagerType string
 
 type ContainerManager interface {
 	Name() string
+	// CloneAsRoot returns a copy of the manager configured to run in root
+	// mode. The original instance is not modified.
+	CloneAsRoot() ContainerManager
 	Enter(ctx context.Context, options EnterOptions, progress *ui.Progress, printer *ui.Printer) error
 	ListContainers(ctx context.Context) ([]Container, error)
 	Create(ctx context.Context, opts CreateOptions) error

--- a/pkg/containermanager/providers/clone_internal_test.go
+++ b/pkg/containermanager/providers/clone_internal_test.go
@@ -1,0 +1,70 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodman_CloneAsRoot_PreservesFieldsAndFlipsRoot(t *testing.T) {
+	original := newPodman(podmanCommandPodman, false, "doas", true)
+
+	cloned := original.CloneAsRoot()
+
+	require.NotSame(t, original, cloned, "expected a fresh instance")
+
+	clone, ok := cloned.(*Podman)
+	require.True(t, ok, "expected *Podman, got %T", cloned)
+
+	assert.True(t, clone.root, "clone should be in root mode")
+	assert.Equal(t, original.command, clone.command)
+	assert.Equal(t, original.sudoCommand, clone.sudoCommand)
+	assert.Equal(t, original.verbose, clone.verbose)
+
+	assert.False(t, original.root, "original should remain non-root")
+}
+
+func TestPodman_CloneAsRoot_AlreadyRootStillReturnsCopy(t *testing.T) {
+	original := newPodman(podmanCommandLauncher, true, "sudo", false)
+
+	cloned := original.CloneAsRoot()
+
+	require.NotSame(t, original, cloned)
+
+	clone, ok := cloned.(*Podman)
+	require.True(t, ok)
+
+	assert.True(t, clone.root)
+	assert.Equal(t, podmanCommandLauncher, clone.command)
+}
+
+func TestDocker_CloneAsRoot_PreservesFieldsAndFlipsRoot(t *testing.T) {
+	original := NewDocker(false, "doas", true)
+
+	cloned := original.CloneAsRoot()
+
+	require.NotSame(t, original, cloned, "expected a fresh instance")
+
+	clone, ok := cloned.(*Docker)
+	require.True(t, ok, "expected *Docker, got %T", cloned)
+
+	assert.True(t, clone.root, "clone should be in root mode")
+	assert.Equal(t, original.sudoCommand, clone.sudoCommand)
+	assert.Equal(t, original.verbose, clone.verbose)
+
+	assert.False(t, original.root, "original should remain non-root")
+}
+
+func TestDocker_CloneAsRoot_AlreadyRootStillReturnsCopy(t *testing.T) {
+	original := NewDocker(true, "sudo", false)
+
+	cloned := original.CloneAsRoot()
+
+	require.NotSame(t, original, cloned)
+
+	clone, ok := cloned.(*Docker)
+	require.True(t, ok)
+
+	assert.True(t, clone.root)
+}

--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -36,6 +36,12 @@ func NewDocker(root bool, sudoCommand string, verbose bool) *Docker {
 	}
 }
 
+func (d *Docker) CloneAsRoot() containermanager.ContainerManager {
+	cp := *d
+	cp.root = true
+	return &cp
+}
+
 func (d *Docker) Name() string {
 	return "docker"
 }

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -54,6 +54,12 @@ func NewPodmanLauncher(root bool, sudoCommand string, verbose bool) *Podman {
 	return newPodman(podmanCommandLauncher, root, sudoCommand, verbose)
 }
 
+func (p *Podman) CloneAsRoot() containermanager.ContainerManager {
+	cp := *p
+	cp.root = true
+	return &cp
+}
+
 func (p *Podman) Name() string {
 	return string(p.command)
 }

--- a/pkg/internal/testutil/mock_containermanager.go
+++ b/pkg/internal/testutil/mock_containermanager.go
@@ -11,6 +11,7 @@ import (
 // Each field is a slice of call argument lists.
 type ContainerManagerSpy struct {
 	Name             [][]any
+	CloneAsRoot      [][]any
 	Enter            [][]any
 	ListContainers   [][]any
 	Create           [][]any
@@ -25,13 +26,27 @@ type ContainerManagerSpy struct {
 
 // MockContainerManager is a no-op container manager for testing.
 // All method calls are recorded in the Spy.
+//
+// CloneAsRoot returns a distinct MockContainerManager so tests can
+// distinguish calls made on the rootless vs root variant. The clone is
+// cached on RootClone after first creation.
 type MockContainerManager struct {
-	Spy ContainerManagerSpy
+	Spy       ContainerManagerSpy
+	Root      bool
+	RootClone *MockContainerManager
 }
 
 func (m *MockContainerManager) Name() string {
 	m.Spy.Name = append(m.Spy.Name, []any{})
 	return "mock"
+}
+
+func (m *MockContainerManager) CloneAsRoot() containermanager.ContainerManager {
+	m.Spy.CloneAsRoot = append(m.Spy.CloneAsRoot, []any{})
+	if m.RootClone == nil {
+		m.RootClone = &MockContainerManager{Root: true}
+	}
+	return m.RootClone
 }
 
 func (m *MockContainerManager) Enter(_ context.Context, options containermanager.EnterOptions, progress *ui.Progress, printer *ui.Printer) error {


### PR DESCRIPTION
`assemble` command cannot be executed as root. Instead, each item can either be processed by a rootful or rootless container manager.

Some refactoring is present in this PR to allow the behaviour change.