### PR TITLE
chore(build): create shell command wrapper for V1 compatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,67 @@ GO_BUILD_ENV := CGO_ENABLED=0 GOOS=$(GOOS)
 VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X github.com/89luca89/distrobox/pkg/version.Version=$(VERSION)"
 
+BINDIR := ./bin
+
+# Go source files — make will rebuild when any .go changes
+GO_SRC := $(shell find . -type f -name '*.go' -not -path './vendor/*')
+
+# Asset files copied from internal/inside-distrobox/assets
+ASSET_SRCDIR := internal/inside-distrobox/assets
+ASSETS := $(notdir $(wildcard $(ASSET_SRCDIR)/*))
+ASSET_TARGETS := $(addprefix $(BINDIR)/,$(ASSETS))
+
+# Commands that need POSIX shim wrappers (map to "distrobox <subcommand>")
+SHIM_COMMANDS := assemble create enter ephemeral generate-entry list rm stop upgrade
+SHIM_TARGETS := $(addprefix $(BINDIR)/distrobox-,$(SHIM_COMMANDS))
+
+# All generated files in $(BINDIR)
+BIN_FILES := $(BINDIR)/distrobox $(ASSET_TARGETS) $(SHIM_TARGETS)
+
 .PHONY: build
-build:
-	$(GO_BUILD_ENV) go build $(LDFLAGS) -o ./bin/distrobox ./cmd/distrobox
+build: $(BIN_FILES)
+
+$(BINDIR):
+	mkdir -p $(BINDIR)
+
+$(BINDIR)/distrobox: go.mod go.sum $(GO_SRC) $(wildcard $(ASSET_SRCDIR)/*) | $(BINDIR)
+	$(GO_BUILD_ENV) go build $(LDFLAGS) -o $@ ./cmd/distrobox
+
+# Copy asset files from internal/inside-distrobox/assets
+$(ASSET_TARGETS): $(BINDIR)/%: $(ASSET_SRCDIR)/% | $(BINDIR)
+	@cp -f $< $@; \
+	chmod 755 $@; \
+	printf '  COPY    %s\n' "$@"
+
+# Generate shim scripts for each subcommand.
+# Regenerate when the binary changes (new subcommands may have been added).
+$(SHIM_TARGETS): $(BINDIR)/distrobox-%: | $(BINDIR)/distrobox $(BINDIR)
+	@cmd=$$(echo $@ | sed 's|.*/distrobox-||'); \
+	printf '  SHIM    %s\n' "$@"; \
+	{ \
+		echo '#!/bin/sh'; \
+		echo '# SPDX-License-Identifier: GPL-3.0-only'; \
+		echo '#'; \
+		echo '# This file is part of the distrobox project:'; \
+		echo '#    https://github.com/89luca89/distrobox'; \
+		echo '#'; \
+		echo '# Copyright (C) 2021 distrobox contributors'; \
+		echo '#'; \
+		echo '# distrobox is free software; you can redistribute it and/or modify it'; \
+		echo '# under the terms of the GNU General Public License version 3'; \
+		echo '# as published by the Free Software Foundation.'; \
+		echo '#'; \
+		echo '# distrobox is distributed in the hope that it will be useful, but'; \
+		echo '# WITHOUT ANY WARRANTY; without even the implied warranty of'; \
+		echo '# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU'; \
+		echo '# General Public License for more details.'; \
+		echo '#'; \
+		echo '# You should have received a copy of the GNU General Public License'; \
+		echo '# along with distrobox; if not, see <http://www.gnu.org/licenses/>.'; \
+		echo ''; \
+		echo 'exec "$$(dirname "$$0")/distrobox" "'$${cmd}'" "$$@"'; \
+	} > $@; \
+	chmod 755 $@ 
 
 # Regenerate man pages from docs/usage/*.md via pandoc.
 # Requires pandoc on $PATH; run after touching docs/usage/.
@@ -37,7 +95,10 @@ ICON_SIZES := 16 22 24 32 36 48 64 72 96 128 256
 .PHONY: install
 install: build
 	install -d $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR) $(DESTDIR)$(BASHCOMPDIR) $(DESTDIR)$(ZSHCOMPDIR)
-	install -m 0755 ./bin/distrobox $(DESTDIR)$(BINDIR)/distrobox
+	install -m 0755 $(BINDIR)/distrobox $(DESTDIR)$(BINDIR)/distrobox
+	for f in $(ASSET_TARGETS) $(SHIM_TARGETS); do \
+		install -m 0755 "$$f" $(DESTDIR)$(BINDIR)/; \
+	done
 	install -m 0644 man/man1/*.1 $(DESTDIR)$(MANDIR)/
 	install -m 0644 completions/bash/distrobox $(DESTDIR)$(BASHCOMPDIR)/distrobox
 	install -m 0644 completions/zsh/_distrobox $(DESTDIR)$(ZSHCOMPDIR)/_distrobox
@@ -51,7 +112,9 @@ install: build
 
 .PHONY: uninstall
 uninstall:
-	rm -f $(DESTDIR)$(BINDIR)/distrobox
+	for f in $(BIN_FILES); do \
+		rm -f $(DESTDIR)$(BINDIR)/"$$(basename "$$f")"; \
+	done
 	rm -f $(DESTDIR)$(MANDIR)/distrobox.1 $(DESTDIR)$(MANDIR)/distrobox-*.1
 	rm -f $(DESTDIR)$(BASHCOMPDIR)/distrobox
 	rm -f $(DESTDIR)$(ZSHCOMPDIR)/_distrobox
@@ -62,7 +125,7 @@ uninstall:
 
 .PHONY: clean
 clean:
-	rm -f ./bin/distrobox
+	rm -f $(BIN_FILES)
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
In the artefact directory (`./bin`), alongside the `distrobox` executable, other shell executable files are added to mimic the content of the distrobox v1 bundle. Shell executables are of two kinds:

* `assets`: those files that are executed inside the container. In v2, those files are budled into the binary and provisioned just-in-time. However, containers created with distrobox v1 expect those files to be reachable and thus the need for copying them and make them available. 
* `shims`: shell executables in the form `distrobox-<cmd>` that are alias for the relative commands and are not present anymore in v2. For example: `distrobox-enteri` file is a shim for the command `distrobox enter`.

Usage:
Run `make` and the files are provisioned only if not already.
```
› make
CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/89luca89/distrobox/pkg/version.Version=1.8.2.5-203-g2fa1339" -o bin/distrobox ./cmd/distrobox
  COPY    bin/distrobox-export
  COPY    bin/distrobox-host-exec
  COPY    bin/distrobox-init
  SHIM    bin/distrobox-assemble
  SHIM    bin/distrobox-create
  SHIM    bin/distrobox-enter
  SHIM    bin/distrobox-ephemeral
  SHIM    bin/distrobox-generate-entry
  SHIM    bin/distrobox-list
  SHIM    bin/distrobox-rm
  SHIM    bin/distrobox-stop
  SHIM    bin/distrobox-upgrade
```