### PR TITLE
fix: avoid mounting systemd-resolve in unshared netns

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -65,6 +65,11 @@ HOST_MOUNTS_RO_INIT="
 	/var/lib/systemd/coredump
 	/var/log/journal"
 
+if [ "${DISTROBOX_UNSHARE_NETNS:-0}" -eq 1 ]; then
+	HOST_MOUNTS="$(printf "%s\n" "${HOST_MOUNTS}" | grep -v "/run/systemd/resolve")"
+	HOST_MOUNTS_RO_INIT="$(printf "%s\n" "${HOST_MOUNTS_RO_INIT}" | grep -v "/run/systemd/resolve")"
+fi
+
 # Defaults
 container_additional_packages=""
 init=0

--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -191,6 +191,8 @@ func (d *Docker) makeCreateCommand(
 
 	if !unshareNetNS {
 		options = append(options, "--network", "host")
+	} else {
+		options = append(options, "--env", "DISTROBOX_UNSHARE_NETNS=1")
 	}
 
 	if !unshareProcess {

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -191,6 +191,8 @@ func (p *Podman) makeCreateCommand(
 
 	if !unshareNetNS {
 		options = append(options, "--network", "host")
+	} else {
+		options = append(options, "--env", "DISTROBOX_UNSHARE_NETNS=1")
 	}
 
 	if !unshareProcess {


### PR DESCRIPTION
This PR solves solves the systemd-resolved socket from being mounted when the container uses an isolated network namespace.
Closes #2079