### PR TITLE
fix(list): detect containers with overridden manager label

### DIFF
--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -72,8 +72,18 @@ type RmOptions struct {
 	ContainerHome string
 }
 
+// IsDistrobox returns true if any label key or value contains "distrobox".
+// We can't just check manager=distrobox because users can override it with
+// --additional-flags --label=manager=foo (apx does this). The
+// distrobox.unshare_groups label is always set on creation, so the
+// substring match catches those containers too.
 func (c Container) IsDistrobox() bool {
-	return c.Labels["manager"] == "distrobox"
+	for key, value := range c.Labels {
+		if strings.Contains(key, "distrobox") || strings.Contains(value, "distrobox") {
+			return true
+		}
+	}
+	return false
 }
 
 func (c Container) IsRunning() bool {

--- a/pkg/containermanager/containermanager_test.go
+++ b/pkg/containermanager/containermanager_test.go
@@ -1,0 +1,39 @@
+package containermanager_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/89luca89/distrobox/pkg/containermanager"
+)
+
+func TestContainer_IsDistrobox_StandardManagerLabel(t *testing.T) {
+	c := containermanager.Container{
+		Labels: map[string]string{"manager": "distrobox", "distrobox.unshare_groups": "0"},
+	}
+	assert.True(t, c.IsDistrobox())
+}
+
+// Regression: when the user overrides the manager label via
+// `--additional-flags --label=manager=apx`, the container is still a
+// distrobox container — the `distrobox.unshare_groups` label is always set on
+// creation and is enough to identify it.
+func TestContainer_IsDistrobox_ManagerLabelOverridden(t *testing.T) {
+	c := containermanager.Container{
+		Labels: map[string]string{"manager": "apx", "distrobox.unshare_groups": "0"},
+	}
+	assert.True(t, c.IsDistrobox())
+}
+
+func TestContainer_IsDistrobox_NoDistroboxLabels(t *testing.T) {
+	c := containermanager.Container{
+		Labels: map[string]string{"manager": "toolbox"},
+	}
+	assert.False(t, c.IsDistrobox())
+}
+
+func TestContainer_IsDistrobox_NilLabels(t *testing.T) {
+	c := containermanager.Container{Labels: nil}
+	assert.False(t, c.IsDistrobox())
+}


### PR DESCRIPTION
When `--additional-flags --label=manager=...` overrides the manager label at creation time, `distrobox list` would hide the container and `distrobox rm` would silently no-op (it filters through the same list). Match the distrobox.* label set alongside `manager` so containers remain detectable when the manager label is overridden, restoring v1's loose `*distrobox*` substring behavior.

Fixes #2112 