### PR TITLE
fix: print container name on create when not provided

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -213,7 +213,7 @@ func createAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) err
 	prompter := ui.NewPrompter(*bufio.NewReader(os.Stdin), os.Stdout)
 
 	createCmd := commands.NewCreateCommand(cfg, containerManager, progress, prompter)
-	err := createCmd.Execute(ctx, opts)
+	result, err := createCmd.Execute(ctx, opts)
 
 	var containerAlreadyExistsErr *commands.ContainerAlreadyExistsError
 	if errors.As(err, &containerAlreadyExistsErr) {
@@ -230,7 +230,7 @@ func createAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) err
 	}
 
 	if !opts.DryRun {
-		printCreateCompleted(progress, opts.ContainerName, opts.Rootful)
+		printCreateCompleted(progress, result.ContainerName, opts.Rootful)
 	}
 
 	return nil

--- a/pkg/commands/assemble.go
+++ b/pkg/commands/assemble.go
@@ -142,7 +142,7 @@ func (ac *AssembleCommand) createItem(ctx context.Context, item manifest.Item, d
 		ContainerAlwaysPull:     item.AlwaysPull,
 	}
 
-	err := ac.createCmd.Execute(ctx, opts)
+	_, err := ac.createCmd.Execute(ctx, opts)
 	if err != nil {
 		ac.progress.Fail()
 		return err

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -82,6 +82,12 @@ type CreateOptions struct {
 	NonInteractive      bool
 }
 
+type CreateResult struct {
+	ContainerName     string
+	ContainerImage    string
+	ContainerHostname string
+}
+
 func NewCreateCommand(cfg *config.Values, cm containermanager.ContainerManager, progress *ui.Progress, prompter *ui.Prompter) *CreateCommand {
 	return &CreateCommand{
 		cfg:              cfg,
@@ -92,30 +98,30 @@ func NewCreateCommand(cfg *config.Values, cm containermanager.ContainerManager, 
 	}
 }
 
-func (c *CreateCommand) Execute(ctx context.Context, opts CreateOptions) error {
+func (c *CreateCommand) Execute(ctx context.Context, opts CreateOptions) (*CreateResult, error) {
 	containerImage := c.makeContainerImage(&opts)
 	containerName := c.makeContainerName(&opts, containerImage)
 	containerHostname, err := c.makeContainerHostname(&opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	containerUserCustomHome := c.makeContainerUserCustomHome(&opts, containerName)
 
 	if !opts.DryRun && c.containerManager.Exists(ctx, containerName) {
-		return &ContainerAlreadyExistsError{ContainerName: containerName}
+		return nil, &ContainerAlreadyExistsError{ContainerName: containerName}
 	}
 
 	if opts.ContainerClone != "" && !opts.DryRun {
 		cloneImage, err := c.clone(ctx, opts.ContainerClone)
 		if err != nil {
-			return fmt.Errorf("failed to clone container %s: %w", opts.ContainerClone, err)
+			return nil, fmt.Errorf("failed to clone container %s: %w", opts.ContainerClone, err)
 		}
 		containerImage = cloneImage
 	}
 
 	if err := c.askPullImage(ctx, containerImage, opts); err != nil {
-		return err
+		return nil, err
 	}
 
 	c.progress.Next("Creating '%s' using image %s", containerName, containerImage)
@@ -148,7 +154,7 @@ func (c *CreateCommand) Execute(ctx context.Context, opts CreateOptions) error {
 
 	if err != nil {
 		c.progress.Fail()
-		return fmt.Errorf("failed to create container: %w", err)
+		return nil, fmt.Errorf("failed to create container: %w", err)
 	}
 
 	c.progress.Done()
@@ -161,11 +167,15 @@ func (c *CreateCommand) Execute(ctx context.Context, opts CreateOptions) error {
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("failed to generate entry for container %s: %w", containerName, err)
+			return nil, fmt.Errorf("failed to generate entry for container %s: %w", containerName, err)
 		}
 	}
 
-	return nil
+	return &CreateResult{
+		ContainerName:     containerName,
+		ContainerImage:    containerImage,
+		ContainerHostname: containerHostname,
+	}, nil
 }
 
 // Determine right containerImage to use

--- a/pkg/commands/ephemeral.go
+++ b/pkg/commands/ephemeral.go
@@ -53,7 +53,7 @@ func (c *EphemeralCommand) Execute(ctx context.Context, opts EphemeralOptions) e
 	createOpts.GenerateEntry = false
 	createOpts.DryRun = opts.DryRun
 	createOpts.NonInteractive = true
-	if err := c.createCmd.Execute(ctx, createOpts); err != nil {
+	if _, err := c.createCmd.Execute(ctx, createOpts); err != nil {
 		return fmt.Errorf("failed to create ephemeral container: %w", err)
 	}
 


### PR DESCRIPTION
The `create` command, when the container name is not provided, it calculates it based on some defaults. This PR prints the actual container name.

```sh
# before
Distrobox 'ubuntu-noble' successfully created.
To enter, run:

distrobox enter

# after
Distrobox 'ubuntu-noble' successfully created.
To enter, run:

distrobox enter ubuntu-noble
```