### PR TITLE
refactor(providers): extract sleep durations into constants

### DIFF
--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -864,7 +864,7 @@ func (d *Docker) waitForSetup(
 		nextSince := containermanager.TimestampNow()
 		output, err := d.run(ctx, []string{"logs", "--since", since, containerName}, runOptions{})
 		if err != nil {
-			time.Sleep(100 * time.Millisecond) //nolint:mnd // TODO refactor sleeps
+			time.Sleep(logsRetryInterval)
 			continue
 		}
 		since = nextSince
@@ -898,6 +898,6 @@ func (d *Docker) waitForSetup(
 			}
 		}
 
-		time.Sleep(500 * time.Millisecond) //nolint:mnd // TODO refactor sleeps
+		time.Sleep(setupPollInterval)
 	}
 }

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -947,7 +947,7 @@ func (p *Podman) waitForSetup(
 		nextSince := containermanager.TimestampNow()
 		output, err := p.run(ctx, []string{"logs", "--since", since, containerName}, runOptions{})
 		if err != nil {
-			time.Sleep(100 * time.Millisecond) //nolint:mnd // TODO refactor sleeps
+			time.Sleep(logsRetryInterval)
 			continue
 		}
 		since = nextSince
@@ -981,6 +981,6 @@ func (p *Podman) waitForSetup(
 			}
 		}
 
-		time.Sleep(500 * time.Millisecond) //nolint:mnd // TODO refactor sleeps
+		time.Sleep(setupPollInterval)
 	}
 }

--- a/pkg/containermanager/providers/sleeps.go
+++ b/pkg/containermanager/providers/sleeps.go
@@ -1,0 +1,13 @@
+package providers
+
+import "time"
+
+// Sleep durations used while waiting for a container's setup to complete.
+const (
+	// logsRetryInterval is the delay before retrying when fetching container
+	// logs fails transiently during setup waiting.
+	logsRetryInterval = 100 * time.Millisecond
+	// setupPollInterval is the cadence at which container setup logs are
+	// polled while waiting for the setup-done marker.
+	setupPollInterval = 500 * time.Millisecond
+)


### PR DESCRIPTION
Replaces TODO-marked magic-number sleeps in docker.go and podman.go waitForSetup with named constants.