### PR TITLE
fix(cli): read correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,12 @@ jobs:
 
       - name: Build
         env:
-          CGO_ENABLED: "0"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -o distrobox-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/distrobox
+          mkdir -p ./bin
+          make build
+          mv ./bin/distrobox distrobox-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-GO_BUILD_ENV := CGO_ENABLED=0 GOOS=linux
-VERSION := $(shell git describe --tags --always 2>/dev/null || echo "dev")
+GOOS ?= $(shell go env GOOS)
+GO_BUILD_ENV := CGO_ENABLED=0 GOOS=$(GOOS)
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X github.com/89luca89/distrobox/pkg/version.Version=$(VERSION)"
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 GO_BUILD_ENV := CGO_ENABLED=0 GOOS=linux
+VERSION := $(shell git describe --tags --always 2>/dev/null || echo "dev")
+LDFLAGS := -ldflags "-X github.com/89luca89/distrobox/pkg/version.Version=$(VERSION)"
 
 .PHONY: build
 build:
-	$(GO_BUILD_ENV) go build -o ./bin/distrobox ./cmd/distrobox
+	$(GO_BUILD_ENV) go build $(LDFLAGS) -o ./bin/distrobox ./cmd/distrobox
 
 .PHONY: test
 test: vet

--- a/internal/cli/generate-entry.go
+++ b/internal/cli/generate-entry.go
@@ -15,9 +15,8 @@ import (
 
 func newGenerateEntryCommand(cfg *config.Values) *cli.Command {
 	return &cli.Command{
-		Name:    "generate-entry",
-		Usage:   "Generate or delete distrobox entries",
-		Version: "1.0.0",
+		Name:  "generate-entry",
+		Usage: "Generate or delete distrobox entries",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "delete",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ const containerManagerKey contextKey = "containerManager"
 func NewRootCommand(cfg *config.Values) *cli.Command {
 	return &cli.Command{
 		Name:    "distrobox",
+		Usage:   "Use any Linux distribution inside your terminal",
 		Version: version.Version,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/89luca89/distrobox/pkg/containermanager"
 	"github.com/89luca89/distrobox/pkg/containermanager/providers"
 	"github.com/89luca89/distrobox/pkg/ui"
+	"github.com/89luca89/distrobox/pkg/version"
 )
 
 type contextKey string
@@ -22,7 +23,7 @@ const containerManagerKey contextKey = "containerManager"
 func NewRootCommand(cfg *config.Values) *cli.Command {
 	return &cli.Command{
 		Name:    "distrobox",
-		Version: "1.0.0",
+		Version: version.Version,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is set at build time via -ldflags.
+var Version = "dev" //nolint:gochecknoglobals // default value for development builds


### PR DESCRIPTION
Previously, the CLI hardcoded "1.0.0" as the version string in two places (the root command and the generate-entry subcommand).

Introduce pkg/version, a minimal package that exposes a single variable Version, defaulting to "dev". The root command now references such a value; generate-entry does not need it al all

The Makefile computes the version at build time by running:

git describe --tags --always
This produces the exact tag name when HEAD is tagged, or --g when it is not, giving a precise description of the build relative to the nearest ancestor tag. If git is unavailable, the value falls back to "dev".

The resulting string is injected into the binary via:

-ldflags "-X github.com/89luca89/distrobox/pkg/version.Version=<value>" so that distrobox --version and distrobox generate-entry --version both report the exact version of the build.