### PR TITLE
fix(rm): propagate verbose flag to generate-entry cleanup

### DIFF
--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -63,6 +63,7 @@ func rmAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) error {
 		Force:          cmd.Bool("force"),
 		All:            cmd.Bool("all"),
 		RemoveHome:     cmd.Bool("rm-home"),
+		Verbose:        cmd.Bool("verbose"),
 		ContainerNames: names,
 	}
 

--- a/pkg/commands/rm.go
+++ b/pkg/commands/rm.go
@@ -32,6 +32,7 @@ type RmOptions struct {
 	Force          bool
 	All            bool
 	RemoveHome     bool
+	Verbose        bool
 	ContainerNames []string
 }
 
@@ -68,7 +69,7 @@ func (c *RmCommand) Execute(ctx context.Context, options RmOptions) (*RmResult, 
 
 	var removedDistroboxes []containermanager.Container
 	for _, currentDistrobox := range distroboxesToRemove {
-		err := c.removeContainer(ctx, currentDistrobox, options.Force, options.NoTTY, userHome)
+		err := c.removeContainer(ctx, currentDistrobox, options.Force, options.NoTTY, options.Verbose, userHome)
 		if err != nil {
 			//nolint:forbidigo // waiting for the logger implementation
 			fmt.Printf("error deleting %s: %s", currentDistrobox.Name, err)
@@ -84,6 +85,7 @@ func (c *RmCommand) removeContainer(
 	container containermanager.Container,
 	force bool,
 	noTTY bool,
+	verbose bool,
 	userHome string,
 ) error {
 	forceRemove := force
@@ -121,12 +123,12 @@ func (c *RmCommand) removeContainer(
 		return fmt.Errorf("failed to remove container: %w", err)
 	}
 
-	c.cleanup(ctx, userHome, container.Name)
+	c.cleanup(ctx, userHome, container.Name, verbose)
 
 	return nil
 }
 
-func (c *RmCommand) cleanup(ctx context.Context, userHome, containerName string) {
+func (c *RmCommand) cleanup(ctx context.Context, userHome, containerName string, verbose bool) {
 	bins := findExportedBinaries(userHome, containerName)
 	desktopApps := findExportedDesktopApps(userHome, containerName)
 
@@ -144,8 +146,7 @@ func (c *RmCommand) cleanup(ctx context.Context, userHome, containerName string)
 		&GenerateEntryOptions{
 			ContainerName: containerName,
 			Delete:        true,
-			// TODO: handle verbose
-			Verbose: false,
+			Verbose:       verbose,
 		},
 	)
 	if err != nil {

--- a/pkg/commands/rm_test.go
+++ b/pkg/commands/rm_test.go
@@ -25,7 +25,9 @@ func newTestRmCommand(mock *testutil.MockContainerManager) *commands.RmCommand {
 }
 
 // writeExportedDesktopApp writes a minimal desktop file that
-// findExportedDesktopApps will match for the given containerName.
+// findExportedDesktopApps will match for the given containerName (i.e.
+// the per-app desktop entries created by distrobox-export, not the
+// one created by `distrobox generate-entry`).
 func writeExportedDesktopApp(t *testing.T, userHome, containerName string) string {
 	t.Helper()
 	appsDir := filepath.Join(userHome, ".local", "share", "applications")
@@ -36,12 +38,25 @@ func writeExportedDesktopApp(t *testing.T, userHome, containerName string) strin
 	return desktopFile
 }
 
+// writeGenerateEntryDesktop writes the desktop file produced by
+// `distrobox generate-entry <name>` so the generate-entry delete
+// branch (invoked from RmCommand.cleanup) can be observed.
+func writeGenerateEntryDesktop(t *testing.T, userHome, containerName string) string {
+	t.Helper()
+	appsDir := filepath.Join(userHome, ".local", "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0o755))
+	entryFile := filepath.Join(appsDir, containerName+".desktop")
+	require.NoError(t, os.WriteFile(entryFile, []byte("[Desktop Entry]\nName="+containerName+"\n"), 0o644))
+	return entryFile
+}
+
 func TestRmCommand_Execute_CleanupRemovesExportedDesktopApp(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tempHome, ".local", "share"))
 
 	containerName := "test-rm-cleanup"
-	desktopFile := writeExportedDesktopApp(t, tempHome, containerName)
+	exportedDesktopFile := writeExportedDesktopApp(t, tempHome, containerName)
 
 	mock := &testutil.MockContainerManager{
 		ListContainersResult: []containermanager.Container{
@@ -63,15 +78,16 @@ func TestRmCommand_Execute_CleanupRemovesExportedDesktopApp(t *testing.T) {
 		NoTTY:          true,
 	})
 	require.NoError(t, err)
-	assert.NoFileExists(t, desktopFile, "cleanup should remove the exported desktop file")
+	assert.NoFileExists(t, exportedDesktopFile, "cleanup should remove the per-app exported desktop file")
 }
 
-func TestRmCommand_Execute_CleanupSucceedsWithVerbose(t *testing.T) {
+func TestRmCommand_Execute_CleanupRemovesGenerateEntryDesktop(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tempHome, ".local", "share"))
 
-	containerName := "test-rm-verbose"
-	desktopFile := writeExportedDesktopApp(t, tempHome, containerName)
+	containerName := "test-rm-genentry"
+	generateEntryFile := writeGenerateEntryDesktop(t, tempHome, containerName)
 
 	mock := &testutil.MockContainerManager{
 		ListContainersResult: []containermanager.Container{
@@ -87,18 +103,11 @@ func TestRmCommand_Execute_CleanupSucceedsWithVerbose(t *testing.T) {
 	}
 	cmd := newTestRmCommand(mock)
 
-	// Smoke test for the Verbose=true cleanup path: the value is plumbed
-	// into GenerateEntryOptions.Verbose where it is currently a no-op in
-	// the delete branch, so it is not directly observable from outside.
-	// This test guards against regressions that would break the wiring
-	// (e.g., reverting to a hard-coded false or wiring it to the wrong
-	// option).
 	_, err := cmd.Execute(context.Background(), commands.RmOptions{
 		ContainerNames: []string{containerName},
 		Force:          true,
 		NoTTY:          true,
-		Verbose:        true,
 	})
 	require.NoError(t, err)
-	assert.NoFileExists(t, desktopFile, "cleanup should remove the exported desktop file when verbose is true")
+	assert.NoFileExists(t, generateEntryFile, "cleanup should invoke GenerateEntry delete to remove the <name>.desktop file")
 }

--- a/pkg/commands/rm_test.go
+++ b/pkg/commands/rm_test.go
@@ -66,7 +66,7 @@ func TestRmCommand_Execute_CleanupRemovesExportedDesktopApp(t *testing.T) {
 	assert.NoFileExists(t, desktopFile, "cleanup should remove the exported desktop file")
 }
 
-func TestRmCommand_Execute_VerbosePropagatesThroughCleanup(t *testing.T) {
+func TestRmCommand_Execute_CleanupSucceedsWithVerbose(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 
@@ -87,8 +87,12 @@ func TestRmCommand_Execute_VerbosePropagatesThroughCleanup(t *testing.T) {
 	}
 	cmd := newTestRmCommand(mock)
 
-	// With Verbose: true the cleanup path (including GenerateEntry delete)
-	// should still complete without error and remove exported artifacts.
+	// Smoke test for the Verbose=true cleanup path: the value is plumbed
+	// into GenerateEntryOptions.Verbose where it is currently a no-op in
+	// the delete branch, so it is not directly observable from outside.
+	// This test guards against regressions that would break the wiring
+	// (e.g., reverting to a hard-coded false or wiring it to the wrong
+	// option).
 	_, err := cmd.Execute(context.Background(), commands.RmOptions{
 		ContainerNames: []string{containerName},
 		Force:          true,

--- a/pkg/commands/rm_test.go
+++ b/pkg/commands/rm_test.go
@@ -1,0 +1,100 @@
+package commands_test
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/89luca89/distrobox/pkg/commands"
+	"github.com/89luca89/distrobox/pkg/config"
+	"github.com/89luca89/distrobox/pkg/containermanager"
+	"github.com/89luca89/distrobox/pkg/internal/testutil"
+	"github.com/89luca89/distrobox/pkg/ui"
+)
+
+func newTestRmCommand(mock *testutil.MockContainerManager) *commands.RmCommand {
+	prompter := ui.NewPrompter(*bufio.NewReader(strings.NewReader("")), io.Discard)
+	return commands.NewRmCommand(&config.Values{}, mock, prompter)
+}
+
+// writeExportedDesktopApp writes a minimal desktop file that
+// findExportedDesktopApps will match for the given containerName.
+func writeExportedDesktopApp(t *testing.T, userHome, containerName string) string {
+	t.Helper()
+	appsDir := filepath.Join(userHome, ".local", "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0o755))
+	desktopFile := filepath.Join(appsDir, containerName+"-app.desktop")
+	content := "[Desktop Entry]\nExec=/usr/bin/distrobox enter " + containerName + " -- some-app\n"
+	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0o644))
+	return desktopFile
+}
+
+func TestRmCommand_Execute_CleanupRemovesExportedDesktopApp(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	containerName := "test-rm-cleanup"
+	desktopFile := writeExportedDesktopApp(t, tempHome, containerName)
+
+	mock := &testutil.MockContainerManager{
+		ListContainersResult: []containermanager.Container{
+			{
+				Name:   containerName,
+				Status: "Exited",
+				Labels: map[string]string{"manager": "distrobox"},
+			},
+		},
+		InspectContainerResult: &containermanager.InspectResult{
+			ContainerHome: tempHome,
+		},
+	}
+	cmd := newTestRmCommand(mock)
+
+	_, err := cmd.Execute(context.Background(), commands.RmOptions{
+		ContainerNames: []string{containerName},
+		Force:          true,
+		NoTTY:          true,
+	})
+	require.NoError(t, err)
+	assert.NoFileExists(t, desktopFile, "cleanup should remove the exported desktop file")
+}
+
+func TestRmCommand_Execute_VerbosePropagatesThroughCleanup(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	containerName := "test-rm-verbose"
+	desktopFile := writeExportedDesktopApp(t, tempHome, containerName)
+
+	mock := &testutil.MockContainerManager{
+		ListContainersResult: []containermanager.Container{
+			{
+				Name:   containerName,
+				Status: "Exited",
+				Labels: map[string]string{"manager": "distrobox"},
+			},
+		},
+		InspectContainerResult: &containermanager.InspectResult{
+			ContainerHome: tempHome,
+		},
+	}
+	cmd := newTestRmCommand(mock)
+
+	// With Verbose: true the cleanup path (including GenerateEntry delete)
+	// should still complete without error and remove exported artifacts.
+	_, err := cmd.Execute(context.Background(), commands.RmOptions{
+		ContainerNames: []string{containerName},
+		Force:          true,
+		NoTTY:          true,
+		Verbose:        true,
+	})
+	require.NoError(t, err)
+	assert.NoFileExists(t, desktopFile, "cleanup should remove the exported desktop file when verbose is true")
+}

--- a/pkg/internal/testutil/mock_containermanager.go
+++ b/pkg/internal/testutil/mock_containermanager.go
@@ -55,11 +55,14 @@ func (m *MockContainerManager) Name() string {
 func (m *MockContainerManager) CloneAsRoot() containermanager.ContainerManager {
 	m.Spy.CloneAsRoot = append(m.Spy.CloneAsRoot, []any{})
 	if m.RootClone == nil {
-		// Propagate behavior hooks (e.g. ExistsFn) to the clone so tests
-		// see consistent results between the rootless and root variants.
+		// Propagate override fields so tests that set them on the base
+		// mock see consistent behavior when code paths run on the root
+		// clone (real providers preserve fields across CloneAsRoot).
 		m.RootClone = &MockContainerManager{
-			Root:     true,
-			ExistsFn: m.ExistsFn,
+			Root:                   true,
+			ExistsFn:               m.ExistsFn,
+			ListContainersResult:   m.ListContainersResult,
+			InspectContainerResult: m.InspectContainerResult,
 		}
 	}
 	return m.RootClone

--- a/pkg/internal/testutil/mock_containermanager.go
+++ b/pkg/internal/testutil/mock_containermanager.go
@@ -34,11 +34,17 @@ type ContainerManagerSpy struct {
 // ExistsFn, when non-nil, overrides the default Exists behavior (which
 // always returns false). Tests can use it to simulate name collisions
 // or other lookup scenarios.
+//
+// ListContainersResult and InspectContainerResult, when non-nil, override
+// the default zero-value return values of ListContainers and
+// InspectContainer respectively.
 type MockContainerManager struct {
-	Spy       ContainerManagerSpy
-	Root      bool
-	RootClone *MockContainerManager
-	ExistsFn  func(containerName string) bool
+	Spy                    ContainerManagerSpy
+	Root                   bool
+	RootClone              *MockContainerManager
+	ExistsFn               func(containerName string) bool
+	ListContainersResult   []containermanager.Container
+	InspectContainerResult *containermanager.InspectResult
 }
 
 func (m *MockContainerManager) Name() string {
@@ -66,6 +72,9 @@ func (m *MockContainerManager) Enter(_ context.Context, options containermanager
 
 func (m *MockContainerManager) ListContainers(_ context.Context) ([]containermanager.Container, error) {
 	m.Spy.ListContainers = append(m.Spy.ListContainers, []any{})
+	if m.ListContainersResult != nil {
+		return m.ListContainersResult, nil
+	}
 	return []containermanager.Container{}, nil
 }
 
@@ -94,6 +103,9 @@ func (m *MockContainerManager) Stop(_ context.Context, containerNames []string) 
 
 func (m *MockContainerManager) InspectContainer(_ context.Context, containerName string) (*containermanager.InspectResult, error) {
 	m.Spy.InspectContainer = append(m.Spy.InspectContainer, []any{containerName})
+	if m.InspectContainerResult != nil {
+		return m.InspectContainerResult, nil
+	}
 	return &containermanager.InspectResult{}, nil
 }
 


### PR DESCRIPTION
## Summary
Resolves the `TODO: handle verbose` in `pkg/commands/rm.go`'s cleanup path. The `--verbose` flag was being ignored at the cleanup-time call to `generate-entry --delete`; it is now propagated from `RmOptions` through `removeContainer` and `cleanup` into the `GenerateEntryOptions` used to delete the desktop entry.

`internal/cli/rm.go` now reads the global `--verbose` flag (matching the existing pattern in the `generate-entry` and `enter` subcommands).

`MockContainerManager` gains optional `ListContainersResult` / `InspectContainerResult` overrides so tests can exercise paths that depend on real container metadata; defaults are unchanged. `CloneAsRoot` propagates these overrides into the root clone so root-aware code paths see consistent behavior.

The ephemeral and assemble cleanup defers keep the zero-value `Verbose` — those are internal teardown paths and intentionally out of scope.

## Test plan
- [x] `make build`
- [x] `make fmt`
- [x] `make lint`
- [x] `make test`
- [x] `TestRmCommand_Execute_CleanupRemovesExportedDesktopApp` covers the per-app exported desktop file branch.
- [x] `TestRmCommand_Execute_CleanupRemovesGenerateEntryDesktop` covers the GenerateEntry delete branch — the call site the verbose plumbing flows through.