### PR TITLE
fix: resolve --version flag conflict with --verbose/-v

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,15 @@ func NewRootCommand(cfg *config.Values) *cli.Command {
 		installShellCompleteRecursively(sub)
 	}
 
+	//nolint:reassign // urfave/cli/v3 explicitly supports reassigning VersionFlag
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:        "version",
+		Aliases:     []string{"V"},
+		Usage:       "print the version",
+		HideDefault: true,
+		Local:       true,
+	}
+
 	return &cli.Command{
 		Name:                  "distrobox",
 		Usage:                 "Use any Linux distribution inside your terminal",


### PR DESCRIPTION
The --version flag was silently dropped because its default -v alias collided with --verbose/-v, causing urfave/cli v3 to skip registering it entirely. This changes the version alias to -V so both --version and --verbose/-v work as expected.

Closes #2152