### PR TITLE
feat(create): implement --compatibility to fetch supported image list

### DIFF
--- a/internal/cli/compatibility.go
+++ b/internal/cli/compatibility.go
@@ -1,0 +1,389 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/89luca89/distrobox/pkg/version"
+)
+
+const (
+	// compatibilityURLTemplate is the upstream URL for docs/compatibility.md.
+	// %s is the git ref (tag or branch) to fetch from.
+	compatibilityURLTemplate = "https://raw.githubusercontent.com/89luca89/distrobox/%s/docs/compatibility.md"
+
+	// compatibilityFetchTimeout caps the time we wait for the HTTP request.
+	compatibilityFetchTimeout = 15 * time.Second
+
+	// devFallbackRef is used in place of the "dev" version (set on local
+	// builds) to fetch the latest upstream compatibility list.
+	devFallbackRef = "main"
+
+	// containersDistrosHeader is the markdown heading that precedes the
+	// "Containers Distros" table in docs/compatibility.md. We parse the
+	// first markdown table that follows it; everything else (including
+	// the "Host Distros" table above it) is ignored.
+	containersDistrosHeader = "## Containers Distros"
+)
+
+// showCompatibility prints the list of container images known to work with
+// distrobox. The list is fetched from the upstream docs/compatibility.md (for
+// the current version) and cached on disk so subsequent invocations are
+// offline-friendly. The provided context is used to cancel the upstream HTTP
+// fetch (e.g., via SIGINT); local cache reads/writes are intentionally
+// uncancellable since they are bounded and very fast.
+//
+// This is the Go port of the bash show_compatibility helper:
+// https://github.com/89luca89/distrobox/blob/main/distrobox-create#L254
+func showCompatibility(ctx context.Context) error {
+	ref := compatibilityRef(version.Version)
+
+	cacheDir, err := compatibilityCacheDir()
+	if err != nil {
+		return fmt.Errorf("resolve cache directory: %w", err)
+	}
+	// Use the sanitized ref in the cache filename so that an unusual
+	// build-time version string (e.g. one containing "/" or "..") can
+	// never escape the cache directory.
+	cachePath := filepath.Join(cacheDir, "distrobox-compatibility-"+sanitizeRefForFilename(ref))
+
+	content, err := readCompatibilityCache(cachePath)
+	if err == nil {
+		fmt.Print(content) //nolint:forbidigo // CLI output by design
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errEmptyCache) {
+		return fmt.Errorf("read compatibility cache: %w", err)
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, compatibilityFetchTimeout)
+	defer cancel()
+
+	markdown, err := fetchCompatibilityMarkdown(fetchCtx, http.DefaultClient, ref)
+	if err != nil {
+		return fmt.Errorf("fetch compatibility list: %w", err)
+	}
+
+	images := parseCompatibilityImages(markdown)
+	if len(images) == 0 {
+		return errors.New("parse compatibility list: no images found")
+	}
+
+	rendered := strings.Join(images, "\n") + "\n"
+
+	if err := writeCompatibilityCache(cachePath, rendered); err != nil {
+		// Cache write failure is not fatal: we still got the data and
+		// the user is entitled to see it.
+		fmt.Fprintf(os.Stderr, "warning: could not write compatibility cache to %s: %v\n", cachePath, err)
+	}
+
+	fmt.Print(rendered) //nolint:forbidigo // CLI output by design
+	return nil
+}
+
+// gitDescribeSuffixRE matches the trailing `-N-gHEX` segment that
+// `git describe --tags --always` appends to a tag when HEAD is N commits
+// past the tag (e.g. `v1.8.1-3-g1bc3554`). Stripping it gives us the tag
+// itself, which is a valid GitHub ref upstream.
+var gitDescribeSuffixRE = regexp.MustCompile(`-\d+-g[0-9a-f]{4,40}$`)
+
+// compatibilityRef returns the git ref to fetch docs/compatibility.md from.
+//
+//   - "" and "dev" (local builds without ldflags overrides) fall back to "main".
+//   - A `git describe` output like "v1.8.1-3-g1bc3554" or
+//     "v1.8.1-3-g1bc3554-dirty" is normalized to the nearest tag ("v1.8.1"),
+//     which is a real ref upstream.
+//   - A bare commit-only output like "g1bc3554" (no tag prefix) also falls
+//     back to "main".
+//   - Anything else is used as-is.
+func compatibilityRef(buildVersion string) string {
+	if buildVersion == "" || buildVersion == "dev" {
+		return devFallbackRef
+	}
+
+	// `git describe --dirty` appends "-dirty"; drop it first so the
+	// suffix regex sees the canonical `-N-gHEX` shape.
+	ref := strings.TrimSuffix(buildVersion, "-dirty")
+	ref = gitDescribeSuffixRE.ReplaceAllString(ref, "")
+
+	// `git describe --always` falls back to a bare hash for untagged
+	// repositories. That is not a useful ref for upstream, so fall back
+	// to main.
+	if isGitHashOnly(ref) {
+		return devFallbackRef
+	}
+
+	return ref
+}
+
+// sanitizeRefForFilename returns a version of ref safe to embed in a
+// filename: every character that is not [A-Za-z0-9._-] is replaced with
+// `_`. This prevents a ref containing path separators (e.g.
+// "feature/foo") or dot-segments (e.g. "../etc/passwd") from creating
+// nested paths or escaping the cache directory when concatenated into
+// the cache file name.
+func sanitizeRefForFilename(ref string) string {
+	if ref == "" {
+		return "_"
+	}
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '_'
+		}
+	}, ref)
+	// A ref of "." or ".." would still be problematic after the per-char
+	// mapping (it stays as-is), so explicitly neutralize it.
+	if mapped == "." || mapped == ".." {
+		return "_"
+	}
+	return mapped
+}
+
+// isGitHashOnly reports whether ref looks like a bare git hash with no
+// surrounding tag information (matches the "g<hex>" or plain "<hex>"
+// shapes that `git describe --always` produces when no tag is reachable).
+func isGitHashOnly(ref string) bool {
+	candidate := strings.TrimPrefix(ref, "g")
+	if len(candidate) < 4 {
+		return false
+	}
+	for _, r := range candidate {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// compatibilityCacheDir returns the per-user cache directory used to store
+// the parsed compatibility list. It honours XDG_CACHE_HOME and falls back to
+// $HOME/.cache.
+func compatibilityCacheDir() (string, error) {
+	base := os.Getenv("XDG_CACHE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("user home directory: %w", err)
+		}
+		base = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(base, "distrobox"), nil
+}
+
+// errEmptyCache is returned by readCompatibilityCache when the cache file
+// exists but contains no data. The caller treats this the same as a miss.
+var errEmptyCache = errors.New("compatibility cache file is empty")
+
+// readCompatibilityCache returns the cached compatibility list if a non-empty
+// cache file exists. It returns os.ErrNotExist when the cache is absent and
+// errEmptyCache when the file is present but empty.
+func readCompatibilityCache(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err //nolint:wrapcheck // sentinel errors are propagated as-is for the caller
+	}
+	if info.Size() == 0 {
+		return "", errEmptyCache
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read cache file: %w", err)
+	}
+	return string(data), nil
+}
+
+// writeCompatibilityCache atomically writes the parsed compatibility list
+// to the on-disk cache, creating the parent directory if needed. The write
+// goes to a temp file in the same directory and is then renamed into place
+// so that a crashed or concurrent writer can never leave a partially
+// populated cache file visible to readCompatibilityCache.
+func writeCompatibilityCache(path, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create cache directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp cache file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// If anything below fails after the temp file is opened, do our best
+	// to leave no garbage behind.
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp cache file: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp cache file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp cache file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp cache file into place: %w", err)
+	}
+	return nil
+}
+
+// fetchCompatibilityMarkdown downloads docs/compatibility.md for the given
+// git ref using the provided HTTP client.
+func fetchCompatibilityMarkdown(ctx context.Context, client *http.Client, ref string) (string, error) {
+	url := fmt.Sprintf(compatibilityURLTemplate, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected HTTP status %d fetching %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response body: %w", err)
+	}
+	return string(body), nil
+}
+
+// parseCompatibilityImages extracts the container image references from the
+// "Containers Distros" table in compatibility.md. It walks the document to
+// the `## Containers Distros` heading, locates the first markdown table that
+// follows (recognised by its `| --- |`-style separator row), then harvests
+// the third column of each subsequent row until the table ends (a non-table,
+// non-blank line) or another heading is reached. The header row and the
+// separator row are skipped automatically because they appear before
+// pastSeparator becomes true. Returned slice is sorted and deduplicated,
+// mirroring the `sort -u` behaviour of the original bash implementation.
+func parseCompatibilityImages(markdown string) []string {
+	seen := make(map[string]struct{})
+
+	var (
+		inSection     bool
+		pastSeparator bool
+	)
+	for _, line := range strings.Split(markdown, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if !inSection {
+			if trimmed == containersDistrosHeader {
+				inSection = true
+			}
+			continue
+		}
+
+		// A subsequent heading at any level closes our section.
+		if strings.HasPrefix(trimmed, "#") {
+			break
+		}
+
+		if !pastSeparator {
+			if isMarkdownTableSeparator(trimmed) {
+				pastSeparator = true
+			}
+			continue
+		}
+
+		// Past the separator the table ends as soon as we see a non-blank
+		// line that is not a row. Blank lines and empty-cell rows are
+		// tolerated and simply yield no images.
+		if trimmed != "" && !strings.HasPrefix(trimmed, "|") {
+			break
+		}
+
+		for _, image := range extractImagesFromRow(line) {
+			seen[image] = struct{}{}
+		}
+	}
+
+	images := make([]string, 0, len(seen))
+	for image := range seen {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	return images
+}
+
+// isMarkdownTableSeparator reports whether line is the separator row of a
+// markdown table (e.g., `| --- | --- | --- |`, optionally with alignment
+// colons such as `| :--- | :---: | ---: |`). The line is expected to be
+// already whitespace-trimmed.
+func isMarkdownTableSeparator(line string) bool {
+	if !strings.HasPrefix(line, "|") || !strings.Contains(line, "---") {
+		return false
+	}
+	for _, r := range line {
+		switch r {
+		case '|', '-', ':', ' ', '\t':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// extractImagesFromRow returns the image references from a single markdown
+// table row. The original bash pipeline cuts on `|`, takes the fourth field
+// (column 3 of the table when counting from 1), splits on `<br>`, strips
+// whitespace and drops empty entries.
+func extractImagesFromRow(line string) []string {
+	fields := strings.Split(line, "|")
+	// `| a | b | c |` splits into ["", " a ", " b ", " c ", ""], so the
+	// fourth field (index 4 with `cut -f 4`, index 3 here) holds the
+	// images column. Anything shorter is not a table row we care about.
+	if len(fields) < 5 {
+		return nil
+	}
+
+	cell := fields[3]
+	var images []string
+	for _, part := range strings.Split(cell, "<br>") {
+		image := strings.TrimSpace(part)
+		// Mirror the bash `tr -d ' '` and the later `sort -u`: also drop
+		// any stray whitespace within the entry (some rows have stray
+		// spaces inside the image name).
+		image = strings.Map(stripWhitespace, image)
+		if image == "" {
+			continue
+		}
+		images = append(images, image)
+	}
+	return images
+}
+
+// stripWhitespace is a strings.Map helper that drops every whitespace rune.
+func stripWhitespace(r rune) rune {
+	if unicode.IsSpace(r) {
+		return -1
+	}
+	return r
+}

--- a/internal/cli/compatibility.go
+++ b/internal/cli/compatibility.go
@@ -1,0 +1,350 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/89luca89/distrobox/pkg/version"
+)
+
+const (
+	// compatibilityURLTemplate is the upstream URL for docs/compatibility.md.
+	// %s is the git ref (tag or branch) to fetch from.
+	compatibilityURLTemplate = "https://raw.githubusercontent.com/89luca89/distrobox/%s/docs/compatibility.md"
+
+	// compatibilityFetchTimeout caps the time we wait for the HTTP request.
+	compatibilityFetchTimeout = 15 * time.Second
+
+	// devFallbackRef is used in place of the "dev" version (set on local
+	// builds) to fetch the latest upstream compatibility list.
+	devFallbackRef = "main"
+
+	// compatibilityTableStartMarker matches the first row of the
+	// "Containers Distros" table in docs/compatibility.md.
+	compatibilityTableStartMarker = "| Alma"
+
+	// compatibilityTableEndMarker matches the last row of the
+	// "Containers Distros" table in docs/compatibility.md.
+	compatibilityTableEndMarker = "| Void"
+)
+
+// showCompatibility prints the list of container images known to work with
+// distrobox. The list is fetched from the upstream docs/compatibility.md (for
+// the current version) and cached on disk so subsequent invocations are
+// offline-friendly. The provided context is used to cancel the upstream HTTP
+// fetch (e.g., via SIGINT); local cache reads/writes are intentionally
+// uncancellable since they are bounded and very fast.
+//
+// This is the Go port of the bash show_compatibility helper:
+// https://github.com/89luca89/distrobox/blob/main/distrobox-create#L254
+func showCompatibility(ctx context.Context) error {
+	ref := compatibilityRef(version.Version)
+
+	cacheDir, err := compatibilityCacheDir()
+	if err != nil {
+		return fmt.Errorf("resolve cache directory: %w", err)
+	}
+	// Use the sanitized ref in the cache filename so that an unusual
+	// build-time version string (e.g. one containing "/" or "..") can
+	// never escape the cache directory.
+	cachePath := filepath.Join(cacheDir, "distrobox-compatibility-"+sanitizeRefForFilename(ref))
+
+	content, err := readCompatibilityCache(cachePath)
+	if err == nil {
+		fmt.Print(content) //nolint:forbidigo // CLI output by design
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errEmptyCache) {
+		return fmt.Errorf("read compatibility cache: %w", err)
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, compatibilityFetchTimeout)
+	defer cancel()
+
+	markdown, err := fetchCompatibilityMarkdown(fetchCtx, http.DefaultClient, ref)
+	if err != nil {
+		return fmt.Errorf("fetch compatibility list: %w", err)
+	}
+
+	images := parseCompatibilityImages(markdown)
+	if len(images) == 0 {
+		return errors.New("parse compatibility list: no images found")
+	}
+
+	rendered := strings.Join(images, "\n") + "\n"
+
+	if err := writeCompatibilityCache(cachePath, rendered); err != nil {
+		// Cache write failure is not fatal: we still got the data and
+		// the user is entitled to see it.
+		fmt.Fprintf(os.Stderr, "warning: could not write compatibility cache to %s: %v\n", cachePath, err)
+	}
+
+	fmt.Print(rendered) //nolint:forbidigo // CLI output by design
+	return nil
+}
+
+// gitDescribeSuffixRE matches the trailing `-N-gHEX` segment that
+// `git describe --tags --always` appends to a tag when HEAD is N commits
+// past the tag (e.g. `v1.8.1-3-g1bc3554`). Stripping it gives us the tag
+// itself, which is a valid GitHub ref upstream.
+var gitDescribeSuffixRE = regexp.MustCompile(`-\d+-g[0-9a-f]{4,40}$`)
+
+// compatibilityRef returns the git ref to fetch docs/compatibility.md from.
+//
+//   - "" and "dev" (local builds without ldflags overrides) fall back to "main".
+//   - A `git describe` output like "v1.8.1-3-g1bc3554" or
+//     "v1.8.1-3-g1bc3554-dirty" is normalized to the nearest tag ("v1.8.1"),
+//     which is a real ref upstream.
+//   - A bare commit-only output like "g1bc3554" (no tag prefix) also falls
+//     back to "main".
+//   - Anything else is used as-is.
+func compatibilityRef(buildVersion string) string {
+	if buildVersion == "" || buildVersion == "dev" {
+		return devFallbackRef
+	}
+
+	// `git describe --dirty` appends "-dirty"; drop it first so the
+	// suffix regex sees the canonical `-N-gHEX` shape.
+	ref := strings.TrimSuffix(buildVersion, "-dirty")
+	ref = gitDescribeSuffixRE.ReplaceAllString(ref, "")
+
+	// `git describe --always` falls back to a bare hash for untagged
+	// repositories. That is not a useful ref for upstream, so fall back
+	// to main.
+	if isGitHashOnly(ref) {
+		return devFallbackRef
+	}
+
+	return ref
+}
+
+// sanitizeRefForFilename returns a version of ref safe to embed in a
+// filename: every character that is not [A-Za-z0-9._-] is replaced with
+// `_`. This prevents a ref containing path separators (e.g.
+// "feature/foo") or dot-segments (e.g. "../etc/passwd") from creating
+// nested paths or escaping the cache directory when concatenated into
+// the cache file name.
+func sanitizeRefForFilename(ref string) string {
+	if ref == "" {
+		return "_"
+	}
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '_'
+		}
+	}, ref)
+	// A ref of "." or ".." would still be problematic after the per-char
+	// mapping (it stays as-is), so explicitly neutralize it.
+	if mapped == "." || mapped == ".." {
+		return "_"
+	}
+	return mapped
+}
+
+// isGitHashOnly reports whether ref looks like a bare git hash with no
+// surrounding tag information (matches the "g<hex>" or plain "<hex>"
+// shapes that `git describe --always` produces when no tag is reachable).
+func isGitHashOnly(ref string) bool {
+	candidate := strings.TrimPrefix(ref, "g")
+	if len(candidate) < 4 {
+		return false
+	}
+	for _, r := range candidate {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// compatibilityCacheDir returns the per-user cache directory used to store
+// the parsed compatibility list. It honours XDG_CACHE_HOME and falls back to
+// $HOME/.cache.
+func compatibilityCacheDir() (string, error) {
+	base := os.Getenv("XDG_CACHE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("user home directory: %w", err)
+		}
+		base = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(base, "distrobox"), nil
+}
+
+// errEmptyCache is returned by readCompatibilityCache when the cache file
+// exists but contains no data. The caller treats this the same as a miss.
+var errEmptyCache = errors.New("compatibility cache file is empty")
+
+// readCompatibilityCache returns the cached compatibility list if a non-empty
+// cache file exists. It returns os.ErrNotExist when the cache is absent and
+// errEmptyCache when the file is present but empty.
+func readCompatibilityCache(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err //nolint:wrapcheck // sentinel errors are propagated as-is for the caller
+	}
+	if info.Size() == 0 {
+		return "", errEmptyCache
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read cache file: %w", err)
+	}
+	return string(data), nil
+}
+
+// writeCompatibilityCache atomically writes the parsed compatibility list
+// to the on-disk cache, creating the parent directory if needed. The write
+// goes to a temp file in the same directory and is then renamed into place
+// so that a crashed or concurrent writer can never leave a partially
+// populated cache file visible to readCompatibilityCache.
+func writeCompatibilityCache(path, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create cache directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp cache file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// If anything below fails after the temp file is opened, do our best
+	// to leave no garbage behind.
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp cache file: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp cache file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp cache file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp cache file into place: %w", err)
+	}
+	return nil
+}
+
+// fetchCompatibilityMarkdown downloads docs/compatibility.md for the given
+// git ref using the provided HTTP client.
+func fetchCompatibilityMarkdown(ctx context.Context, client *http.Client, ref string) (string, error) {
+	url := fmt.Sprintf(compatibilityURLTemplate, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected HTTP status %d fetching %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response body: %w", err)
+	}
+	return string(body), nil
+}
+
+// parseCompatibilityImages extracts the container image references from the
+// "Containers Distros" table in compatibility.md. The third column of each
+// row (image names, optionally separated by "<br>") is harvested between the
+// first line that starts with "| Alma" and the next line that starts with
+// "| Void". Returned slice is sorted and deduplicated, mirroring the
+// `sort -u` behaviour of the original bash implementation.
+func parseCompatibilityImages(markdown string) []string {
+	seen := make(map[string]struct{})
+
+	inTable := false
+	for _, line := range strings.Split(markdown, "\n") {
+		if !inTable {
+			if strings.HasPrefix(line, compatibilityTableStartMarker) {
+				inTable = true
+			} else {
+				continue
+			}
+		}
+
+		for _, image := range extractImagesFromRow(line) {
+			seen[image] = struct{}{}
+		}
+
+		if strings.HasPrefix(line, compatibilityTableEndMarker) {
+			break
+		}
+	}
+
+	images := make([]string, 0, len(seen))
+	for image := range seen {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	return images
+}
+
+// extractImagesFromRow returns the image references from a single markdown
+// table row. The original bash pipeline cuts on `|`, takes the fourth field
+// (column 3 of the table when counting from 1), splits on `<br>`, strips
+// whitespace and drops empty entries.
+func extractImagesFromRow(line string) []string {
+	fields := strings.Split(line, "|")
+	// `| a | b | c |` splits into ["", " a ", " b ", " c ", ""], so the
+	// fourth field (index 4 with `cut -f 4`, index 3 here) holds the
+	// images column. Anything shorter is not a table row we care about.
+	if len(fields) < 5 {
+		return nil
+	}
+
+	cell := fields[3]
+	var images []string
+	for _, part := range strings.Split(cell, "<br>") {
+		image := strings.TrimSpace(part)
+		// Mirror the bash `tr -d ' '` and the later `sort -u`: also drop
+		// any stray whitespace within the entry (some rows have stray
+		// spaces inside the image name).
+		image = strings.Map(stripWhitespace, image)
+		if image == "" {
+			continue
+		}
+		images = append(images, image)
+	}
+	return images
+}
+
+// stripWhitespace is a strings.Map helper that drops every whitespace rune.
+func stripWhitespace(r rune) rune {
+	if unicode.IsSpace(r) {
+		return -1
+	}
+	return r
+}

--- a/internal/cli/compatibility_internal_test.go
+++ b/internal/cli/compatibility_internal_test.go
@@ -1,0 +1,466 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleCompatibilityMarkdown = `# Compatibility
+
+## Host Distros
+
+| Distro | Version | Notes |
+| --- | --- | --- |
+| Alpine Linux | | |
+| Void Linux | glibc <br> musl | |
+
+## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux (Toolbox) | 8 <br> 9 | quay.io/toolbx-images/almalinux-toolbox:8 <br> quay.io/toolbx-images/almalinux-toolbox:9 <br> quay.io/toolbx-images/almalinux-toolbox:latest |
+| Alpine (Toolbox) | edge | quay.io/toolbx-images/alpine-toolbox:edge |
+| Fedora | 39 | quay.io/fedora/fedora:39 |
+| Void Linux | glibc <br> musl | ghcr.io/void-linux/void-glibc-full:latest <br> ghcr.io/void-linux/void-musl-full:latest |
+
+Trailing text that should be ignored.
+`
+
+func TestParseCompatibilityImages_ReturnsSortedUniqueImagesFromContainerDistrosTable(t *testing.T) {
+	images := parseCompatibilityImages(sampleCompatibilityMarkdown)
+
+	expected := []string{
+		"ghcr.io/void-linux/void-glibc-full:latest",
+		"ghcr.io/void-linux/void-musl-full:latest",
+		"quay.io/fedora/fedora:39",
+		"quay.io/toolbx-images/almalinux-toolbox:8",
+		"quay.io/toolbx-images/almalinux-toolbox:9",
+		"quay.io/toolbx-images/almalinux-toolbox:latest",
+		"quay.io/toolbx-images/alpine-toolbox:edge",
+	}
+	assert.Equal(t, expected, images)
+}
+
+func TestParseCompatibilityImages_SkipsHostDistrosTable(t *testing.T) {
+	// Rows that live in a markdown table BEFORE the `## Containers Distros`
+	// heading must never contribute, even when their third column happens
+	// to look like an image reference.
+	markdown := `## Host Distros
+
+| Distro | Version | Notes |
+| --- | --- | --- |
+| Alpine | | docker.io/should-not-appear:latest |
+
+## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.NotContains(t, images, "docker.io/should-not-appear:latest",
+		"rows from the Host Distros table must not contribute")
+	assert.Contains(t, images, "docker.io/library/almalinux:8")
+}
+
+func TestParseCompatibilityImages_StopsAtNonTableLine(t *testing.T) {
+	markdown := sampleCompatibilityMarkdown + `
+| Wonderlandia | 1 | docker.io/wonderlandia/wonderlandia:1 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.NotContains(t, images, "docker.io/wonderlandia/wonderlandia:1",
+		"rows after the table-terminating prose line should be ignored")
+}
+
+func TestParseCompatibilityImages_StopsAtSubsequentHeading(t *testing.T) {
+	markdown := `## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+
+### New Distro support
+
+| Wonderlandia | 1 | docker.io/wonderlandia/wonderlandia:1 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.Contains(t, images, "docker.io/library/almalinux:8")
+	assert.NotContains(t, images, "docker.io/wonderlandia/wonderlandia:1",
+		"rows after the next heading should be ignored")
+}
+
+func TestParseCompatibilityImages_SkipsTableHeaderRow(t *testing.T) {
+	// The literal "Images" cell of the header row must not leak through
+	// as if it were an image name. It precedes the separator, so the
+	// parser should ignore it.
+	markdown := `## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.NotContains(t, images, "Images")
+	assert.Equal(t, []string{"docker.io/library/almalinux:8"}, images)
+}
+
+func TestParseCompatibilityImages_DeduplicatesIdenticalEntries(t *testing.T) {
+	markdown := `## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+| AlmaLinux 2 | 8 | docker.io/library/almalinux:8 |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	require.Len(t, images, 2)
+	assert.Equal(t, []string{
+		"docker.io/library/almalinux:8",
+		"ghcr.io/void-linux/void-musl-full:latest",
+	}, images)
+}
+
+func TestParseCompatibilityImages_StripsInternalAndSurroundingWhitespace(t *testing.T) {
+	// Some rows in the real doc have stray spaces around the <br>
+	// separator inside the image column. The bash pipeline uses
+	// `tr -d ' '` to scrub everything, and we mirror that here.
+	markdown := `## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux |   |    docker.io/library/almalinux:8   <br>   docker.io/library/almalinux:9 |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.Equal(t, []string{
+		"docker.io/library/almalinux:8",
+		"docker.io/library/almalinux:9",
+		"ghcr.io/void-linux/void-musl-full:latest",
+	}, images)
+}
+
+func TestParseCompatibilityImages_IgnoresEmptySeparatorRow(t *testing.T) {
+	// The real document has `| | | |` between toolbox images and plain
+	// images. That row must not yield an empty entry.
+	markdown := `## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+| | | |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	for _, image := range images {
+		assert.NotEmpty(t, image)
+	}
+}
+
+func TestParseCompatibilityImages_ReturnsEmptySliceWhenSectionHeaderMissing(t *testing.T) {
+	// Without the `## Containers Distros` heading, no table is considered
+	// authoritative — even a perfectly shaped table is ignored.
+	markdown := `## Host Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.Empty(t, images)
+}
+
+func TestParseCompatibilityImages_ReturnsEmptySliceForUnrelatedMarkdown(t *testing.T) {
+	markdown := "# Nothing here\n\nNo tables, no images.\n"
+
+	images := parseCompatibilityImages(markdown)
+
+	assert.Empty(t, images)
+}
+
+func TestExtractImagesFromRow_ReturnsAllImagesSeparatedByBr(t *testing.T) {
+	row := "| Fedora | 38 <br> 39 | quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 |"
+
+	images := extractImagesFromRow(row)
+
+	assert.Equal(t, []string{
+		"quay.io/fedora/fedora:38",
+		"quay.io/fedora/fedora:39",
+	}, images)
+}
+
+func TestExtractImagesFromRow_ReturnsNilForNonTableLine(t *testing.T) {
+	row := "Some prose, not a table row."
+
+	images := extractImagesFromRow(row)
+
+	assert.Nil(t, images)
+}
+
+func TestExtractImagesFromRow_ReturnsNilForRowWithoutImagesColumn(t *testing.T) {
+	// `| a | b |` has only 4 fields when split (incl. leading/trailing
+	// empties), so the third column does not exist.
+	row := "| a | b |"
+
+	images := extractImagesFromRow(row)
+
+	assert.Nil(t, images)
+}
+
+func TestIsMarkdownTableSeparator_DetectsCanonicalSeparator(t *testing.T) {
+	assert.True(t, isMarkdownTableSeparator("| --- | --- | --- |"))
+}
+
+func TestIsMarkdownTableSeparator_DetectsCompactSeparator(t *testing.T) {
+	assert.True(t, isMarkdownTableSeparator("|---|---|---|"))
+}
+
+func TestIsMarkdownTableSeparator_DetectsAlignmentMarkers(t *testing.T) {
+	assert.True(t, isMarkdownTableSeparator("| :--- | :---: | ---: |"))
+}
+
+func TestIsMarkdownTableSeparator_RejectsHeaderRow(t *testing.T) {
+	assert.False(t, isMarkdownTableSeparator("| Distro | Version | Images |"))
+}
+
+func TestIsMarkdownTableSeparator_RejectsDataRow(t *testing.T) {
+	assert.False(t, isMarkdownTableSeparator("| AlmaLinux | 8 | docker.io/library/almalinux:8 |"))
+}
+
+func TestIsMarkdownTableSeparator_RejectsBlankLine(t *testing.T) {
+	assert.False(t, isMarkdownTableSeparator(""))
+}
+
+func TestIsMarkdownTableSeparator_RejectsNonTableLine(t *testing.T) {
+	assert.False(t, isMarkdownTableSeparator("--- some divider ---"))
+}
+
+func TestCompatibilityRef_ReturnsMainForDevVersion(t *testing.T) {
+	assert.Equal(t, "main", compatibilityRef("dev"))
+}
+
+func TestCompatibilityRef_ReturnsMainForEmptyVersion(t *testing.T) {
+	assert.Equal(t, "main", compatibilityRef(""))
+}
+
+func TestCompatibilityRef_ReturnsBuildVersionWhenSet(t *testing.T) {
+	assert.Equal(t, "1.8.1", compatibilityRef("1.8.1"))
+}
+
+func TestCompatibilityRef_StripsGitDescribeSuffix(t *testing.T) {
+	// `git describe --tags` on a commit past v1.8.1 yields this shape.
+	// We want to fetch docs/compatibility.md from the v1.8.1 tag, which
+	// is a real ref upstream, not from "v1.8.1-3-g1bc3554" which is not.
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-3-g1bc3554"))
+}
+
+func TestCompatibilityRef_StripsGitDescribeSuffixWithDirty(t *testing.T) {
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-3-g1bc3554-dirty"))
+}
+
+func TestCompatibilityRef_StripsDirtySuffixAlone(t *testing.T) {
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-dirty"))
+}
+
+func TestCompatibilityRef_FallsBackToMainForBareHash(t *testing.T) {
+	// `git describe --always` produces a bare hash when no tag is
+	// reachable. That is not a useful ref for the upstream repo.
+	assert.Equal(t, "main", compatibilityRef("g1bc3554"))
+	assert.Equal(t, "main", compatibilityRef("1bc3554"))
+}
+
+func TestCompatibilityRef_PreservesUnconventionalRefs(t *testing.T) {
+	// Anything that doesn't look like git describe output should be
+	// passed through untouched (e.g., a branch name set via ldflags).
+	assert.Equal(t, "release-2.0", compatibilityRef("release-2.0"))
+}
+
+func TestSanitizeRefForFilename_PreservesSafeCharacters(t *testing.T) {
+	assert.Equal(t, "v1.8.1", sanitizeRefForFilename("v1.8.1"))
+	assert.Equal(t, "main", sanitizeRefForFilename("main"))
+	assert.Equal(t, "release-2.0", sanitizeRefForFilename("release-2.0"))
+}
+
+func TestSanitizeRefForFilename_ReplacesPathSeparator(t *testing.T) {
+	// A branch ref like "feature/foo" must not introduce a sub-directory
+	// segment in the cache filename.
+	assert.Equal(t, "feature_foo", sanitizeRefForFilename("feature/foo"))
+}
+
+func TestSanitizeRefForFilename_NeutralisesParentDirSegments(t *testing.T) {
+	// "../etc/passwd" must not be able to escape the cache directory.
+	assert.Equal(t, ".._etc_passwd", sanitizeRefForFilename("../etc/passwd"))
+}
+
+func TestSanitizeRefForFilename_ReplacesDotOnlyRef(t *testing.T) {
+	assert.Equal(t, "_", sanitizeRefForFilename("."))
+	assert.Equal(t, "_", sanitizeRefForFilename(".."))
+}
+
+func TestSanitizeRefForFilename_ReplacesEmptyRef(t *testing.T) {
+	assert.Equal(t, "_", sanitizeRefForFilename(""))
+}
+
+func TestSanitizeRefForFilename_ReplacesWhitespaceAndShellChars(t *testing.T) {
+	assert.Equal(t, "v1_0__rc1_", sanitizeRefForFilename("v1 0 \trc1\n"))
+	assert.Equal(t, "ref_with_quote", sanitizeRefForFilename("ref'with\"quote"))
+}
+
+func TestCompatibilityCacheDir_HonoursXdgCacheHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	dir, err := compatibilityCacheDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(tmp, "distrobox"), dir)
+}
+
+func TestCompatibilityCacheDir_FallsBackToHomeCache(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", tmp)
+
+	dir, err := compatibilityCacheDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(tmp, ".cache", "distrobox"), dir)
+}
+
+func TestReadCompatibilityCache_ReturnsContentsWhenPresent(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cache")
+	require.NoError(t, os.WriteFile(path, []byte("alpine\nfedora\n"), 0o644))
+
+	got, err := readCompatibilityCache(path)
+	require.NoError(t, err)
+	assert.Equal(t, "alpine\nfedora\n", got)
+}
+
+func TestReadCompatibilityCache_ReturnsOsErrNotExistWhenMissing(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "missing")
+
+	_, err := readCompatibilityCache(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReadCompatibilityCache_ReturnsEmptyCacheSentinelForZeroByteFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "empty")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	_, err := readCompatibilityCache(path)
+	assert.ErrorIs(t, err, errEmptyCache)
+}
+
+func TestWriteCompatibilityCache_CreatesParentDirectoriesAndFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "nested", "dir", "cache")
+
+	err := writeCompatibilityCache(path, "alpine\nfedora\n")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "alpine\nfedora\n", string(data))
+}
+
+func TestWriteCompatibilityCache_ReplacesExistingFileAtomically(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cache")
+	require.NoError(t, os.WriteFile(path, []byte("old-content"), 0o644))
+
+	err := writeCompatibilityCache(path, "new-content\n")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new-content\n", string(data))
+
+	// No leftover ".tmp-*" temp files in the cache directory.
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp-",
+			"unexpected leftover temp file %q", e.Name())
+	}
+}
+
+func TestFetchCompatibilityMarkdown_ReturnsBodyForOKResponse(t *testing.T) {
+	var seenPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		_, _ = w.Write([]byte("hello from fixture"))
+	}))
+	defer server.Close()
+
+	// Hit the test server directly by constructing an explicit URL —
+	// the real fetcher hard-codes the GitHub URL, so we exercise it
+	// via the lower-level request flow by calling through the helper
+	// after re-pointing the URL via a custom RoundTripper.
+	client := &http.Client{
+		Transport: rewriteTransport{base: http.DefaultTransport, target: server.URL},
+	}
+
+	body, err := fetchCompatibilityMarkdown(context.Background(), client, "v1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from fixture", body)
+	assert.Equal(t, "/89luca89/distrobox/v1.2.3/docs/compatibility.md", seenPath)
+}
+
+func TestFetchCompatibilityMarkdown_ReturnsErrorForNonOKResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: rewriteTransport{base: http.DefaultTransport, target: server.URL},
+	}
+
+	_, err := fetchCompatibilityMarkdown(context.Background(), client, "v1.2.3")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// rewriteTransport redirects every request to the configured target while
+// preserving the original request path, so tests can hit a local httptest
+// server without changing the production URL template.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Build a new URL that points at the test server but keeps the path
+	// and query of the original request so callers can assert on them.
+	rewritten := strings.TrimRight(t.target, "/") + req.URL.Path
+	if req.URL.RawQuery != "" {
+		rewritten += "?" + req.URL.RawQuery
+	}
+	newReq := req.Clone(req.Context())
+	newURL, err := newReq.URL.Parse(rewritten)
+	if err != nil {
+		return nil, err
+	}
+	newReq.URL = newURL
+	newReq.Host = newURL.Host
+	return t.base.RoundTrip(newReq)
+}

--- a/internal/cli/compatibility_internal_test.go
+++ b/internal/cli/compatibility_internal_test.go
@@ -1,0 +1,364 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleCompatibilityMarkdown = `# Compatibility
+
+## Host Distros
+
+| Distro | Version | Notes |
+| --- | --- | --- |
+| Alpine Linux | | |
+| Void Linux | glibc <br> musl | |
+
+## Containers Distros
+
+| Distro | Version | Images |
+| --- | --- | --- |
+| AlmaLinux (Toolbox) | 8 <br> 9 | quay.io/toolbx-images/almalinux-toolbox:8 <br> quay.io/toolbx-images/almalinux-toolbox:9 <br> quay.io/toolbx-images/almalinux-toolbox:latest |
+| Alpine (Toolbox) | edge | quay.io/toolbx-images/alpine-toolbox:edge |
+| Fedora | 39 | quay.io/fedora/fedora:39 |
+| Void Linux | glibc <br> musl | ghcr.io/void-linux/void-glibc-full:latest <br> ghcr.io/void-linux/void-musl-full:latest |
+
+Trailing text that should be ignored.
+`
+
+func TestParseCompatibilityImages_ReturnsSortedUniqueImagesFromContainerDistrosTable(t *testing.T) {
+	images := parseCompatibilityImages(sampleCompatibilityMarkdown)
+
+	expected := []string{
+		"ghcr.io/void-linux/void-glibc-full:latest",
+		"ghcr.io/void-linux/void-musl-full:latest",
+		"quay.io/fedora/fedora:39",
+		"quay.io/toolbx-images/almalinux-toolbox:8",
+		"quay.io/toolbx-images/almalinux-toolbox:9",
+		"quay.io/toolbx-images/almalinux-toolbox:latest",
+		"quay.io/toolbx-images/alpine-toolbox:edge",
+	}
+	assert.Equal(t, expected, images)
+}
+
+func TestParseCompatibilityImages_SkipsRowsBeforeAlmaMarker(t *testing.T) {
+	images := parseCompatibilityImages(sampleCompatibilityMarkdown)
+
+	// Both Host Distros and Containers Distros tables contain "Void Linux",
+	// but the host one has an empty images column. The host row should
+	// never contribute, and the container row must.
+	assert.Contains(t, images, "ghcr.io/void-linux/void-glibc-full:latest")
+}
+
+func TestParseCompatibilityImages_StopsAtVoidMarker(t *testing.T) {
+	markdown := sampleCompatibilityMarkdown + `
+| Wonderlandia | 1 | docker.io/wonderlandia/wonderlandia:1 |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.NotContains(t, images, "docker.io/wonderlandia/wonderlandia:1",
+		"images after the | Void row should be ignored")
+}
+
+func TestParseCompatibilityImages_DeduplicatesIdenticalEntries(t *testing.T) {
+	markdown := `| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+| AlmaLinux 2 | 8 | docker.io/library/almalinux:8 |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	require.Len(t, images, 2)
+	assert.Equal(t, []string{
+		"docker.io/library/almalinux:8",
+		"ghcr.io/void-linux/void-musl-full:latest",
+	}, images)
+}
+
+func TestParseCompatibilityImages_StripsInternalAndSurroundingWhitespace(t *testing.T) {
+	// Some rows in the real doc have stray spaces around the <br>
+	// separator inside the image column. The bash pipeline uses
+	// `tr -d ' '` to scrub everything, and we mirror that here.
+	markdown := `| AlmaLinux |   |    docker.io/library/almalinux:8   <br>   docker.io/library/almalinux:9 |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	assert.Equal(t, []string{
+		"docker.io/library/almalinux:8",
+		"docker.io/library/almalinux:9",
+		"ghcr.io/void-linux/void-musl-full:latest",
+	}, images)
+}
+
+func TestParseCompatibilityImages_IgnoresEmptySeparatorRow(t *testing.T) {
+	// The real document has `| | | |` between toolbox images and plain
+	// images. That row must not yield an empty entry.
+	markdown := `| AlmaLinux | 8 | docker.io/library/almalinux:8 |
+| | | |
+| Void Linux | musl | ghcr.io/void-linux/void-musl-full:latest |
+`
+	images := parseCompatibilityImages(markdown)
+
+	for _, image := range images {
+		assert.NotEmpty(t, image)
+	}
+}
+
+func TestParseCompatibilityImages_ReturnsEmptySliceWhenMarkerMissing(t *testing.T) {
+	markdown := `# Nothing here\n\nNo tables, no images.\n`
+
+	images := parseCompatibilityImages(markdown)
+
+	assert.Empty(t, images)
+}
+
+func TestExtractImagesFromRow_ReturnsAllImagesSeparatedByBr(t *testing.T) {
+	row := "| Fedora | 38 <br> 39 | quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 |"
+
+	images := extractImagesFromRow(row)
+
+	assert.Equal(t, []string{
+		"quay.io/fedora/fedora:38",
+		"quay.io/fedora/fedora:39",
+	}, images)
+}
+
+func TestExtractImagesFromRow_ReturnsNilForNonTableLine(t *testing.T) {
+	row := "Some prose, not a table row."
+
+	images := extractImagesFromRow(row)
+
+	assert.Nil(t, images)
+}
+
+func TestExtractImagesFromRow_ReturnsNilForRowWithoutImagesColumn(t *testing.T) {
+	// `| a | b |` has only 4 fields when split (incl. leading/trailing
+	// empties), so the third column does not exist.
+	row := "| a | b |"
+
+	images := extractImagesFromRow(row)
+
+	assert.Nil(t, images)
+}
+
+func TestCompatibilityRef_ReturnsMainForDevVersion(t *testing.T) {
+	assert.Equal(t, "main", compatibilityRef("dev"))
+}
+
+func TestCompatibilityRef_ReturnsMainForEmptyVersion(t *testing.T) {
+	assert.Equal(t, "main", compatibilityRef(""))
+}
+
+func TestCompatibilityRef_ReturnsBuildVersionWhenSet(t *testing.T) {
+	assert.Equal(t, "1.8.1", compatibilityRef("1.8.1"))
+}
+
+func TestCompatibilityRef_StripsGitDescribeSuffix(t *testing.T) {
+	// `git describe --tags` on a commit past v1.8.1 yields this shape.
+	// We want to fetch docs/compatibility.md from the v1.8.1 tag, which
+	// is a real ref upstream, not from "v1.8.1-3-g1bc3554" which is not.
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-3-g1bc3554"))
+}
+
+func TestCompatibilityRef_StripsGitDescribeSuffixWithDirty(t *testing.T) {
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-3-g1bc3554-dirty"))
+}
+
+func TestCompatibilityRef_StripsDirtySuffixAlone(t *testing.T) {
+	assert.Equal(t, "v1.8.1", compatibilityRef("v1.8.1-dirty"))
+}
+
+func TestCompatibilityRef_FallsBackToMainForBareHash(t *testing.T) {
+	// `git describe --always` produces a bare hash when no tag is
+	// reachable. That is not a useful ref for the upstream repo.
+	assert.Equal(t, "main", compatibilityRef("g1bc3554"))
+	assert.Equal(t, "main", compatibilityRef("1bc3554"))
+}
+
+func TestCompatibilityRef_PreservesUnconventionalRefs(t *testing.T) {
+	// Anything that doesn't look like git describe output should be
+	// passed through untouched (e.g., a branch name set via ldflags).
+	assert.Equal(t, "release-2.0", compatibilityRef("release-2.0"))
+}
+
+func TestSanitizeRefForFilename_PreservesSafeCharacters(t *testing.T) {
+	assert.Equal(t, "v1.8.1", sanitizeRefForFilename("v1.8.1"))
+	assert.Equal(t, "main", sanitizeRefForFilename("main"))
+	assert.Equal(t, "release-2.0", sanitizeRefForFilename("release-2.0"))
+}
+
+func TestSanitizeRefForFilename_ReplacesPathSeparator(t *testing.T) {
+	// A branch ref like "feature/foo" must not introduce a sub-directory
+	// segment in the cache filename.
+	assert.Equal(t, "feature_foo", sanitizeRefForFilename("feature/foo"))
+}
+
+func TestSanitizeRefForFilename_NeutralisesParentDirSegments(t *testing.T) {
+	// "../etc/passwd" must not be able to escape the cache directory.
+	assert.Equal(t, ".._etc_passwd", sanitizeRefForFilename("../etc/passwd"))
+}
+
+func TestSanitizeRefForFilename_ReplacesDotOnlyRef(t *testing.T) {
+	assert.Equal(t, "_", sanitizeRefForFilename("."))
+	assert.Equal(t, "_", sanitizeRefForFilename(".."))
+}
+
+func TestSanitizeRefForFilename_ReplacesEmptyRef(t *testing.T) {
+	assert.Equal(t, "_", sanitizeRefForFilename(""))
+}
+
+func TestSanitizeRefForFilename_ReplacesWhitespaceAndShellChars(t *testing.T) {
+	assert.Equal(t, "v1_0__rc1_", sanitizeRefForFilename("v1 0 \trc1\n"))
+	assert.Equal(t, "ref_with_quote", sanitizeRefForFilename("ref'with\"quote"))
+}
+
+func TestCompatibilityCacheDir_HonoursXdgCacheHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	dir, err := compatibilityCacheDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(tmp, "distrobox"), dir)
+}
+
+func TestCompatibilityCacheDir_FallsBackToHomeCache(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", tmp)
+
+	dir, err := compatibilityCacheDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(tmp, ".cache", "distrobox"), dir)
+}
+
+func TestReadCompatibilityCache_ReturnsContentsWhenPresent(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cache")
+	require.NoError(t, os.WriteFile(path, []byte("alpine\nfedora\n"), 0o644))
+
+	got, err := readCompatibilityCache(path)
+	require.NoError(t, err)
+	assert.Equal(t, "alpine\nfedora\n", got)
+}
+
+func TestReadCompatibilityCache_ReturnsOsErrNotExistWhenMissing(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "missing")
+
+	_, err := readCompatibilityCache(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReadCompatibilityCache_ReturnsEmptyCacheSentinelForZeroByteFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "empty")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	_, err := readCompatibilityCache(path)
+	assert.ErrorIs(t, err, errEmptyCache)
+}
+
+func TestWriteCompatibilityCache_CreatesParentDirectoriesAndFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "nested", "dir", "cache")
+
+	err := writeCompatibilityCache(path, "alpine\nfedora\n")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "alpine\nfedora\n", string(data))
+}
+
+func TestWriteCompatibilityCache_ReplacesExistingFileAtomically(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "cache")
+	require.NoError(t, os.WriteFile(path, []byte("old-content"), 0o644))
+
+	err := writeCompatibilityCache(path, "new-content\n")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new-content\n", string(data))
+
+	// No leftover ".tmp-*" temp files in the cache directory.
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp-",
+			"unexpected leftover temp file %q", e.Name())
+	}
+}
+
+func TestFetchCompatibilityMarkdown_ReturnsBodyForOKResponse(t *testing.T) {
+	var seenPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		_, _ = w.Write([]byte("hello from fixture"))
+	}))
+	defer server.Close()
+
+	// Hit the test server directly by constructing an explicit URL —
+	// the real fetcher hard-codes the GitHub URL, so we exercise it
+	// via the lower-level request flow by calling through the helper
+	// after re-pointing the URL via a custom RoundTripper.
+	client := &http.Client{
+		Transport: rewriteTransport{base: http.DefaultTransport, target: server.URL},
+	}
+
+	body, err := fetchCompatibilityMarkdown(context.Background(), client, "v1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from fixture", body)
+	assert.Equal(t, "/89luca89/distrobox/v1.2.3/docs/compatibility.md", seenPath)
+}
+
+func TestFetchCompatibilityMarkdown_ReturnsErrorForNonOKResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: rewriteTransport{base: http.DefaultTransport, target: server.URL},
+	}
+
+	_, err := fetchCompatibilityMarkdown(context.Background(), client, "v1.2.3")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// rewriteTransport redirects every request to the configured target while
+// preserving the original request path, so tests can hit a local httptest
+// server without changing the production URL template.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Build a new URL that points at the test server but keeps the path
+	// and query of the original request so callers can assert on them.
+	rewritten := strings.TrimRight(t.target, "/") + req.URL.Path
+	if req.URL.RawQuery != "" {
+		rewritten += "?" + req.URL.RawQuery
+	}
+	newReq := req.Clone(req.Context())
+	newURL, err := newReq.URL.Parse(rewritten)
+	if err != nil {
+		return nil, err
+	}
+	newReq.URL = newURL
+	newReq.Host = newURL.Host
+	return t.base.RoundTrip(newReq)
+}

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -170,7 +170,7 @@ may require additional packages depending on the container image: https://github
 
 func createAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) error {
 	if cmd.Bool("compatibility") {
-		err := showCompatibility()
+		err := showCompatibility(ctx)
 		if err != nil {
 			return fmt.Errorf("compatibility check failed: %w", err)
 		}
@@ -233,12 +233,6 @@ func createAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) err
 		printCreateCompleted(progress, result.ContainerName, opts.Rootful)
 	}
 
