### PR TITLE
fix(enter): parse additional-flags when placed after the distrobox name

### DIFF
--- a/internal/cli/enter.go
+++ b/internal/cli/enter.go
@@ -93,6 +93,17 @@ func enterAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) erro
 
 	args := cmd.Args().Slice()
 
+	// When --additional-flags (or -a) is placed after the first positional
+	// argument it lands in the positional tail instead of being consumed as
+	// a flag, because urfave/cli's StopOnNthArg: 1 stops flag parsing after
+	// the first positional arg. We recover it here.
+	args, tailAdditionalFlags := extractAdditionalFlagsFromPositionals(args)
+
+	additionalFlags := cmd.String("additional-flags")
+	if tailAdditionalFlags != "" {
+		additionalFlags = tailAdditionalFlags
+	}
+
 	// If the user placed -e/--exec AFTER the container name, it lands in
 	// the positional tail. In that case the first positional arg is still
 	// the container name and the custom command starts right after the
@@ -136,7 +147,7 @@ func enterAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) erro
 
 	options := commands.EnterOptions{
 		ContainerName:   containerName,
-		AdditionalFlags: cmd.String("additional-flags"),
+		AdditionalFlags: additionalFlags,
 		CustomCommand:   customCommand,
 		DryRun:          dryRun,
 		NoTTY:           cmd.Bool("no-tty"),

--- a/internal/cli/enter_internal_test.go
+++ b/internal/cli/enter_internal_test.go
@@ -102,27 +102,27 @@ func TestEnterCommand_CustomCommandVariants(t *testing.T) {
 	}{
 		{
 			name: "short -e flag",
-			argv: []string{"enter", "suse", "-e", "echo", "ciao"},
+			argv: []string{"enter", "suse", "-e", "echo", "hello"},
 		},
 		{
 			name: "long --exec flag",
-			argv: []string{"enter", "suse", "--exec", "echo", "ciao"},
+			argv: []string{"enter", "suse", "--exec", "echo", "hello"},
 		},
 		{
 			name: "bare -- separator",
-			argv: []string{"enter", "suse", "--", "echo", "ciao"},
+			argv: []string{"enter", "suse", "--", "echo", "hello"},
 		},
 		{
 			name: "implicit (no -e/--exec/--)",
-			argv: []string{"enter", "suse", "echo", "ciao"},
+			argv: []string{"enter", "suse", "echo", "hello"},
 		},
 		{
 			name: "explicit --name with -e",
-			argv: []string{"enter", "--name", "suse", "-e", "echo", "ciao"},
+			argv: []string{"enter", "--name", "suse", "-e", "echo", "hello"},
 		},
 		{
 			name: "explicit --name with --",
-			argv: []string{"enter", "--name", "suse", "--", "echo", "ciao"},
+			argv: []string{"enter", "--name", "suse", "--", "echo", "hello"},
 		},
 		{
 			// Regression: the custom command itself contains a short
@@ -151,7 +151,7 @@ func TestEnterCommand_CustomCommandVariants(t *testing.T) {
 
 			assert.Equal(t, "suse", opts.ContainerName)
 
-			want := []string{"echo", "ciao"}
+			want := []string{"echo", "hello"}
 			if strings.HasPrefix(tc.name, "custom command with short flag") ||
 				strings.HasPrefix(tc.name, "-e before the container name") ||
 				strings.HasPrefix(tc.name, "short flag combo with --no-tty") {
@@ -175,7 +175,7 @@ func TestFindExecMarkerIndex(t *testing.T) {
 		},
 		{
 			name: "no marker",
-			args: []string{"suse", "echo", "ciao"},
+			args: []string{"suse", "echo", "hello"},
 			want: -1,
 		},
 		{
@@ -228,6 +228,190 @@ func TestFindExecMarkerIndex(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, findExecMarkerIndex(tc.args))
+		})
+	}
+}
+
+func TestExtractAdditionalFlagsFromPositionals(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantArgs []string
+		wantFlag string
+	}{
+		{
+			name:     "empty args",
+			args:     nil,
+			wantArgs: nil,
+			wantFlag: "",
+		},
+		{
+			name:     "no additional-flags",
+			args:     []string{"suse", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "",
+		},
+		{
+			name:     "long --additional-flags with value",
+			args:     []string{"suse", "--additional-flags", "--tty", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "short -a with value",
+			args:     []string{"suse", "-a", "--tty", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "--additional-flags with = syntax",
+			args:     []string{"suse", "--additional-flags=--tty", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "-a with = syntax",
+			args:     []string{"suse", "-a=--tty", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "--additional-flags at end with no value",
+			args:     []string{"suse", "--additional-flags"},
+			wantArgs: []string{"suse"},
+			wantFlag: "",
+		},
+		{
+			name:     "--additional-flags before -e marker",
+			args:     []string{"suse", "--additional-flags", "--tty", "-e", "echo", "hello"},
+			wantArgs: []string{"suse", "-e", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "--additional-flags at the very start",
+			args:     []string{"--additional-flags", "--tty", "suse", "echo", "hello"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "--tty",
+		},
+		{
+			name:     "-a at end with no value",
+			args:     []string{"suse", "echo", "hello", "-a"},
+			wantArgs: []string{"suse", "echo", "hello"},
+			wantFlag: "",
+		},
+		{
+			name:     "only flag with = value",
+			args:     []string{"--additional-flags=--preserve-fds"},
+			wantArgs: []string{},
+			wantFlag: "--preserve-fds",
+		},
+		{
+			name:     "value is a single hyphen flag",
+			args:     []string{"test", "--additional-flags", "--tty"},
+			wantArgs: []string{"test"},
+			wantFlag: "--tty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotArgs, gotFlag := extractAdditionalFlagsFromPositionals(tc.args)
+			assert.Equal(t, tc.wantArgs, gotArgs)
+			assert.Equal(t, tc.wantFlag, gotFlag)
+		})
+	}
+}
+
+// TestEnterCommand_AdditionalFlagsFromTail verifies that --additional-flags
+// placed after the container name (i.e. in the positional tail) is correctly
+// extracted and passed as AdditionalFlags to the container manager, rather
+// than ending up in the custom command. This is the regression introduced
+// in the Go rewrite (v2.0.0-rc.3).
+func TestEnterCommand_AdditionalFlagsFromTail(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want containermanager.EnterOptions
+	}{
+		{
+			// Primary regression: Ptyxis uses this invocation pattern.
+			name: "--additional-flags after container name (Ptyxis pattern)",
+			argv: []string{"enter", "--no-tty", "test", "--additional-flags", "--tty"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "--tty",
+				NoTTY:           true,
+				// No custom command → Go returns empty slice, not nil
+				CustomCommand: []string{},
+			},
+		},
+		{
+			name: "-a after container name with custom command",
+			argv: []string{"enter", "test", "-a", "--env", "FOO=bar", "echo", "hello"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "--env",
+				CustomCommand:   []string{"FOO=bar", "echo", "hello"},
+			},
+		},
+		{
+			name: "--additional-flags before container name (normal parsing)",
+			argv: []string{"enter", "--additional-flags", "--tty", "test", "echo", "hello"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "--tty",
+				CustomCommand:   []string{"echo", "hello"},
+			},
+		},
+		{
+			name: "--additional-flags after container name with --exec",
+			argv: []string{"enter", "--no-tty", "test", "--additional-flags", "--tty", "-e", "echo", "hello"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "--tty",
+				NoTTY:           true,
+				CustomCommand:   []string{"echo", "hello"},
+			},
+		},
+		{
+			name: "--additional-flags with = syntax after container name",
+			argv: []string{"enter", "test", "--additional-flags=--preserve-fds", "--", "bash", "-l"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "--preserve-fds",
+				// Note: when StopOnNthArg triggers on a non-`--` arg,
+				// urfave/cli returns before the `--` separator check,
+				// so `--` remains in the positional tail.
+				CustomCommand: []string{"--", "bash", "-l"},
+			},
+		},
+		{
+			name: "no additional-flags should leave field empty",
+			argv: []string{"enter", "test", "echo", "hello"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "test",
+				AdditionalFlags: "",
+				CustomCommand:   []string{"echo", "hello"},
+			},
+		},
+		{
+			name: "--name flag with --additional-flags before positional (normal parsing)",
+			argv: []string{"enter", "--name", "mybox", "--additional-flags", "--tty", "echo", "hello"},
+			want: containermanager.EnterOptions{
+				ContainerName:   "mybox",
+				AdditionalFlags: "--tty",
+				CustomCommand:   []string{"echo", "hello"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := runEnter(t, tc.argv...)
+			assert.Equal(t, tc.want.ContainerName, opts.ContainerName)
+			assert.Equal(t, tc.want.AdditionalFlags, opts.AdditionalFlags)
+			assert.Equal(t, tc.want.CustomCommand, opts.CustomCommand)
+			assert.Equal(t, tc.want.NoTTY, opts.NoTTY)
 		})
 	}
 }

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,5 +1,7 @@
 package cli
 
+import "strings"
+
 // findExecMarkerIndex returns the index of the first -e or --exec in
 // args, or -1 if neither is present. It is used by the enter and
 // ephemeral commands to recover the marker when the user placed it
@@ -14,4 +16,49 @@ func findExecMarkerIndex(args []string) int {
 		}
 	}
 	return -1
+}
+
+// extractAdditionalFlagsFromPositionals scans args for the first occurrence
+// of --additional-flags or -a and returns the cleaned args (with the flag
+// tokens removed) along with the extracted flag value. If no such flag is
+// found it returns the original args and an empty string.
+//
+// This is needed because urfave/cli's StopOnNthArg leaves flag-like tokens
+// in the positional tail, so --additional-flags placed after the container
+// name is not consumed as a flag during normal parsing.
+func extractAdditionalFlagsFromPositionals(args []string) ([]string, string) {
+	for i := range args {
+		switch arg := args[i]; {
+		case arg == "--additional-flags" || arg == "-a":
+			if i+1 < len(args) {
+				// Space-separated value: --additional-flags VALUE
+				flags := args[i+1]
+				cleaned := make([]string, 0, len(args)-2)
+				cleaned = append(cleaned, args[:i]...)
+				cleaned = append(cleaned, args[i+2:]...)
+				return cleaned, flags
+			}
+			// Flag at end with no value: remove it silently.
+			cleaned := make([]string, 0, len(args)-1)
+			cleaned = append(cleaned, args[:i]...)
+			return cleaned, ""
+
+		case strings.HasPrefix(arg, "--additional-flags="):
+			// --additional-flags=VALUE
+			v := strings.TrimPrefix(arg, "--additional-flags=")
+			cleaned := make([]string, 0, len(args)-1)
+			cleaned = append(cleaned, args[:i]...)
+			cleaned = append(cleaned, args[i+1:]...)
+			return cleaned, v
+
+		case strings.HasPrefix(arg, "-a="):
+			// -a=VALUE
+			v := strings.TrimPrefix(arg, "-a=")
+			cleaned := make([]string, 0, len(args)-1)
+			cleaned = append(cleaned, args[:i]...)
+			cleaned = append(cleaned, args[i+1:]...)
+			return cleaned, v
+		}
+	}
+	return args, ""
 }


### PR DESCRIPTION
Fixes #2160.

I took a look, and it looks like this is the only missing case that we need to parse. All of the other dash-dash args are nonsensical when placed after the box' name.