### PR TITLE
fix(ephemeral): pass custom command to enter

### DIFF
--- a/internal/cli/ephemeral.go
+++ b/internal/cli/ephemeral.go
@@ -77,7 +77,8 @@ func ephemeralAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) 
 			GenerateEntry:           false,
 			Rootful:                 cmd.Bool("root"),
 		},
-		DryRun: cmd.Bool("dry-run"),
+		CustomCommand: cmd.Args().Slice(),
+		DryRun:        cmd.Bool("dry-run"),
 	}
 
 	progress := ui.NewProgress(os.Stderr)

--- a/pkg/commands/ephemeral.go
+++ b/pkg/commands/ephemeral.go
@@ -16,7 +16,11 @@ const ephemeralCleanupTimeout = 30 * time.Second
 type EphemeralOptions struct {
 	CreateOptions
 
-	DryRun bool
+	// CustomCommand is the command (and its arguments) to execute inside the
+	// ephemeral container instead of the default login shell. It is forwarded
+	// to the underlying enter command.
+	CustomCommand []string
+	DryRun        bool
 }
 
 type EphemeralCommand struct {
@@ -78,8 +82,8 @@ func (c *EphemeralCommand) Execute(ctx context.Context, opts EphemeralOptions) e
 	// enter into it
 	enterOpts := EnterOptions{
 		ContainerName: name,
+		CustomCommand: opts.CustomCommand,
 		DryRun:        opts.DryRun,
-		// TODO: handle enter command
 	}
 	if _, enterErr := c.enterCmd.Execute(ctx, enterOpts); enterErr != nil {
 		return fmt.Errorf("ephemeral: %w", enterErr)

--- a/pkg/commands/ephemeral_test.go
+++ b/pkg/commands/ephemeral_test.go
@@ -1,0 +1,64 @@
+package commands_test
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/89luca89/distrobox/pkg/commands"
+	"github.com/89luca89/distrobox/pkg/config"
+	"github.com/89luca89/distrobox/pkg/internal/testutil"
+	"github.com/89luca89/distrobox/pkg/ui"
+)
+
+func newTestEphemeralCommand(mock *testutil.MockContainerManager) *commands.EphemeralCommand {
+	progress := ui.NewDevNullProgress()
+	prompter := ui.NewPrompter(*bufio.NewReader(strings.NewReader("")), io.Discard)
+	printer := ui.NewPrinter(io.Discard, false)
+	return commands.NewEphemeralCommand(&config.Values{}, mock, progress, printer, prompter)
+}
+
+func TestEphemeralCommand_PassesCustomCommandToEnter(t *testing.T) {
+	mock := &testutil.MockContainerManager{}
+	cmd := newTestEphemeralCommand(mock)
+
+	customCommand := []string{"cat", "/etc/os-release"}
+	err := cmd.Execute(context.Background(), commands.EphemeralOptions{
+		CreateOptions: commands.CreateOptions{
+			ContainerName:  "ephemeral-test",
+			ContainerImage: "alpine:latest",
+		},
+		CustomCommand: customCommand,
+		DryRun:        true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.Spy.Enter, 1, "expected Enter to be called exactly once")
+	opts := getEnterOptions(mock.Spy, 0)
+	assert.Equal(t, "ephemeral-test", opts.ContainerName)
+	assert.Equal(t, customCommand, opts.CustomCommand)
+}
+
+func TestEphemeralCommand_EmptyCustomCommandIsNotForwardedAsArgs(t *testing.T) {
+	mock := &testutil.MockContainerManager{}
+	cmd := newTestEphemeralCommand(mock)
+
+	err := cmd.Execute(context.Background(), commands.EphemeralOptions{
+		CreateOptions: commands.CreateOptions{
+			ContainerName:  "ephemeral-no-cmd",
+			ContainerImage: "alpine:latest",
+		},
+		DryRun: true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.Spy.Enter, 1, "expected Enter to be called exactly once")
+	opts := getEnterOptions(mock.Spy, 0)
+	assert.Equal(t, "ephemeral-no-cmd", opts.ContainerName)
+	assert.Empty(t, opts.CustomCommand, "expected no custom command to be forwarded")
+}


### PR DESCRIPTION
## Summary

- Resolves the `// TODO: handle enter command` in `pkg/commands/ephemeral.go` so the trailing positional arguments are actually forwarded to `distrobox enter`.
- Adds a `CustomCommand []string` field to `EphemeralOptions` (alongside the embedded `CreateOptions`), wires it into the synthesized `EnterOptions`, and populates it in the CLI from `cmd.Args().Slice()` (urfave/cli v3 consumes the `--` separator and exposes the remainder as positional args).
- Matches the bash reference (`distrobox-ephemeral` → `distrobox-enter ${extra_flags} "${name}" ${container_command}`).

Without this, `distrobox ephemeral --image alpine -- cat /etc/os-release` silently dropped the trailing command and just dropped the user into the default login shell.

## Test plan

- [x] `go test ./pkg/commands/...` — added two new tests:
  - `TestEphemeralCommand_PassesCustomCommandToEnter` asserts the spy records the exact `CustomCommand` slice on `Enter`.
  - `TestEphemeralCommand_EmptyCustomCommandIsNotForwardedAsArgs` asserts the absence of `CustomCommand` does not synthesize one (regression guard).
- [x] `make` (build)
- [x] `make fmt`
- [x] `make lint` (0 issues)
- [x] `make test` (full suite, including providers)