### PR TITLE
fix(enter): always attach stdio to final exec

### DIFF
--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -546,7 +546,7 @@ func (d *Docker) Enter(
 		progress.Finalize("Container Setup Complete!")
 	}
 
-	if _, err := d.run(ctx, append(command, commandArgs...), runOptions{Interactive: !options.NoTTY}); err != nil {
+	if _, err := d.run(ctx, append(command, commandArgs...), runOptions{Interactive: true}); err != nil {
 		return err
 	}
 

--- a/pkg/containermanager/providers/docker_internal_test.go
+++ b/pkg/containermanager/providers/docker_internal_test.go
@@ -529,7 +529,7 @@ func TestDockerEnterPropagatesExecError(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "exec failed")
+	assert.ErrorContains(t, err, "exit status 7")
 }
 
 func installFakeDockerRuntime(t *testing.T) {

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -553,7 +553,7 @@ func (p *Podman) Enter(
 		progress.Finalize("Container Setup Complete!")
 	}
 
-	if _, err := p.run(ctx, append(command, commandArgs...), runOptions{Interactive: !options.NoTTY}); err != nil {
+	if _, err := p.run(ctx, append(command, commandArgs...), runOptions{Interactive: true}); err != nil {
 		return err
 	}
 

--- a/pkg/containermanager/providers/podman_internal_test.go
+++ b/pkg/containermanager/providers/podman_internal_test.go
@@ -716,7 +716,7 @@ func TestPodmanEnterPropagatesExecError(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "exec failed")
+	assert.ErrorContains(t, err, "exit status 7")
 }
 
 func installFakePodmanRuntime(t *testing.T) {


### PR DESCRIPTION
`Interactive: !NoTTY` routed stdio to discarded buffers whenever --no-tty was set, breaking ptyxis. --no-tty only governs whether `--tty` is appended to the exec args, not stdio plumbing.