### PR TITLE
Add a Fedora 44 distrobox

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -183,7 +183,7 @@ Distrobox guests tested successfully with the following container images:
 | Debian | Testing | docker.io/library/debian:testing  <br>  docker.io/library/debian:testing-backports |
 | Debian | Unstable | docker.io/library/debian:unstable |
 | deepin | 20 (apricot) <br> 23 (beige) | docker.io/linuxdeepin/apricot <br> docker.io/linuxdeepin/deepin:beige |
-| Fedora | 38 <br> 39 <br> 40 <br> 41 <br> 42 <br> 43 <br> Rawhide | quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 <br> quay.io/fedora/fedora:40 <br> quay.io/fedora/fedora:41 <br> quay.io/fedora/fedora:42 <br> <br> quay.io/fedora/fedora:43 <br> quay.io/fedora/fedora:rawhide |
+| Fedora | 38 <br> 39 <br> 40 <br> 41 <br> 42 <br> 43 <br> 44 <br> Rawhide | quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 <br> quay.io/fedora/fedora:40 <br> quay.io/fedora/fedora:41 <br> quay.io/fedora/fedora:42 <br> quay.io/fedora/fedora:43 <br> quay.io/fedora/fedora:44 <br> quay.io/fedora/fedora:rawhide |
 | Gentoo Linux | rolling | docker.io/gentoo/stage3:latest |
 | KDE neon | Latest | invent-registry.kde.org/neon/docker-images/plasma:latest |
 | Kali Linux | rolling | docker.io/kalilinux/kali-rolling:latest |


### PR DESCRIPTION
Taken from quay.io as were the other ones.

Fixes #2117 