### PR TITLE
fix: use overlay mount for fonts to prevent cache poisoning

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -727,6 +727,7 @@ setup_apk()
 		util-linux-login
 		util-linux-misc
 		vulkan-loader
+		fuse-overlayfs
 		wget
 		xauth
 		xz
@@ -851,6 +852,7 @@ setup_apt()
 		libglx-mesa0
 		libvulkan1
 		mesa-vulkan-drivers
+		fuse-overlayfs
 	"
 	# shellcheck disable=SC2086,2046
 	apt-get install -y $(apt-cache show ${deps} 2> /dev/null | grep "Package:" | sort -u | cut -d' ' -f2-)
@@ -959,6 +961,7 @@ setup_aptrpm()
 		unzip
 		util-linux
 		wget
+		fuse-overlayfs
 		xauth
 		xorg-dri-intel
 		xorg-dri-radeon
@@ -1106,6 +1109,7 @@ setup_dnf()
 		mesa-dri-drivers
 		mesa-vulkan-drivers
 		vulkan
+		fuse-overlayfs
 	"
 	# shellcheck disable=SC2086,2046,2248
 	${manager} install ${flags} -y $(${manager} list -q ${deps} |
@@ -1182,6 +1186,7 @@ setup_emerge()
 		sys-process/lsof
 		sys-apps/util-linux
 		net-misc/wget
+		sys-fs/fuse-overlayfs
 	"
 	install_pkg=""
 	for dep in ${deps}; do
@@ -1289,6 +1294,7 @@ setup_microdnf()
 		mesa-dri-drivers
 		mesa-vulkan-drivers
 		vulkan
+		fuse-overlayfs
 	"
 	install_pkg=""
 	for dep in ${deps}; do
@@ -1398,6 +1404,7 @@ setup_pacman()
 		mesa
 		vulkan-intel
 		vulkan-radeon
+		fuse-overlayfs
 	"
 	# shellcheck disable=SC2086,2046
 	pacman -S --needed --noconfirm $(pacman -Ssq | grep -E "^($(echo ${deps} | tr ' ' '|'))$")
@@ -1588,6 +1595,7 @@ setup_xbps()
 		vulkan-loader
 		mesa-vulkan-intel
 		mesa-vulkan-radeon
+		fuse-overlayfs
 	"
 	# shellcheck disable=SC2086,2046
 	xbps-install -Sy $(xbps-query -Rs '*' | awk '{print $2}' | sed 's/-[^-]*$//' | grep -E "^($(echo ${deps} | tr ' ' '|'))$")
@@ -1707,6 +1715,7 @@ EOF
 		libvulkan1
 		libvulkan_intel
 		libvulkan_radeon
+		fuse-overlayfs
 	"
 	# Mark gpg errors (exit code 106) as non-fatal, but don't pull anything from unverified repos
 	# shellcheck disable=SC2086,SC2046
@@ -2185,6 +2194,8 @@ printf "distrobox: Integrating host's themes, icons, fonts...\n"
 # Themes and icons integration works using a bind mount inside the container
 # of the host's themes and icons directory. This ensures that the host's home will
 # not be littered with files and directories and broken symlinks.
+# Fonts integration uses an overlay mount instead of a bind mount to prevent
+# font cache poisoning. See: https://github.com/89luca89/distrobox/issues/1945
 if ! mount_bind "/run/host/usr/share/themes" "/usr/local/share/themes"; then
 	printf "Warning: Cannot bind mount /run/host/usr/share/themes to /usr/local/share/themes\n"
 	printf "Warning: Themes integration with the host is disabled.\n"
@@ -2193,9 +2204,35 @@ if ! mount_bind "/run/host/usr/share/icons" "/usr/local/share/icons"; then
 	printf "Warning: Cannot bind mount /run/host/usr/share/icons to /usr/local/share/icons\n"
 	printf "Warning: Icons integration with the host is disabled.\n"
 fi
-if ! mount_bind "/run/host/usr/share/fonts" "/usr/local/share/fonts"; then
-	printf "Warning: Cannot bind mount /run/host/usr/share/fonts to /usr/local/share/fonts\n"
-	printf "Warning: Fonts integration with the host is disabled.\n"
+# Move container's own fonts to upperdir for overlay mount.
+# This is done only once, on first container setup.
+if [ -d "/usr/share/fonts" ] && [ ! -d "/usr/share/fonts-upper" ]; then
+	mv /usr/share/fonts /usr/share/fonts-upper
+	mkdir -p /usr/share/fonts
+	mkdir -p /usr/share/fonts-work
+fi
+# Use overlay mount to merge host fonts into container's /usr/share/fonts.
+# This prevents font cache poisoning caused by path mismatch between host
+# (/usr/share/fonts) and the old bind mount approach (/usr/local/share/fonts).
+# See: https://github.com/89luca89/distrobox/issues/1945
+if [ -d "/run/host/usr/share/fonts" ]; then
+	# Try kernel OverlayFS first (requires root or unprivileged overlay support)
+	if ! mount -t overlay overlay \
+		-o lowerdir=/run/host/usr/share/fonts,upperdir=/usr/share/fonts-upper,workdir=/usr/share/fonts-work \
+		/usr/share/fonts; then
+		# Fall back to fuse-overlayfs for rootless containers
+		if command -v fuse-overlayfs > /dev/null 2>&1; then
+			if ! fuse-overlayfs \
+				-o lowerdir=/run/host/usr/share/fonts,upperdir=/usr/share/fonts-upper,workdir=/usr/share/fonts-work \
+				/usr/share/fonts; then
+				printf "Warning: Cannot overlay mount fonts\n"
+				printf "Warning: Fonts integration with the host is disabled.\n"
+			fi
+		else
+			printf "Warning: Neither overlay mount nor fuse-overlayfs available\n"
+			printf "Warning: Fonts integration with the host is disabled.\n"
+		fi
+	fi
 fi
 ###############################################################################
 


### PR DESCRIPTION

Problem : The previous approach of bind mounting host fonts at /usr/local/share/fonts inside the container caused font cache poisoning. When any app inside the container updated the shared fontconfig cache (~/.cache/fontconfig), it
recorded /usr/local/share/fonts/... paths which do not exist on the host.This left the host desktop environment unable to find its own fonts.

Fix this by using an overlay mount that merges host fonts directly into the container's /usr/share/fonts. This ensures that both host and container see fonts at the same path, so any cache update is valid for both sides.

The overlay mount uses:
- lowerdir: host fonts at /run/host/usr/share/fonts (read-only)
- upperdir: container's own fonts (read-write)
- merged result at /usr/share/fonts inside the container

Kernel OverlayFS is tried first, with fuse-overlayfs as fallback for rootless containers. fuse-overlayfs is added to the deps list of all supported package managers so it is available when needed.

Fixes: https://github.com/89luca89/distrobox/issues/1945