### PR TITLE
fix: bump install script `next` branch to rc4

### DIFF
--- a/install
+++ b/install
@@ -39,7 +39,7 @@
 REPO="89luca89/distrobox"
 # Bump on every release. Override with --version to install a different tag.
 LEGACY_VERSION="1.8.2.5"
-V2_VERSION="2.0.0-rc.3"
+V2_VERSION="2.0.0-rc.4"
 VERSION="${LEGACY_VERSION}"
 prefix=""
 no_color=0


### PR DESCRIPTION
My bad, bumping the install script to the latest RC available :+1: 