### PR TITLE
resolve relative DBX_CONTAINER_HOME_PREFIX against HOME

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -265,7 +265,13 @@ func (c *CreateCommand) makeContainerUserCustomHome(
 ) string {
 	containerUserCustomHome := strings.TrimRight(opts.ContainerUserCustomHome, "/")
 	if opts.ContainerHomePrefix != "" && containerUserCustomHome == "" {
-		containerUserCustomHome = filepath.Join(opts.ContainerHomePrefix, containerName)
+		containerHomePrefix := opts.ContainerHomePrefix
+		if !strings.HasPrefix(containerHomePrefix, "/") {
+			if homeDir, err := os.UserHomeDir(); err == nil {
+				containerHomePrefix = filepath.Join(homeDir, containerHomePrefix)
+			}
+		}
+		containerUserCustomHome = filepath.Join(containerHomePrefix, containerName)
 	}
 	return containerUserCustomHome
 }


### PR DESCRIPTION
Relative DBX_CONTAINER_HOME_PREFIX values are now resolved against HOME before being passed to the container runtime, making portable configs work without hardcoded absolute paths.

Closes #2154