### PR TITLE
fix(assemble): preserve section names from manifest

### DIFF
--- a/pkg/commands/assemble_test.go
+++ b/pkg/commands/assemble_test.go
@@ -237,6 +237,60 @@ func TestAssembleCommand_RootlessOnlyManifest_DoesNotInvokeRootMock(t *testing.T
 	assert.Empty(t, mock.RootClone.Spy.Enter, "root mock should not receive Enter for rootless items")
 }
 
+func TestAssembleCommand_CreateUsesItemNameWhenImageEmpty(t *testing.T) {
+	mock := &testutil.MockContainerManager{}
+	cfg := &config.Values{
+		DefaultContainerName:  "my-distrobox",
+		DefaultContainerImage: "registry.fedoraproject.org/fedora-toolbox:latest",
+	}
+	progress := ui.NewDevNullProgress()
+	prompter := ui.NewPrompter(*bufio.NewReader(strings.NewReader("")), io.Discard)
+	printer := ui.NewPrinter(io.Discard, false)
+	cmd := commands.NewAssembleCommand(cfg, mock, prompter, progress, printer)
+
+	err := cmd.Execute(context.Background(), commands.AssembleOptions{
+		Items: []manifest.Item{
+			{Name: "generic1"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.Spy.Create, 1)
+	createOpts := mock.Spy.Create[0][0].(containermanager.CreateOptions)
+	assert.Equal(t, "generic1", createOpts.ContainerName)
+}
+
+func TestAssembleCommand_ExampleManifest(t *testing.T) {
+	items, err := manifest.Parse(context.Background(), "../../extras/distrobox-example-manifest.ini")
+	require.NoError(t, err)
+
+	mock := &testutil.MockContainerManager{}
+	cfg := &config.Values{
+		DefaultContainerName:  "my-distrobox",
+		DefaultContainerImage: "registry.fedoraproject.org/fedora-toolbox:latest",
+	}
+	progress := ui.NewDevNullProgress()
+	prompter := ui.NewPrompter(*bufio.NewReader(strings.NewReader("")), io.Discard)
+	printer := ui.NewPrinter(io.Discard, false)
+	cmd := commands.NewAssembleCommand(cfg, mock, prompter, progress, printer)
+
+	err = cmd.Execute(context.Background(), commands.AssembleOptions{
+		Items:  items,
+		DryRun: true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.Spy.Create, len(items))
+	got := make([]string, len(mock.Spy.Create))
+	for i, call := range mock.Spy.Create {
+		got[i] = call[0].(containermanager.CreateOptions).ContainerName
+	}
+	assert.Equal(t,
+		[]string{"generic1", "generic2", "generic3", "arch", "tumbleweed_distrobox"},
+		got,
+	)
+}
+
 func TestAssembleCommand_SetupBox_ExportedBins_InvalidExportPath(t *testing.T) {
 	invalidPaths := []string{
 		"",

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -216,7 +216,7 @@ func (c *CreateCommand) makeContainerImage(opts *CreateOptions) string {
 //	ghcr.io/void-linux/void-linux:latest-full-x86_64 -> void-linux-latest-full-x86_64
 func (c *CreateCommand) makeContainerName(opts *CreateOptions, containerImage string) string {
 	containerName := opts.ContainerName
-	if opts.ContainerImage == "" {
+	if containerName == "" && opts.ContainerImage == "" {
 		containerName = c.cfg.DefaultContainerName
 	}
 	if containerName == "" {

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -142,7 +142,7 @@ func resolveIncludes(cfg *ini.File, section *ini.Section, processing, processed 
 
 // sectionToItem converts an ini.Section to an Item struct.
 func sectionToItem(section *ini.Section, env *userenv.UserEnvironment) Item { //nolint:funlen // Function length is acceptable here.
-	item := Item{Name: section.Name()}
+	item := Item{Name: strings.TrimSpace(section.Name())}
 
 	// default, to be overridden by manifest value if provided
 	item.ExportedBinsPath = env.Home + "/.local/bin"

--- a/pkg/manifest/parse_test.go
+++ b/pkg/manifest/parse_test.go
@@ -256,6 +256,78 @@ func TestParse_FromUrlServerError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParse_TrimsSectionNameWhitespace(t *testing.T) {
+	rawManifest := `
+[ leading]
+image=ubuntu:24.04
+
+[trailing ]
+image=ubuntu:24.04
+
+[ both ]
+image=ubuntu:24.04
+
+[none]
+image=ubuntu:24.04
+`
+
+	manifestPath := t.TempDir() + "/manifest.ini"
+	err := os.WriteFile(manifestPath, []byte(rawManifest), 0o644)
+	require.NoError(t, err)
+
+	parsed, err := manifest.Parse(t.Context(), manifestPath)
+	require.NoError(t, err)
+	require.Len(t, parsed, 4)
+
+	assert.Equal(t, "leading", parsed[0].Name)
+	assert.Equal(t, "trailing", parsed[1].Name)
+	assert.Equal(t, "both", parsed[2].Name)
+	assert.Equal(t, "none", parsed[3].Name)
+}
+
+func TestParse_ExampleManifest(t *testing.T) {
+	parsed, err := manifest.Parse(t.Context(), "../../extras/distrobox-example-manifest.ini")
+	require.NoError(t, err)
+	require.Len(t, parsed, 5)
+
+	names := make([]string, len(parsed))
+	for i, item := range parsed {
+		names[i] = item.Name
+	}
+	assert.Equal(t,
+		[]string{"generic1", "generic2", "generic3", "arch", "tumbleweed_distrobox"},
+		names,
+	)
+
+	generic1 := parsed[0]
+	assert.True(t, generic1.UnshareNetns)
+	assert.True(t, generic1.UnshareIPC)
+	assert.Empty(t, generic1.Image)
+
+	generic2 := parsed[1]
+	assert.True(t, generic2.Nvidia)
+	assert.Equal(t, []string{"git", "vim", "tmux"}, generic2.AdditionalPackages)
+
+	generic3 := parsed[2]
+	assert.Equal(t, "/tmp/home", generic3.Home)
+	assert.Equal(t, []string{"git", "vim", "tmux"}, generic3.AdditionalPackages)
+
+	arch := parsed[3]
+	assert.Equal(t, "archlinux:latest", arch.Image)
+	assert.True(t, arch.AlwaysPull)
+	assert.True(t, arch.StartNow)
+	assert.True(t, arch.UnshareNetns)
+	assert.Equal(t, "/tmp/home", arch.Home)
+	assert.Equal(t, []string{"touch /pre-init"}, arch.PreInitHooks)
+	assert.Equal(t, []string{"touch /init-normal"}, arch.InitHooks)
+
+	tw := parsed[4]
+	assert.Equal(t, "registry.opensuse.org/opensuse/distrobox", tw.Image)
+	assert.True(t, tw.AlwaysPull)
+	assert.Equal(t, []string{"htop"}, tw.ExportedApps)
+	assert.Equal(t, []string{"/usr/bin/htop", "/usr/bin/git"}, tw.ExportedBins)
+}
+
 func TestParse_FailCircularInclude(t *testing.T) {
 	rawManifest := `
 [a]


### PR DESCRIPTION
`makeContainerName` replaced user-provided names with DefaultContainerName whenever `image=` was empty, and `sectionToItem` kept whitespace from headers like `[ generic1]`.
Both made `assemble create` emit `--name my-distrobox` (or a leading-space name) for sections without an explicit image.