### PR TITLE
fix(create): don't pull images in --dry-run mode

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -287,7 +287,7 @@ func (c *CreateCommand) clone(ctx context.Context, containerName string) (string
 
 func (c *CreateCommand) askPullImage(ctx context.Context, containerImage string, opts CreateOptions) error {
 	if opts.ContainerAlwaysPull || !c.containerManager.ImageExists(ctx, containerImage) {
-		skipConfirm := opts.NonInteractive || opts.ContainerAlwaysPull
+		skipConfirm := opts.NonInteractive || opts.ContainerAlwaysPull || opts.DryRun
 		if !skipConfirm {
 			msg := fmt.Sprintf("Image '%s' not found.\n. Do you want to pull the image now?", containerImage)
 			answer := c.prompter.Prompt(msg, true)
@@ -296,7 +296,7 @@ func (c *CreateCommand) askPullImage(ctx context.Context, containerImage string,
 			}
 		}
 
-		err := c.containerManager.PullImage(ctx, containerImage, opts.ContainerPlatform)
+		err := c.containerManager.PullImage(ctx, containerImage, opts.ContainerPlatform, opts.DryRun)
 		if err != nil {
 			return fmt.Errorf("failed to pull image '%s': %w", containerImage, err)
 		}

--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -97,7 +97,7 @@ type ContainerManager interface {
 	ImageExists(ctx context.Context, imageName string) bool
 	Stop(ctx context.Context, containerNames []string) error
 	InspectContainer(ctx context.Context, containerName string) (*InspectResult, error)
-	PullImage(ctx context.Context, imageName string, platform string) error
+	PullImage(ctx context.Context, imageName string, platform string, dryRun bool) error
 	Commit(ctx context.Context, containerID string, imageTag string) error
 }
 

--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -700,14 +700,14 @@ func (d *Docker) ImageExists(ctx context.Context, imageName string) bool {
 	return true
 }
 
-func (d *Docker) PullImage(ctx context.Context, imageName string, platform string) error {
+func (d *Docker) PullImage(ctx context.Context, imageName string, platform string, dryRun bool) error {
 	var args []string
 	if platform != "" {
 		args = []string{"pull", "--platform", platform, imageName}
 	} else {
 		args = []string{"pull", imageName}
 	}
-	_, err := d.run(ctx, args, runOptions{TailLogs: true})
+	_, err := d.run(ctx, args, runOptions{DryRun: dryRun, TailLogs: true})
 	return err
 }
 

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -121,6 +121,7 @@ func (p *Podman) Create(
 		opts.UnshareIPC,
 		opts.UnshareNetNS,
 		opts.UnshareProcess,
+		opts.DryRun,
 		userEnv,
 		filepath.Join(scriptsDir, "distrobox-init"),
 		filepath.Join(scriptsDir, "distrobox-export"),
@@ -136,7 +137,7 @@ func (p *Podman) Create(
 
 // makeCreateCommand builds the podman create command with all necessary options.
 //
-//nolint:gocognit,funlen // ignore cognitive complexity here, the function is mostly imperative option appending
+//nolint:gocognit,funlen,gocyclo,cyclop // ignore cognitive complexity here, the function is mostly imperative option appending
 func (p *Podman) makeCreateCommand(
 	ctx context.Context,
 	containerName string,
@@ -157,6 +158,7 @@ func (p *Podman) makeCreateCommand(
 	unshareIPC bool,
 	unshareNetNS bool,
 	unshareProcess bool,
+	dryRun bool,
 	userEnv *userenv.UserEnvironment,
 	distroboxInitPath string,
 	distroboxExportPath string,
@@ -234,7 +236,7 @@ func (p *Podman) makeCreateCommand(
 	//
 	// This happens ONLY with podman+runc, docker and lilipod are unaffected,
 	// so let's do this only if we have podman AND runc.
-	if p.usesRunc(ctx) {
+	if !dryRun && p.usesRunc(ctx) {
 		options = append(options, hostRootMountsForRunc(ctx)...)
 	} else {
 		options = append(options, "--volume", "/:/run/host/:rslave")
@@ -401,7 +403,7 @@ func (p *Podman) makeCreateCommand(
 
 	// Use keep-id only if going rootless.
 	if !p.root {
-		if p.supportsKeepIDSize(ctx, containerImage) {
+		if dryRun || p.supportsKeepIDSize(ctx, containerImage) {
 			options = append(options, "--userns", "keep-id:size=65536")
 		} else {
 			options = append(options, "--userns", "keep-id")
@@ -579,14 +581,14 @@ func (p *Podman) ImageExists(ctx context.Context, imageName string) bool {
 	return true
 }
 
-func (p *Podman) PullImage(ctx context.Context, imageName string, platform string) error {
+func (p *Podman) PullImage(ctx context.Context, imageName string, platform string, dryRun bool) error {
 	var args []string
 	if platform != "" {
 		args = []string{"pull", "--platform", platform, imageName}
 	} else {
 		args = []string{"pull", imageName}
 	}
-	_, err := p.run(ctx, args, runOptions{TailLogs: true})
+	_, err := p.run(ctx, args, runOptions{DryRun: dryRun, TailLogs: true})
 	return err
 }
 

--- a/pkg/containermanager/providers/podman_internal_test.go
+++ b/pkg/containermanager/providers/podman_internal_test.go
@@ -53,6 +53,7 @@ func TestPodman_makeCreateCommand(t *testing.T) {
 		false,                         // unshareIPC
 		false,                         // unshareNetNS
 		false,                         // unshareProcess
+		false,                         // dryRun
 		userEnv,                       // userEnv
 		"/path/to/distrobox-init",     // distroboxInitPath
 		"/path/to/distrobox-export",   // distroboxExportPath
@@ -131,6 +132,7 @@ func TestPodman_makeCreateCommandRootful(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -179,6 +181,7 @@ func TestPodman_makeCreateCommandNoInit(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -228,6 +231,7 @@ func TestPodman_makeCreateCommandWithCrun(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -275,6 +279,7 @@ func TestPodman_makeCreateCommandWithPlatform(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -317,6 +322,7 @@ func TestPodman_makeCreateCommandWithCustomHome(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -374,6 +380,7 @@ func TestPodman_makeCreateCommandWithAdditionalFlags(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -423,6 +430,7 @@ func TestPodman_makeCreateCommandWithAdditionalPackages(t *testing.T) {
 		false,
 		false,
 		false,
+		false, // dryRun
 		userEnv,
 		"/path/to/distrobox-init",
 		"/path/to/distrobox-export",
@@ -523,6 +531,7 @@ func TestPodman_makeCreateCommandUnshareOptions(t *testing.T) {
 				tt.unshareIPC,
 				tt.unshareNetNS,
 				tt.unshareProcess,
+				false, // dryRun
 				userEnv,
 				"/path/to/distrobox-init",
 				"/path/to/distrobox-export",

--- a/pkg/internal/testutil/mock_containermanager.go
+++ b/pkg/internal/testutil/mock_containermanager.go
@@ -94,7 +94,7 @@ func (m *MockContainerManager) ImageExists(_ context.Context, imageName string) 
 	return false
 }
 
-func (m *MockContainerManager) PullImage(_ context.Context, imageName string, platform string) error {
-	m.Spy.PullImage = append(m.Spy.PullImage, []any{imageName, platform})
+func (m *MockContainerManager) PullImage(_ context.Context, imageName string, platform string, dryRun bool) error {
+	m.Spy.PullImage = append(m.Spy.PullImage, []any{imageName, platform, dryRun})
 	return nil
 }


### PR DESCRIPTION
PullImage ignored opts.DryRun and pulled anyway.
Thread DryRun through PullImage and gate
the usesRunc / supportsKeepIDSize probes.