### PR TITLE
fix(export): match running apps with exported .desktop entry

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-export
+++ b/internal/inside-distrobox/assets/distrobox-export
@@ -572,10 +572,9 @@ export_application()
 				> "/run/host${host_home}/.local/share/applications/${desktop_home_file}"
 		# in the end we add the final quote we've opened in the "container_command_prefix"
 
-		if ! grep -q "StartupWMClass" "/run/host${host_home}/.local/share/applications/${desktop_home_file}"; then
-			printf "StartupWMClass=%s\n" "${exported_app}" >> "\
-/run/host${host_home}/.local/share/applications/${desktop_home_file}"
-		fi
+		sed -i -e '/StartupWMClass=/d' -e "/\[Desktop Entry\]/a\StartupWMClass=${desktop_original_file%.desktop}" \
+			"/run/host${host_home}/.local/share/applications/${desktop_home_file}"
+
 		# In case of an icon in a non canonical path, we need to replace the path
 		# in the desktop file.
 		if [ -n "${icon_file_absolute_path}" ]; then


### PR DESCRIPTION
The DE (at least Gnome and KDE) tries to match the app_id of the running application with the corresponding .desktop file in this order:
 - find ${app_id}.desktop
 - if not found, tries to find a .desktop with StartupWMClass=${app_id} Because when exporting a application we change the name of the .desktop file, the DE can't match the running app, displaying a generic icon.

To solve this, change StartupWMClass key of the exported .desktop file to the name of the .desktop inside distrobox (minus the .desktop extension).

Fixes #1808