### PR TITLE
feat(generate-entry): auto-detect icon from container distro

### DIFF
--- a/pkg/commands/distro_icons.go
+++ b/pkg/commands/distro_icons.go
@@ -1,0 +1,67 @@
+package commands
+
+import "strings"
+
+// distroIconBaseURL is the upstream raw asset root for the bundled distro
+// logos shipped with the distrobox project.
+const distroIconBaseURL = "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/"
+
+// distroIconEntry maps a substring expected to appear in a container image
+// or container name to the matching desktop icon URL.
+//
+// The list is ordered from most specific to most generic so that, when
+// scanning a hint string for the first matching key, more specific variants
+// (e.g. opensuse-tumbleweed, kdeneon) win over short, ambiguous prefixes.
+type distroIconEntry struct {
+	key string
+	url string
+}
+
+// distroIconMap mirrors the DISTRO_ICON_MAP from the upstream
+// distrobox-generate-entry shell script. Keep entries in sync when new
+// distro icons are added under docs/assets/png/distros.
+//
+//nolint:gochecknoglobals // static lookup table, behaves like a constant
+var distroIconMap = []distroIconEntry{
+	{"opensuse-tumbleweed", distroIconBaseURL + "opensuse-distrobox.png"},
+	{"opensuse-leap", distroIconBaseURL + "opensuse-distrobox.png"},
+	{"opensuse", distroIconBaseURL + "opensuse-distrobox.png"},
+	{"tumbleweed", distroIconBaseURL + "opensuse-distrobox.png"},
+	{"kdeneon", distroIconBaseURL + "kdeneon-distrobox.png"},
+	{"archlinux", distroIconBaseURL + "arch-distrobox.png"},
+	{"alpinelinux", distroIconBaseURL + "alpine-distrobox.png"},
+	{"kalilinux", distroIconBaseURL + "kali-distrobox.png"},
+	{"clear", distroIconBaseURL + "clear-distrobox.png"},
+	{"alma", distroIconBaseURL + "alma-distrobox.png"},
+	{"alpine", distroIconBaseURL + "alpine-distrobox.png"},
+	{"alt", distroIconBaseURL + "alt-distrobox.png"},
+	{"arch", distroIconBaseURL + "arch-distrobox.png"},
+	{"centos", distroIconBaseURL + "centos-distrobox.png"},
+	{"debian", distroIconBaseURL + "debian-distrobox.png"},
+	{"deepin", distroIconBaseURL + "deepin-distrobox.png"},
+	{"fedora", distroIconBaseURL + "fedora-distrobox.png"},
+	{"gentoo", distroIconBaseURL + "gentoo-distrobox.png"},
+	{"kali", distroIconBaseURL + "kali-distrobox.png"},
+	{"rhel", distroIconBaseURL + "redhat-distrobox.png"},
+	{"redhat", distroIconBaseURL + "redhat-distrobox.png"},
+	{"rocky", distroIconBaseURL + "rocky-distrobox.png"},
+	{"ubuntu", distroIconBaseURL + "ubuntu-distrobox.png"},
+	{"vanilla", distroIconBaseURL + "vanilla-distrobox.png"},
+	{"void", distroIconBaseURL + "void-distrobox.png"},
+}
+
+// lookupDistroIcon returns the icon URL for the first distro key found as a
+// substring of hint (case-insensitive). When no key matches it returns the
+// empty string so callers can apply their own fallback.
+func lookupDistroIcon(hint string) string {
+	if hint == "" {
+		return ""
+	}
+	lower := strings.ToLower(hint)
+	for _, entry := range distroIconMap {
+		if strings.Contains(lower, entry.key) {
+			return entry.url
+		}
+	}
+	return ""
+}

