### PR TITLE
fix(cli): match upstream when no container name is given

### DIFF
--- a/internal/cli/enter.go
+++ b/internal/cli/enter.go
@@ -79,6 +79,10 @@ func enterAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) erro
 		args = args[1:]
 	}
 
+	if containerName == "" {
+		containerName = cfg.DefaultContainerName
+	}
+
 	options := commands.EnterOptions{
 		ContainerName:   containerName,
 		AdditionalFlags: cmd.String("additional-flags"),

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -53,12 +53,17 @@ func rmAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) error {
 		return errors.New("container manager not found in context")
 	}
 
+	names := cmd.Args().Slice()
+	if len(names) == 0 && !cmd.Bool("all") {
+		names = []string{cfg.DefaultContainerName}
+	}
+
 	options := commands.RmOptions{
 		NoTTY:          cmd.Bool("yes"),
 		Force:          cmd.Bool("force"),
 		All:            cmd.Bool("all"),
 		RemoveHome:     cmd.Bool("rm-home"),
-		ContainerNames: cmd.Args().Slice(),
+		ContainerNames: names,
 	}
 
 	prompter := ui.NewPrompter(*bufio.NewReader(os.Stdin), os.Stdout)

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -81,6 +81,12 @@ func upgradeAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) er
 		return nil
 	}
 
+	if errors.Is(err, commands.ErrUpgradeNoContainerSpecified) {
+		errPrinter.Println("Please specify the name of the container.")
+		//nolint:wrapcheck // sentinel returned as-is so caller exits non-zero
+		return err
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to upgrade containers: %w", err)
 	}

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -29,6 +29,7 @@ type UpgradeCommand struct {
 }
 
 var ErrUpgradeAbortedByUser = errors.New("upgrade operation aborted by user")
+var ErrUpgradeNoContainerSpecified = errors.New("please specify the name of the container")
 
 func NewUpgradeCommand(
 	cfg *config.Values,
@@ -75,7 +76,7 @@ func (c *UpgradeCommand) Execute(ctx context.Context, opts *UpgradeOptions) erro
 	case len(opts.ContainerNames) > 0:
 		containerNames = opts.ContainerNames
 	default:
-		containerNames = []string{c.cfg.DefaultContainerName}
+		return ErrUpgradeNoContainerSpecified
 	}
 
 	proceed := opts.NonInteractive || c.canProceed(containerNames)


### PR DESCRIPTION
- enter: fall back to cfg.DefaultContainerName (was passing "" to the manager)
- rm: fall back to cfg.DefaultContainerName (was a silent no-op)
- upgrade: error with "Please specify the name of the container." (was silently using my-distrobox)