### PR TITLE
fix: prevent host-spawn from consuming profile stdin

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -2231,20 +2231,20 @@ test -z "\${DBUS_SESSION_BUS_ADDRESS:-}" && export DBUS_SESSION_BUS_ADDRESS="uni
 # Ensure we have these two variables from the host, so that graphical apps
 # also work in case we use a login session
 if [ -z "\$XAUTHORITY" ]; then
-    export XAUTHORITY="\$(host-spawn sh -c "printf "%s" \\\$XAUTHORITY")"
+    export XAUTHORITY="\$(host-spawn sh -c "printf "%s" \\\$XAUTHORITY" < /dev/null)"
     # if the variable is still empty, unset it, because empty it could be harmful
     [ -z "\$XAUTHORITY" ] && unset XAUTHORITY
 fi
 if [ -z "\$XAUTHLOCALHOSTNAME" ]; then
-    export XAUTHLOCALHOSTNAME="\$(host-spawn sh -c "printf "%s" \\\$XAUTHLOCALHOSTNAME")"
+    export XAUTHLOCALHOSTNAME="\$(host-spawn sh -c "printf "%s" \\\$XAUTHLOCALHOSTNAME" < /dev/null)"
     [ -z "\$XAUTHLOCALHOSTNAME" ] && unset XAUTHLOCALHOSTNAME
 fi
 if [ -z "\$WAYLAND_DISPLAY" ]; then
-    export WAYLAND_DISPLAY="\$(host-spawn sh -c "printf "%s" \\\$WAYLAND_DISPLAY")"
+    export WAYLAND_DISPLAY="\$(host-spawn sh -c "printf "%s" \\\$WAYLAND_DISPLAY" < /dev/null)"
     [ -z "\$WAYLAND_DISPLAY" ] && unset WAYLAND_DISPLAY
 fi
 if [ -z "\$DISPLAY" ]; then
-    export DISPLAY="\$(host-spawn sh -c "printf "%s" \\\$DISPLAY")"
+    export DISPLAY="\$(host-spawn sh -c "printf "%s" \\\$DISPLAY" < /dev/null)"
     [ -z "\$DISPLAY" ] && unset DISPLAY
 fi
 
@@ -2282,20 +2282,20 @@ if status --is-interactive
 	# Ensure we have these two variables from the host, so that graphical apps
 	# also work in case we use a login session
 	if test -z \$XAUTHORITY
-		set -gx XAUTHORITY (host-spawn sh -c "printf "%s" \\\$XAUTHORITY")
+		set -gx XAUTHORITY (host-spawn sh -c "printf "%s" \\\$XAUTHORITY" < /dev/null)
 		# if the variable is still empty, unset it, because empty it could be harmful
 		test -z \$XAUTHORITY ; and set -e XAUTHORITY
 	end
 	if test -z \$XAUTHLOCALHOSTNAME
-		set -gx XAUTHLOCALHOSTNAME (host-spawn sh -c "printf "%s" \\\$XAUTHLOCALHOSTNAME")
+		set -gx XAUTHLOCALHOSTNAME (host-spawn sh -c "printf "%s" \\\$XAUTHLOCALHOSTNAME" < /dev/null)
 		test -z \$XAUTHLOCALHOSTNAME ; and set -e XAUTHLOCALHOSTNAME
 	end
 	if test -z \$WAYLAND_DISPLAY
-		set -gx WAYLAND_DISPLAY (host-spawn sh -c "printf "%s" \\\$WAYLAND_DISPLAY")
+		set -gx WAYLAND_DISPLAY (host-spawn sh -c "printf "%s" \\\$WAYLAND_DISPLAY" < /dev/null)
 		test -z \$WAYLAND_DISPLAY ; and set -e WAYLAND_DISPLAY
 	end
 	if test -z \$DISPLAY
-		set -gx DISPLAY (host-spawn sh -c "printf "%s" \\\$DISPLAY")
+		set -gx DISPLAY (host-spawn sh -c "printf "%s" \\\$DISPLAY" < /dev/null)
 		test -z \$DISPLAY ; and set -e DISPLAY
 	end
 


### PR DESCRIPTION
Fix `distrobox_profile.sh` and fish profile generation so `host-spawn` does not consume the profile shell's stdin.

When a login shell is started with script input from stdin, for example:

```sh
echo 'echo xxx;' | bash -l
```

The generated profile can run host-spawn while inheriting that same stdin. This may consume the remaining script input before the login shell executes it.

This redirects host-spawn calls to use `/dev/null` .