-	return nil
-}
-
-func showCompatibility() error {
-	// TODO: fetch compatibility
-	// https://github.com/89luca89/distrobox/blob/main/distrobox-create#L254
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Implements the `distrobox create --compatibility` flag in Go (resolves the `TODO` at `internal/cli/create.go:240`), porting the bash `show_compatibility` helper from the legacy `distrobox-create` script.
- Fetches `docs/compatibility.md` from upstream for the current build version (falling back to `main` for `dev` builds, or to the nearest tag when `git describe --tags` produces a `<tag>-N-g<sha>[-dirty]` suffix), parses the "Containers Distros" table, and caches the deduplicated/sorted image list under `$XDG_CACHE_HOME/distrobox/distrobox-compatibility-<ref>` so subsequent invocations are offline-friendly.
- Cache writes are atomic (temp file + rename) so a crashed or concurrent writer cannot leave a partially populated cache file visible to readers.
- The build-time version string is sanitized before being embedded in the cache filename, preventing any ref containing `/`, `..`, or unusual characters from creating nested paths or escaping the cache directory.
- The action passes its `context.Context` into the HTTP fetch so Ctrl+C / parent cancellation aborts the request.

## Implementation notes

- New file `internal/cli/compatibility.go` houses the fetch / parse / cache logic.
- Parsing mirrors the original bash pipeline (`sed -n '/| Alma/,/| Void/ p' | cut -f4 | sed s/<br>/\n/ | tr -d ' ' | sort -u`) line-by-line in Go.
- 33 unit tests (one function per case, no table-driven subtests) cover the parser, the cache read/write/atomic-replace path, ref normalization (including `git describe` shapes and bare hashes), ref sanitization for filename safety, the HTTP fetch helpers, and the `XDG_CACHE_HOME` / `HOME` fallback chain.

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (33 new tests in `internal/cli`, full suite green)
- [x] `make lint` passes with zero issues
- [x] Smoke test: `distrobox create --compatibility` returns 122 image entries on first invocation and serves from cache on the second
- [x] Smoke test with `VERSION=dev`: falls back to `main` ref and writes `distrobox-compatibility-main`