### PR TITLE
refactor(config): move the script dir resolution to the global config

### DIFF
--- a/internal/inside-distrobox/scripts.go
+++ b/internal/inside-distrobox/scripts.go
@@ -16,10 +16,10 @@ var initScript string
 //go:embed assets/distrobox-export
 var exportScripts string
 
-// ProvisionScripts ensures that all necessary scripts are created in the host directory.
-// It returns the path to the directory where the scripts are stored.
-func ProvisionScripts() (string, error) {
-	dir := hostDir()
+// ProvisionScripts ensures that all necessary scripts are created in the given directory.
+// It returns scriptsDir unchanged on success.
+func ProvisionScripts(scriptsDir string) (string, error) {
+	dir := scriptsDir
 	//nolint:gosec // 0755 is the same as from distrobox v1, let's keep it for compatibility
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create scripts directory: %w", err)
@@ -60,26 +60,4 @@ func exists(name string) bool {
 	}
 
 	return false
-}
-
-// hostDir returns the directory path where the scripts should be stored.
-// Evaluates DBX_SCRIPTS_DIR env var first, then HOME env var, and falls back to default path.
-func hostDir() string {
-	// First check DBX_SCRIPTS_DIR env var
-	if dir := os.Getenv("DBX_SCRIPTS_DIR"); dir != "" {
-		return dir
-	}
-
-	// then check the path where main distrobox is installed
-	if exe, err := os.Executable(); err == nil {
-		return filepath.Dir(exe)
-	}
-
-	// Then, check HOME env var
-	if home := os.Getenv("HOME"); home != "" {
-		return filepath.Join(home, ".local", "bin")
-	}
-
-	// Fallback to default path
-	return "/usr/bin"
 }

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -29,27 +29,54 @@ func assertAllScripts(t *testing.T, dir string) {
 	}
 }
 
-// TestProvisionScripts_CustomDir checks the DBX_SCRIPTS_DIR override:
-// when set to an empty directory, ProvisionScripts writes all three
-// scripts there and returns that directory.
+// isolatePath wipes PATH for the duration of the test so the PATH branch
+// of exists() never finds a system-installed distrobox-init while we are
+// trying to exercise other resolution branches.
+func isolatePath(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", "")
+}
+
+// TestProvisionScripts_CustomDir checks that ProvisionScripts writes all three
+// scripts into the given directory and returns it unchanged.
 func TestProvisionScripts_CustomDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("DBX_SCRIPTS_DIR", tmpDir)
+	isolatePath(t)
 
-	dir, err := insidedistrobox.ProvisionScripts()
+	dir, err := insidedistrobox.ProvisionScripts(tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, tmpDir, dir)
 	assertAllScripts(t, dir)
 }
 
-// TestProvisionScripts_ExtractsAdjacentToBinary verifies the default
-// resolution: with no DBX_SCRIPTS_DIR override,
-// ProvisionScripts writes to the directory containing the running
-// binary. That is the layout a fresh `go install` or curl-only deploy
-// produces.
+// TestProvisionScripts_DetectOnPath confirms the skip-write shortcut via
+// the PATH branch of exists(): when the helper scripts already exist
+// somewhere on PATH, ProvisionScripts leaves them byte-for-byte
+// untouched rather than overwriting from the embedded copies.
+func TestProvisionScripts_DetectOnPath(t *testing.T) {
+	writeDir := t.TempDir()
+	scriptsDir := t.TempDir()
+	marker := "#!/bin/sh\n# pre-existing-marker\n"
+	for _, name := range expectedScripts {
+		require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, name), []byte(marker), 0755))
+	}
+
+	t.Setenv("PATH", scriptsDir)
+
+	_, err := insidedistrobox.ProvisionScripts(writeDir)
+	require.NoError(t, err)
+
+	for _, name := range expectedScripts {
+		got, err := os.ReadFile(filepath.Join(scriptsDir, name))
+		require.NoError(t, err)
+		require.Equal(t, marker, string(got), "%s was overwritten despite existing on PATH", name)
+	}
+}
+
+// TestProvisionScripts_ExtractsAdjacentToBinary verifies that ProvisionScripts
+// writes to the given directory.
 func TestProvisionScripts_ExtractsAdjacentToBinary(t *testing.T) {
-	t.Setenv("DBX_SCRIPTS_DIR", "")
-	t.Setenv("HOME", t.TempDir())
+	isolatePath(t)
 
 	exe, err := os.Executable()
 	require.NoError(t, err)
@@ -63,7 +90,7 @@ func TestProvisionScripts_ExtractsAdjacentToBinary(t *testing.T) {
 		}
 	})
 
