### PR TITLE
fix(inside-distrobox): do not consider scripts in PATH

### DIFF
--- a/internal/inside-distrobox/scripts.go
+++ b/internal/inside-distrobox/scripts.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -58,10 +57,6 @@ func exists(name string) bool {
 		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
 			return true
 		}
-	}
-
-	if _, err := exec.LookPath(name); err == nil {
-		return true
 	}
 
 	return false

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -29,21 +29,12 @@ func assertAllScripts(t *testing.T, dir string) {
 	}
 }
 
-// isolatePath wipes PATH for the duration of the test so the PATH branch
-// of exists() never finds a system-installed distrobox-init while we are
-// trying to exercise other resolution branches.
-func isolatePath(t *testing.T) {
-	t.Helper()
-	t.Setenv("PATH", "")
-}
-
 // TestProvisionScripts_CustomDir checks the DBX_SCRIPTS_DIR override:
 // when set to an empty directory, ProvisionScripts writes all three
 // scripts there and returns that directory.
 func TestProvisionScripts_CustomDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("DBX_SCRIPTS_DIR", tmpDir)
-	isolatePath(t)
 
 	dir, err := insidedistrobox.ProvisionScripts()
 	require.NoError(t, err)
@@ -51,38 +42,13 @@ func TestProvisionScripts_CustomDir(t *testing.T) {
 	assertAllScripts(t, dir)
 }
 
-// TestProvisionScripts_DetectOnPath confirms the skip-write shortcut via
-// the PATH branch of exists(): when the helper scripts already exist
-// somewhere on PATH, ProvisionScripts leaves them byte-for-byte
-// untouched rather than overwriting from the embedded copies.
-func TestProvisionScripts_DetectOnPath(t *testing.T) {
-	scriptsDir := t.TempDir()
-	marker := "#!/bin/sh\n# pre-existing-marker\n"
-	for _, name := range expectedScripts {
-		require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, name), []byte(marker), 0755))
-	}
-
-	t.Setenv("PATH", scriptsDir)
-	t.Setenv("DBX_SCRIPTS_DIR", t.TempDir())
-
-	_, err := insidedistrobox.ProvisionScripts()
-	require.NoError(t, err)
-
-	for _, name := range expectedScripts {
-		got, err := os.ReadFile(filepath.Join(scriptsDir, name))
-		require.NoError(t, err)
-		require.Equal(t, marker, string(got), "%s was overwritten despite existing on PATH", name)
-	}
-}
-
 // TestProvisionScripts_ExtractsAdjacentToBinary verifies the default
-// resolution: with no DBX_SCRIPTS_DIR override and nothing on PATH,
+// resolution: with no DBX_SCRIPTS_DIR override,
 // ProvisionScripts writes to the directory containing the running
 // binary. That is the layout a fresh `go install` or curl-only deploy
 // produces.
 func TestProvisionScripts_ExtractsAdjacentToBinary(t *testing.T) {
 	t.Setenv("DBX_SCRIPTS_DIR", "")
-	isolatePath(t)
 	t.Setenv("HOME", t.TempDir())
 
 	exe, err := os.Executable()


### PR DESCRIPTION
The presence of distrobox-init (or -export or -host-exec) in the host PATH must not be considered when checking the presence of the scripts, the container manager is only considering the configured host directory as a source for copying the files into a newly-created container.

An alternative solution could it be to use the location of the file when the script is detected in PATH. That has been discarded for two reasons:
1. the need to propagate the value of the file location though all the usage chain; also, potentially each file can be in different locations thus requiring the code to handle them;
2. the scripts in PATH may not be the ones used by the current version of Distrobox (think about try out the latest version while having the stable one installed on the machine).