--- a/pkg/commands/generate_entry.go
+++ b/pkg/commands/generate_entry.go
@@ -47,31 +47,14 @@ func NewGenerateEntryCommand(cfg *pkgconfig.Values, listCommand *ListCommand) *G
 func (c *GenerateEntryCommand) Execute(
 	ctx context.Context,
 	opts *GenerateEntryOptions) error {
-	// Determine whether is a single or all entries generation
-	// If all is set, fetch the list of all containers
-	// If not, use the provided container name or the default one
-	var containerNames []string
-	var icon string
-	switch {
-	case opts.All:
-		// Generate entries for all containers
-		listResult, err := c.listCommand.Execute(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list containers: %w", err)
-		}
-
-		containerNames = make([]string, 0, len(listResult.Containers))
-		for _, container := range listResult.Containers {
-			containerNames = append(containerNames, container.Name)
-		}
-		// Set icon to auto for all entries
-		icon = "auto"
-	case opts.ContainerName != "":
-		containerNames = []string{opts.ContainerName}
-		icon = opts.Icon
-	default:
-		containerNames = []string{defaultContainerName}
-		icon = opts.Icon
+	// containerImages maps a container name to its image; it is consulted
+	// when icon == "auto" to pick the matching distro logo. The map may be
+	// missing entries when the container manager can't be reached (e.g. in
+	// tests), in which case the container name itself is used as the
+	// distro hint.
+	containerNames, containerImages, icon, err := c.resolveTargets(ctx, opts)
+	if err != nil {
+		return err
 	}
 
 	// Determine the desktop entry base dir
@@ -104,12 +87,49 @@ func (c *GenerateEntryCommand) Execute(
 
 	// Create the desktop entries for all the containers
 	for _, containerName := range containerNames {
-		if err := c.createEntry(containerName, icon, desktopEntryBaseDir, distroboxPath, opts.Root); err != nil {
+		// Prefer the container's image as the distro hint when known;
+		// fall back to the container name so auto-detection still has
+		// something to match against.
+		distroHint := containerName
+		if image, ok := containerImages[containerName]; ok && image != "" {
+			distroHint = image
+		}
+		if err := c.createEntry(containerName, icon, distroHint, desktopEntryBaseDir, distroboxPath, opts.Root); err != nil {
 			return fmt.Errorf("failed to create desktop entry for container %s: %w", containerName, err)
 		}
 	}
 
 	return nil
+}
+
+// resolveTargets determines which containers need entries written, which
+// images back them (if known), and which icon string to use.
+//
+// When All is set the container manager is queried so the resulting images
+// can later feed distro auto-detection. For single-container modes the icon
+// comes from the user.
+func (c *GenerateEntryCommand) resolveTargets(
+	ctx context.Context,
+	opts *GenerateEntryOptions,
+) ([]string, map[string]string, string, error) {
+	switch {
+	case opts.All:
+		listResult, err := c.listCommand.Execute(ctx)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("failed to list containers: %w", err)
+		}
+		names := make([]string, 0, len(listResult.Containers))
+		images := make(map[string]string, len(listResult.Containers))
+		for _, container := range listResult.Containers {
+			names = append(names, container.Name)
+			images[container.Name] = container.Image
+		}
+		return names, images, "auto", nil
+	case opts.ContainerName != "":
+		return []string{opts.ContainerName}, nil, opts.Icon, nil
+	default:
+		return []string{defaultContainerName}, nil, opts.Icon, nil
+	}
 }
 
 func (c *GenerateEntryCommand) deleteEntry(containerName string, desktopEntryBaseDir string) error {
@@ -127,6 +147,7 @@ func (c *GenerateEntryCommand) deleteEntry(containerName string, desktopEntryBas
 func (c *GenerateEntryCommand) createEntry(
 	containerName string,
 	icon string,
+	distroHint string,
 	desktopEntryBaseDir string,
 	distroboxPath string,
 	root bool,
@@ -137,7 +158,7 @@ func (c *GenerateEntryCommand) createEntry(
 	}
 
 	entryFilePath := c.getEntryFilePath(desktopEntryAppsDir, containerName)
-	data := c.composeDesktopEntryData(containerName, icon, distroboxPath, root)
+	data := c.composeDesktopEntryData(containerName, icon, distroHint, distroboxPath, root)
 	if err := c.writeDesktopEntryFile(entryFilePath, data); err != nil {
 		return fmt.Errorf("failed to write desktop entry file for container %s: %w", containerName, err)
 	}
@@ -158,10 +179,14 @@ func (c *GenerateEntryCommand) ensureDesktopEntryDirExists(desktopEntryBaseDir s
 	return desktopEntryAppsDir, desktopEntryIconsDir, nil
 }
 
-// composeDesktopEntry generates the desktop entry for a single container
+// composeDesktopEntry generates the desktop entry for a single container.
+// distroHint is consulted only when icon == "auto" to pick a distro-specific
+// logo; pass the container's image name when available, otherwise the
+// container name itself.
 func (c *GenerateEntryCommand) composeDesktopEntryData(
 	containerName string,
 	icon string,
+	distroHint string,
 	distroboxPath string,
 	root bool,
 ) map[string]string {
@@ -174,7 +199,7 @@ func (c *GenerateEntryCommand) composeDesktopEntryData(
 		"entry_name":     getEntryName(containerName),
 		"container_name": containerName,
 		"distrobox_path": distroboxPath,
-		"icon":           c.getDesktopIcon(icon),
+		"icon":           c.getDesktopIcon(icon, distroHint),
 		"extra_flags":    extraFlags,
 	}
 }
@@ -219,13 +244,19 @@ func (c *GenerateEntryCommand) getEntryFilePath(desktopEntryDir, containerName s
 	return filepath.Join(desktopEntryDir, containerName+".desktop")
 }
 
-func (c *GenerateEntryCommand) getDesktopIcon(
-	icon string,
-) string {
-	if icon == "auto" {
-		// TODO: detect the icon for the current container's distro
-		return defaultEntryIcon
+// getDesktopIcon resolves the icon URL written to the desktop entry.
+//
+// When the caller passes a concrete icon it is returned unchanged. When the
+// special value "auto" is used, distroHint (typically the container's image
+// name, falling back to its name) is matched against the known distro icon
+// map. The generic terminal icon is returned if no distro can be detected.
+func (c *GenerateEntryCommand) getDesktopIcon(icon, distroHint string) string {
+	if icon != "auto" {
+		return icon
 	}
 
-	return icon
+	if url := lookupDistroIcon(distroHint); url != "" {
+		return url
+	}
+	return defaultEntryIcon
 }

--- a/pkg/commands/generate_entry_internal_test.go
+++ b/pkg/commands/generate_entry_internal_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDesktopIcon_AutoDetectsFedora(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "fedora-39")
+
+	want := "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/fedora-distrobox.png"
+	assert.Equal(t, want, got)
+}
+
+func TestGetDesktopIcon_AutoDetectsUbuntu(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "ubuntu-22")
+
+	want := "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/ubuntu-distrobox.png"
+	assert.Equal(t, want, got)
+}
+
+func TestGetDesktopIcon_AutoFallsBackToTerminalOnUnknownDistro(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "unknown-distro")
+
+	assert.Equal(t, defaultEntryIcon, got)
+}
+
+func TestGetDesktopIcon_CustomIconIsPassedThroughUnchanged(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("custom-url", "fedora")
+
+	assert.Equal(t, "custom-url", got)
+}
+
+func TestGetDesktopIcon_AutoDetectsOpenSUSETumbleweedBeforeGenericOpenSUSE(t *testing.T) {
+	// Regression: opensuse-tumbleweed must be matched as a specific variant,
+	// not collapsed to a non-existent generic "opensuse" entry.
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "registry.opensuse.org/opensuse/tumbleweed:latest")
+
+	want := "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/opensuse-distrobox.png"
+	assert.Equal(t, want, got)
+}
+
+func TestGetDesktopIcon_AutoDetectsArchFromImageRegistry(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "docker.io/library/archlinux:latest")
+
+	want := "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/arch-distrobox.png"
+	assert.Equal(t, want, got)
+}
+
+func TestGetDesktopIcon_AutoIsCaseInsensitive(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "Fedora-Toolbox")
+
+	want := "https://raw.githubusercontent.com/89luca89/distrobox/main/docs/assets/png/distros/fedora-distrobox.png"
+	assert.Equal(t, want, got)
+}
+
+func TestGetDesktopIcon_AutoWithEmptyHintFallsBackToDefault(t *testing.T) {
+	c := &GenerateEntryCommand{}
+
+	got := c.getDesktopIcon("auto", "")
+
+	assert.Equal(t, defaultEntryIcon, got)
+}


### PR DESCRIPTION
## Summary

Resolves a `TODO` in the Go port of `distrobox-generate-entry`:
`getDesktopIcon` used to ignore `--icon auto` (and the implicit `auto`
applied by `--all`) and always return the generic terminal logo.

- Adds `pkg/commands/distro_icons.go` with the same `DISTRO_ICON_MAP`
  shipped in the Bash `distrobox-generate-entry` (alma, alpine, alt,
  arch, centos, clear, debian, deepin, fedora, gentoo, kali, kdeneon,
  opensuse-leap, opensuse-tumbleweed, rhel, rocky, ubuntu, vanilla,
  void) plus a few obvious aliases (archlinux, alpinelinux, kalilinux,
  tumbleweed, redhat) so common image names match.
- Extends `getDesktopIcon` to take a `distroHint` string. Hints are
  matched case-insensitively against the map; more specific keys
  (e.g. `opensuse-tumbleweed`, `archlinux`) are listed before short
  prefixes (`arch`, `opensuse`) so they win on substring match.
- Plumbs the hint down from `Execute` -> `createEntry` ->
  `composeDesktopEntryData`. The `--all` flow now records each
  container's image alongside its name, so detection works without
  extra calls. When a hint is missing (e.g. single-container call) we
  fall back to the container name, then to the generic terminal icon.
- Extracts the target-resolution `switch` from `Execute` into a
  `resolveTargets` helper to keep cognitive complexity below the
  project's `gocognit` budget.

The Bash original reads `/etc/os-release` from the running container;
matching against the image name covers the common cases (`fedora:39`,
`registry.fedoraproject.org/fedora-toolbox:latest`, `archlinux`,
`docker.io/library/ubuntu:22.04`, ...) without requiring the
container to be running, which is needed for `distrobox generate-entry
--all` to work on stopped boxes too.

## Test plan

- [x] `go test ./pkg/commands/ -run TestGetDesktopIcon` - 8 new
  white-box tests in `generate_entry_internal_test.go` covering:
  fedora detection, ubuntu detection, unknown-distro fallback to the
  default icon, custom-URL pass-through, opensuse-tumbleweed beating
  generic opensuse, archlinux detected from a registry path,
  case-insensitive matching, and the empty-hint fallback.
- [x] `make` - build succeeds.
- [x] `make fmt` - clean.
- [x] `make lint` - 0 issues.
- [x] `make test` - full suite green, no regressions.