-	dir, err := insidedistrobox.ProvisionScripts()
+	dir, err := insidedistrobox.ProvisionScripts(exeDir)
 	require.NoError(t, err)
 	require.Equal(t, exeDir, dir)
 	assertAllScripts(t, dir)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -149,6 +149,7 @@ func (c *CreateCommand) Execute(ctx context.Context, opts CreateOptions) (*Creat
 			Init:                    opts.Init,
 			Nvidia:                  opts.Nvidia,
 			DryRun:                  opts.DryRun,
+			ScriptsDir:              c.cfg.ScriptsDir,
 		},
 	)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,12 @@ type Values struct {
 	SkipWorkDir         bool
 	UsernsNoLimit       bool
 	RmCustomHome        bool
+
+	// ScriptsDir is the directory path where the helper scripts
+	// (distrobox-init, distrobox-export, distrobox-host-exec) are stored.
+	// Resolved from DBX_SCRIPTS_DIR env var first, then the directory of the
+	// running binary, then ~/.local/bin, falling back to /usr/bin.
+	ScriptsDir string
 }
 
 func defaultsMap() map[string]string {
@@ -96,6 +102,7 @@ func toStruct(configMap map[string]string) *Values {
 		SkipWorkDir:           toBool(configMap["container_skip_workdir"]),
 		UsernsNoLimit:         toBool(configMap["userns_nolimit"]),
 		RmCustomHome:          toBool(configMap["rm_home"]),
+		ScriptsDir:            resolveScriptsDir(),
 	}
 }
 
@@ -240,4 +247,26 @@ func readEnv() map[string]string {
 	}
 
 	return envConfig
+}
+
+// resolveScriptsDir returns the directory path where the helper scripts should
+// be stored.
+func resolveScriptsDir() string {
+	// First check DBX_SCRIPTS_DIR env var
+	if dir := os.Getenv("DBX_SCRIPTS_DIR"); dir != "" {
+		return dir
+	}
+
+	// then check the path where main distrobox is installed
+	if exe, err := os.Executable(); err == nil {
+		return filepath.Dir(exe)
+	}
+
+	// Then, check host's HOME env var
+	if home := os.Getenv("HOME"); home != "" {
+		return filepath.Join(home, ".local", "bin")
+	}
+
+	// Fallback to default path
+	return "/usr/bin"
 }

--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -83,6 +83,11 @@ type CreateOptions struct {
 	Init                    bool
 	Nvidia                  bool
 	DryRun                  bool
+	// ScriptsDir is the directory where helper scripts (distrobox-init,
+	// distrobox-export, distrobox-host-exec) are stored. It is resolved
+	// by config.Values.ScriptsDir and passed through so the provider can
+	// mount them into the container.
+	ScriptsDir string
 }
 
 type EnterOptions struct {

--- a/pkg/containermanager/providers/docker.go
+++ b/pkg/containermanager/providers/docker.go
@@ -92,7 +92,7 @@ func (d *Docker) Create(
 ) error {
 	userEnv := userenv.LoadUserEnvironment(ctx)
 
-	scriptsDir, err := insidedistrobox.ProvisionScripts()
+	scriptsDir, err := insidedistrobox.ProvisionScripts(opts.ScriptsDir)
 	if err != nil {
 		return fmt.Errorf("failed to provision scripts: %w", err)
 	}

--- a/pkg/containermanager/providers/podman.go
+++ b/pkg/containermanager/providers/podman.go
@@ -90,7 +90,7 @@ func (p *Podman) Create(
 ) error {
 	userEnv := userenv.LoadUserEnvironment(ctx)
 
-	scriptsDir, err := insidedistrobox.ProvisionScripts()
+	scriptsDir, err := insidedistrobox.ProvisionScripts(opts.ScriptsDir)
 	if err != nil {
 		return fmt.Errorf("failed to provision scripts: %w", err)
 	}


### PR DESCRIPTION
So that we centralize all the references to environment configurations and their defaults

#### Summary
* directory resolution moved to config.go
* actual value passed as parameter from config