### PR TITLE
refactor(cleanup): remove dead code and duplication

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -163,11 +163,6 @@ may require additional packages depending on the container image: https://github
 				Usage:   "only print the container manager command generated",
 			},
 			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Usage:   "show more verbosity",
-			},
-			&cli.BoolFlag{
 				Name:  "absolutely-disable-root-password-i-am-really-positively-sure",
 				Usage: `⚠️ ⚠️ when setting up a rootful distrobox, this will skip user password setup, leaving it blank. ⚠️ ⚠️`,
 			},

--- a/internal/cli/ephemeral.go
+++ b/internal/cli/ephemeral.go
@@ -100,9 +100,9 @@ func ephemeralAction(ctx context.Context, cmd *cli.Command, cfg *config.Values) 
 			ContainerPlatform:       cmd.String("platform"),
 			GenerateEntry:           false,
 			Rootful:                 cmd.Bool("root"),
+			DryRun:                  cmd.Bool("dry-run"),
 		},
 		CustomCommand: customCommand,
-		DryRun:        cmd.Bool("dry-run"),
 	}
 
 	progress := ui.NewProgress(os.Stderr)

--- a/internal/userenv/user_environment.go
+++ b/internal/userenv/user_environment.go
@@ -27,8 +27,6 @@ type UserEnvironment struct {
 // - USER
 // - HOME
 // - SHELL
-//
-//nolint:gocognit
 func LoadUserEnvironment(ctx context.Context) *UserEnvironment {
 	env := &UserEnvironment{}
 
@@ -71,19 +69,10 @@ func LoadUserEnvironment(ctx context.Context) *UserEnvironment {
 		}
 	}
 
-	// USER ID
-	if uid := os.Getuid(); uid >= 0 {
-		env.UserID = strconv.Itoa(uid)
-	} else if uid, err := exec.CommandContext(ctx, "id", "-ru").Output(); err == nil {
-		env.UserID = strings.TrimSpace(string(uid))
-	}
-
-	// GROUP ID
-	if gid := os.Getgid(); gid >= 0 {
-		env.GroupID = strconv.Itoa(gid)
-	} else if gid, err := exec.CommandContext(ctx, "id", "-rg").Output(); err == nil {
-		env.GroupID = strings.TrimSpace(string(gid))
-	}
+	// os.Getuid/os.Getgid only return -1 on Windows; distrobox is Linux/macOS
+	// only, so they always succeed.
+	env.UserID = strconv.Itoa(os.Getuid())
+	env.GroupID = strconv.Itoa(os.Getgid())
 
 	// DESKTOP ENTRY DIR
 	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {

--- a/pkg/commands/ephemeral.go
+++ b/pkg/commands/ephemeral.go
@@ -24,7 +24,6 @@ type EphemeralOptions struct {
 	// ephemeral container instead of the default login shell. It is forwarded
 	// to the underlying enter command.
 	CustomCommand []string
-	DryRun        bool
 }
 
 type EphemeralCommand struct {
@@ -68,7 +67,6 @@ func (c *EphemeralCommand) Execute(ctx context.Context, opts EphemeralOptions) e
 	createOpts.ContainerName = name
 	// override options not relevant for creating ephemeral containers
 	createOpts.GenerateEntry = false
-	createOpts.DryRun = opts.DryRun
 	createOpts.NonInteractive = true
 	if _, createErr := c.createCmd.Execute(ctx, createOpts); createErr != nil {
 		return fmt.Errorf("ephemeral: %w", createErr)

--- a/pkg/commands/ephemeral_test.go
+++ b/pkg/commands/ephemeral_test.go
@@ -32,9 +32,9 @@ func TestEphemeralCommand_PassesCustomCommandToEnter(t *testing.T) {
 		CreateOptions: commands.CreateOptions{
 			ContainerName:  "ephemeral-test",
 			ContainerImage: "alpine:latest",
+			DryRun:         true,
 		},
 		CustomCommand: customCommand,
-		DryRun:        true,
 	})
 	require.NoError(t, err)
 
@@ -52,8 +52,8 @@ func TestEphemeralCommand_EmptyCustomCommandIsNotForwardedAsArgs(t *testing.T) {
 		CreateOptions: commands.CreateOptions{
 			ContainerName:  "ephemeral-no-cmd",
 			ContainerImage: "alpine:latest",
+			DryRun:         true,
 		},
-		DryRun: true,
 	})
 	require.NoError(t, err)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -151,12 +152,10 @@ func getConfigFilePaths() ([]string, error) {
 	}, nil
 }
 
-func mergeConfigMaps(maps ...map[string]string) map[string]string {
+func mergeConfigMaps(configMaps ...map[string]string) map[string]string {
 	merged := make(map[string]string)
-	for _, m := range maps {
-		for k, v := range m {
-			merged[k] = v
-		}
+	for _, m := range configMaps {
+		maps.Copy(merged, m)
 	}
 	return merged
 }

--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -369,5 +369,5 @@ func BuildCommandArgs(customCommand []string, user string, noTTY bool, unshareGr
 }
 
 func TimestampNow() string {
-	return time.Now().UTC().Format("2006-01-02T15:04:05.000000000+00:00")
+	return time.Now().UTC().Format(time.RFC3339Nano)
 }


### PR DESCRIPTION
A handful of small simplifications from a review pass: leaning on the
standard library where it already covers us, keeping a single source of
truth where a field or flag had a second copy, and trimming a fallback
that isn't needed on Linux/macOS.