### PR TITLE
ci(e2e): add end-to-end behavioral tests across distros and engines

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,25 +1,23 @@
 ---
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
+# Full compatibility suite: the e2e matrix over every supported image
+# (docs/compatibility.md -> Makefile E2E_FULL_IMAGES), both backends. Runs on main
+# pushes and CI-labelled PRs, only when distrobox files changed. The per-PR gating
+# subset is e2e.yml; both share the matrix logic in e2e-matrix.yml.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [main]
   pull_request:
     branches: [main]
     types: [opened, synchronize, ready_for_review, edited, labeled]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       run_always:
         description: 'Run even if no files are changed'
         required: true
         type: boolean
-# Check if we indeed modified distrobox stuff
+
 jobs:
   check_changes:
     runs-on: ubuntu-latest
@@ -29,201 +27,23 @@ jobs:
     outputs:
       distrobox_changed: ${{ steps.check_file_changed.outputs.distrobox_changed }}
     steps:
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2
-
-      # Fetch from compatibility table all the distros supported
       - id: check_file_changed
         run: |
-          if git diff --name-only HEAD^ HEAD | grep -E '\.go$|go\.mod|go\.sum|Makefile|docs/compatibility\.md|internal/inside-distrobox/assets/'; then
-            echo "::set-output name=distrobox_changed::True"
+          if git diff --name-only HEAD^ HEAD | grep -E '\.go$|go\.mod|go\.sum|Makefile|docs/compatibility\.md|internal/inside-distrobox/assets/|hack/ci/'; then
+            echo "distrobox_changed=True" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=distrobox_changed::False"
+            echo "distrobox_changed=False" >> "$GITHUB_OUTPUT"
           fi
 
-  # Prepare distros matrix
-  setup:
-    runs-on: ubuntu-latest
+  e2e:
     needs: check_changes
-    outputs:
-      targets: ${{ steps.set-matrix.outputs.targets }}
     if: >-
       needs.check_changes.outputs.distrobox_changed == 'True' ||
       github.event.inputs.run_always == 'True'
-    steps:
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      # Fetch from compatibility table all the distros supported
-      - id: set-matrix
-        run: |
-            skip_list="bazzite|chimera|slackware|stream8|ublue|neon|steamos"
-
-            echo "::set-output name=targets::$(sed -n -e '/| Alma/,/| Void/ p' docs/compatibility.md |
-            cut -d'|' -f 4 |
-            sed 's/<br>/\n/g' |
-            tr -d ' ' |
-            sed '/^[[:space:]]*$/d' |
-            sort -u | grep -Ev "${skip_list}" |
-            jq -R -s -c 'split("\n")[:-1]')"
-
-  run:
-    runs-on: ubuntu-latest
-    needs: setup
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        distribution: ${{fromJSON(needs.setup.outputs.targets)}}
-        container_manager: ["podman"] #, "docker"]
-    env:
-      XDG_CACHE_HOME: "/tmp/"
-      DBX_CONTAINER_MANAGER: ${{ matrix.container_manager }}
-
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-
-      - name: Build distrobox binary
-        run: |
-          make build
-          cp ./bin/distrobox ./distrobox
-
-      # Ensure distrobox create works:
-      - name: Distrobox create
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ${DBX_CONTAINER_MANAGER} pull "${image}"
-          # ./distrobox create --yes --absolutely-disable-root-password-i-am-really-positively-sure -i "${image}" --name "${container_name}"
-          case "${container_name}" in
-            *init*)
-              echo "SYSTEMD DETECTED: creating container with --init..."
-              ./distrobox create --yes -i "${image}" --hostname "${container_name}" --name "${container_name}" --init --unshare-all
-              ;;
-            *)
-              ./distrobox create --yes -i "${image}" --hostname "${container_name}" --name "${container_name}"
-              ;;
-          esac
-
-      # Ensure distrobox enter and init works:
-      - name: Distrobox enter - init
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          case "${container_name}" in
-            *init*)
-              echo "SYSTEMD DETECTED: performing systemctl check..."
-              ./distrobox enter --name "${container_name}" -- systemctl is-system-running | grep -E "degraded|running|starting"
-              ;;
-            *)
-              ./distrobox enter --name "${container_name}" -- whoami
-              ;;
-          esac
-
-      # Ensure distrobox enter and init works:
-      - name: Distrobox enter - user
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          # Assert that distrobox exported binary indeed works
-          set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- whoami | tr -d '\r' | tr -d '^@')"
-          expected_output="$(whoami)"
-          if [ "$command_output" != "$expected_output" ]; then
-            exit 1
-          fi
-
-      # Ensure distrobox enter and init works:
-      - name: Distrobox enter - command
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          # Assert that distrobox exported binary indeed works
-          set -x
-          command_output="$(./distrobox enter --name "${container_name}" -- uname -n | tr -d '\r' | tr -d '^@')"
-          expected_output="${container_name}"
-          if [ "$command_output" != "$expected_output" ]; then
-            exit 1
-          fi
-
-      # Ensure distrobox export works:
-      - name: Distrobox export
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --bin /bin/uname --export-path ${HOME}/
-          # Assert that distrobox exported binary indeed works
-          set -x
-          command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
-          expected_output="${container_name}"
-          if [ "$command_output" != "$expected_output" ]; then
-            exit 1
-          fi
-
-      # Ensure distrobox export works:
-      - name: Distrobox export - sudo
-        if: matrix.container_manager != 'docker'
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox enter "${container_name}" -- distrobox-export --sudo --bin /bin/uname --export-path ${HOME}/
-          # Assert that distrobox exported binary indeed works
-          set -x
-          command_output="$(${HOME}/uname -n | tr -d '\r' | tr -d '^@')"
-          expected_output="${container_name}"
-          if [ "$command_output" != "$expected_output" ]; then
-            exit 1
-          fi
-
-      # Ensure distrobox upgrade works:
-      - name: Distrobox upgrade
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox upgrade "${container_name}"
-
-      # Ensure distrobox list works:
-      - name: Distrobox list
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox list | grep "${container_name}" | grep "${image}" | grep -E "Up|running"
-
-      # Ensure distrobox stop works:
-      - name: Distrobox stop
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox stop --yes "${container_name}"
-
-      # Ensure distrobox rm works:
-      - name: Distrobox logs
-        if: ${{ always() }}
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          $DBX_CONTAINER_MANAGER logs "${container_name}"
-
-      # Ensure distrobox rm works:
-      - name: Distrobox rm
-        if: ${{ always() }}
-        run: |
-          image=${{ matrix.distribution }}
-          container_name="$(basename "${image}" | sed -E 's/[:.]/-/g')"
-          ./distrobox rm --force "${container_name}"
-          $DBX_CONTAINER_MANAGER rmi -f "${image}"
+    uses: ./.github/workflows/e2e-matrix.yml
+    with:
+      images_var: E2E_FULL_IMAGES

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,0 +1,44 @@
+---
+name: e2e-matrix
+
+# Reusable: run the per-distro e2e matrix (image list x both backends) via
+# `make e2e-one`. The image list is read from the Makefile variable named by
+# `images_var`, so the list lives only there.
+on:
+  workflow_call:
+    inputs:
+      images_var:
+        description: Makefile variable holding the image list (e.g. E2E_IMAGES).
+        required: true
+        type: string
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.set.outputs.images }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: set
+        env:
+          VAR: ${{ inputs.images_var }}
+        run: echo "images=$(make -s print-"$VAR" | jq -R -c 'split(" ") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: ${{ matrix.image }} (${{ matrix.backend }})
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.setup.outputs.images) }}
+        backend: [podman, docker]
+    env:
+      XDG_CACHE_HOME: "/tmp/"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      - run: make e2e-one IMAGE="${{ matrix.image }}" CM="${{ matrix.backend }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+---
+name: E2E
+
+# Gating suite on EVERY pull request: the e2e matrix over the gating image subset
+# (Makefile E2E_IMAGES) plus the distro-agnostic commands. The full matrix runs in
+# compatibility.yml (main / CI-labelled); both share e2e-matrix.yml.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    uses: ./.github/workflows/e2e-matrix.yml
+    with:
+      images_var: E2E_IMAGES
+
+  # Distro-agnostic subcommands, once per backend on a fast image.
+  commands:
+    name: commands (${{ matrix.backend }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [podman, docker]
+    env:
+      XDG_CACHE_HOME: "/tmp/"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      - run: make e2e-commands CM="${{ matrix.backend }}"

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,61 @@ lint:
 .PHONY: lint-fix
 lint-fix:
 	$(GO_BUILD_ENV) golangci-lint run --fix
+
+# ---------------------------------------------------------------------------
+# Local e2e via the hack/ci/*.sh scripts, on the freshly-built binary. Pulled
+# images are kept so repeated runs do not re-download. Targets:
+#   e2e          mirrors the per-PR gate (.github/workflows/e2e.yml): the gating
+#                image subset + commands.sh, on both backends (podman, docker).
+#   e2e-full     the whole compatibility matrix (docs/compatibility.md) + commands.
+#   e2e-one      one e2e.sh run for a single image + backend; override IMAGE=/CM=.
+#   e2e-commands just commands.sh on one image/backend; override IMAGE=/CM=.
+# ---------------------------------------------------------------------------
+IMAGE ?= docker.io/library/alpine:latest
+CM    ?= podman
+E2E_ENV := DBX="$(CURDIR)/bin/distrobox" DBX_E2E_KEEP_IMAGE=1
+
+E2E_IMAGES := \
+	docker.io/library/alpine:latest \
+	docker.io/library/debian:stable \
+	docker.io/library/ubuntu:24.04 \
+	docker.io/library/fedora:latest \
+	registry.opensuse.org/opensuse/distrobox:latest \
+	docker.io/library/archlinux:latest \
+	registry.access.redhat.com/ubi9/ubi-init
+
+# Full compatibility matrix, derived from docs/compatibility.md like compatibility.yml
+# (no drift). Lazy '=' so the pipeline runs only when e2e-full is invoked.
+E2E_FULL_SKIP := bazzite|chimera|slackware|stream8|ublue|neon|steamos
+E2E_FULL_IMAGES = $(shell sed -n -e '/| Alma/,/| Void/ p' docs/compatibility.md | cut -d'|' -f 4 | sed 's/<br>/\n/g' | tr -d ' ' | sed '/^[[:space:]]*$$/d' | sort -u | grep -Ev '$(E2E_FULL_SKIP)')
+
+# print-<VAR> — echo a make variable; the CI matrices build from these lists.
+.PHONY: print-%
+print-%:
+	@echo '$($*)'
+
+.PHONY: e2e-one
+e2e-one: build
+	echo ">>> e2e: $(IMAGE) / $(CM)"; \
+	$(E2E_ENV) hack/ci/e2e.sh "$(IMAGE)" "$(CM)"
+
+.PHONY: e2e-commands
+e2e-commands: build
+	echo ">>> commands: $(IMAGE) / $(CM)"; \
+	$(E2E_ENV) hack/ci/commands.sh "$(IMAGE)" "$(CM)"
+
+.PHONY: e2e
+e2e: build
+	@for img in $(E2E_IMAGES); do \
+		for cm in podman docker; do \
+			$(MAKE) --no-print-directory e2e-one IMAGE="$$img" CM="$$cm" || exit 1; \
+		done; \
+	done
+	@for cm in podman docker; do \
+		$(MAKE) --no-print-directory e2e-commands CM="$$cm" || exit 1; \
+	done
+
+# Full compatibility sweep (100+ images x 2 backends); local twin of compatibility.yml.
+.PHONY: e2e-full
+e2e-full:
+	$(MAKE) --no-print-directory e2e E2E_IMAGES="$(E2E_FULL_IMAGES)"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -51,27 +51,27 @@ Distrobox has been successfully tested on:
 | --- | --- | --- |
 | Alpine Linux | | To setup rootless podman, look [HERE](https://wiki.alpinelinux.org/wiki/Podman) |
 | Arch Linux | | `distrobox` is available in the `extra` repository and `distrobox-git` is available in the AUR (thanks [M0Rf30](https://github.com/M0Rf30)!). <br> To setup rootless podman, look [HERE](https://wiki.archlinux.org/title/Podman) |
-| Bazzite | 38 | `distrobox-git` is preinstalled. |
-| CentOS | 8 <br> 8 Stream <br> 9 Stream | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
+| Bazzite | 44 | `distrobox-git` is preinstalled. |
+| CentOS | 9 Stream <br> 10 Stream | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
 | Chimera Linux | | `distrobox` is available in `chimera-repo-user`. |
-| ChromeOS | Debian 11 (docker with make-shared workaround #non-shared-mounts) <br> Debian 12 (podman) | using built-in Linux on ChromeOS mode which is debian-based, which can be [upgraded](https://wiki.debian.org/DebianUpgrade) from 11 bullseye to 12 bookworm (in fact 12 is recommended) |
-| Debian | 11 <br> 12 <br> Testing <br> Unstable | `distrobox` is available in default repos starting from version 12 (thanks [michel-slm!](https://github.com/michel-slm!)!) |
-| deepin | 23 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` |
-| EndlessOS | 4.0.0 | |
-| Fedora Silverblue/Kinoite | 35 <br> 36 <br> 37 <br> Rawhide | `distrobox` is available in default repos.(thanks [alcir](https://github.com/alcir)!) |
-| Fedora | 35 <br> 36 <br> 37 <br> 38 <br> Rawhide | `distrobox` is available in default repos.(thanks [alcir](https://github.com/alcir)!) |
+| ChromeOS | Debian 12 (docker with make-shared workaround #non-shared-mounts) <br> Debian 13 (podman) | using built-in Linux on ChromeOS mode which is debian-based, which can be [upgraded](https://wiki.debian.org/DebianUpgrade) from 12 bookworm to 13 trixie (in fact 13 is recommended) |
+| Debian | 12 <br> 13 <br> Testing <br> Unstable | `distrobox` is available in default repos starting from version 12 (thanks [michel-slm!](https://github.com/michel-slm!)!) |
+| deepin | 25 <br> Testing <br> Unstable | `distrobox` is available in default repos in `testing` and `unstable` |
+| EndlessOS | 6 | |
+| Fedora Silverblue/Kinoite | 43 <br> 44 <br> Rawhide | `distrobox` is available in default repos.(thanks [alcir](https://github.com/alcir)!) |
+| Fedora | 43 <br> 44 <br> Rawhide | `distrobox` is available in default repos.(thanks [alcir](https://github.com/alcir)!) |
 | Gentoo | | To setup rootless podman, look [HERE](https://wiki.gentoo.org/wiki/Podman) |
 | KDE neon | | `distrobox` is available in default repo |
 | macOS | | Requires [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/). Support is limited to CLI use only; GUI, sound, and graphics are not supported. Please do not open issues for GUI/sound/graphics-related bugs on macOS. |
 | Manjaro | | To setup rootless podman, look [HERE](https://wiki.archlinux.org/title/Podman) |
-| NixOS | 21.11 | Make sure to mind your executable paths. Sometimes a container will not have nix paths, and sometimes it will not have its own paths.  <br>  Distrobox is available in Nixpkg collection (thanks [AtilaSaraiva](https://github.com/AtilaSaraiva)!)< <br> To setup Docker, look [HERE](https://wiki.nixos.org/wiki/Docker)  <br> To setup Podman, look [HERE](https://wiki.nixos.org/wiki/Podman) and [HERE](https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947) |
+| NixOS | 26.05 | Make sure to mind your executable paths. Sometimes a container will not have nix paths, and sometimes it will not have its own paths.  <br>  Distrobox is available in Nixpkg collection (thanks [AtilaSaraiva](https://github.com/AtilaSaraiva)!)< <br> To setup Docker, look [HERE](https://wiki.nixos.org/wiki/Docker)  <br> To setup Podman, look [HERE](https://wiki.nixos.org/wiki/Podman) and [HERE](https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947) |
 | openSUSE | Leap | `distrobox` is available in default repos (thanks [dfaggioli](https://github.com/dfaggioli)!). <br> Prior to Leap 15.6 ``podman`` logging needs to be configured properly, more details in [this openSUSE bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1199871). |
 | openSUSE | Tumbleweed <br> Slowroll <br> Aeon/Kalpa | `distrobox` is available in default repos (thanks [dfaggioli](https://github.com/dfaggioli)!) <br> For Tumbleweed/Slowroll, do: `zypper install distrobox`. <br> For Aeon/Kalpa, **distrobox is installed by default**. |
-| SUSE Linux Enterprise Server | 15 SP5 <br> or later | `distrobox` is available in `SUSE Package Hub` repo. <br> Enable this repo and then: <br> `zypper install distrobox`. <br>Prior to SLES 15 SP6 ``podman`` logging needs to be configured properly, more details in [this openSUSE bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1199871). |
+| SUSE Linux Enterprise Server | 15 SP7 <br> or later | `distrobox` is available in `SUSE Package Hub` repo. <br> Enable this repo and then: <br> `zypper install distrobox`. <br>Prior to SLES 15 SP6 ``podman`` logging needs to be configured properly, more details in [this openSUSE bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1199871). |
 | SteamOS | | SteamOS officially included Podman and Distrobox as pre-installed tools starting with the release of **SteamOS 3.5**. However, the versions are a little bit behind. You can follow the [Install Podman in a static manner](posts/install_podman_static.md) or [Install Lilipod in a static manner](posts/install_lilipod_static.md) guide, this will install it in your $HOME and it will survive updates. |
-| RedHat | 8 <br> 9 | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
-| Ubuntu | 18.04 <br> 20.04 <br> 22.04 <br> 23.04 <br> 24.04 <br> | Older versions based on 20.04 or earlier may need external repos to install newer Podman and Docker releases. <br> Derivatives like Pop_OS!, Mint and Elementary OS should work the same. <br> [Now PPA available!](https://launchpad.net/~michel-slm/+archive/ubuntu/distrobox), also `distrobox` is available in default repos from `22.10` onward (thanks [michel-slm](https://github.com/michel-slm)!) |
-| Vanilla OS | 22.10 <br> Orchid | `distrobox` should be installed in the home directory using the official script |
+| RedHat | 8 <br> 9 <br> 10 | `distrobox` is available in epel repos. (thanks [alcir](https://github.com/alcir)!) |
+| Ubuntu | 20.04 <br> 22.04 <br> 24.04 <br> 26.04 <br> | Older versions based on 20.04 or earlier may need external repos to install newer Podman and Docker releases. <br> Derivatives like Pop_OS!, Mint and Elementary OS should work the same. <br> [Now PPA available!](https://launchpad.net/~michel-slm/+archive/ubuntu/distrobox), also `distrobox` is available in default repos from `22.10` onward (thanks [michel-slm](https://github.com/michel-slm)!) |
+| Vanilla OS | Orchid | `distrobox` should be installed in the home directory using the official script |
 | Void Linux | glibc <br> musl | |
 | Windows | Oracle Linux 9 | using built-in Windows Subsystem for Linux |
 
@@ -154,35 +154,35 @@ Distrobox guests tested successfully with the following container images:
 
 | Distro | Version | Images |
 | --- | --- | --- |
-| AlmaLinux (Toolbox) | 8 <br> 9 | quay.io/toolbx-images/almalinux-toolbox:8 <br> quay.io/toolbx-images/almalinux-toolbox:9 <br> quay.io/toolbx-images/almalinux-toolbox:latest |
-| Alpine (Toolbox) | 3.20 <br> 3.21 <br> 3.22 <br> edge | quay.io/toolbx-images/alpine-toolbox:3.20 <br> quay.io/toolbx-images/alpine-toolbox:3.21 <br> quay.io/toolbx-images/alpine-toolbox:3.22 <br> quay.io/toolbx-images/alpine-toolbox:edge <br> quay.io/toolbx-images/alpine-toolbox:latest |
-| AmazonLinux (Toolbox) | 2 <br> 2022 | quay.io/toolbx-images/amazonlinux-toolbox:2 <br> quay.io/toolbx-images/amazonlinux-toolbox:2023 <br> quay.io/toolbx-images/amazonlinux-toolbox:latest |
+| AlmaLinux (Toolbox) | 8 <br> 9 <br> 10 | quay.io/toolbx-images/almalinux-toolbox:8 <br> quay.io/toolbx-images/almalinux-toolbox:9 <br> quay.io/toolbx-images/almalinux-toolbox:latest |
+| Alpine (Toolbox) | 3.21 <br> 3.22 <br> edge | quay.io/toolbx-images/alpine-toolbox:3.21 <br> quay.io/toolbx-images/alpine-toolbox:3.22 <br> quay.io/toolbx-images/alpine-toolbox:edge <br> quay.io/toolbx-images/alpine-toolbox:latest |
+| AmazonLinux (Toolbox) | 2 <br> 2023 | quay.io/toolbx-images/amazonlinux-toolbox:2 <br> quay.io/toolbx-images/amazonlinux-toolbox:2023 <br> quay.io/toolbx-images/amazonlinux-toolbox:latest |
 | Archlinux (Toolbox) | | quay.io/toolbx/arch-toolbox:latest |
 | ALT Linux | p10 <br> p11 <br> sisyphus | docker.io/library/alt:p10 <br> docker.io/library/alt:p11 <br> docker.io/library/alt:sisyphus |
 | Bazzite Arch | | ghcr.io/ublue-os/bazzite-arch:latest <br> ghcr.io/ublue-os/bazzite-arch-gnome:latest |
 | Centos (Toolbox) | stream9 <br> stream10 | quay.io/toolbx-images/centos-toolbox:stream9 <br> quay.io/toolbx-images/centos-toolbox:stream10 <br> quay.io/toolbx-images/centos-toolbox:latest |
 | Debian (Toolbox) | 11 <br> 12 <br> 13 <br> testing <br> unstable <br> | quay.io/toolbx-images/debian-toolbox:11 <br> quay.io/toolbx-images/debian-toolbox:12 <br> quay.io/toolbx-images/debian-toolbox:13 <br> quay.io/toolbx-images/debian-toolbox:testing <br> quay.io/toolbx-images/debian-toolbox:unstable <br> quay.io/toolbx-images/debian-toolbox:latest |
-| Fedora (Toolbox) | 38 <br> 39 <br> 40 <br> 41 <br> 42 <br> 43 <br> Rawhide | registry.fedoraproject.org/fedora-toolbox:38 <br> registry.fedoraproject.org/fedora-toolbox:39 <br> registry.fedoraproject.org/fedora-toolbox:40 <br> quay.io/fedora/fedora-toolbox:41 <br> quay.io/fedora/fedora-toolbox:42 <br> quay.io/fedora/fedora-toolbox:43 <br> quay.io/fedora/fedora-toolbox:rawhide |
+| Fedora (Toolbox) | 42 <br> 43 <br> 44 <br> Rawhide | quay.io/fedora/fedora-toolbox:42 <br> quay.io/fedora/fedora-toolbox:43 <br> quay.io/fedora/fedora-toolbox:44 <br> quay.io/fedora/fedora-toolbox:rawhide |
 | openSUSE (Toolbox) | | registry.opensuse.org/opensuse/distrobox:latest |
-| RedHat (Toolbox) | 8 <br> 9 | registry.access.redhat.com/ubi8/toolbox <br> registry.access.redhat.com/ubi9/toolbox |
+| RedHat (Toolbox) | 8 <br> 9 <br> 10 | registry.access.redhat.com/ubi8/toolbox <br> registry.access.redhat.com/ubi9/toolbox <br> registry.access.redhat.com/ubi10/toolbox |
 | Rocky Linux (Toolbox) | 8 <br> 9 | quay.io/toolbx-images/rockylinux-toolbox:8 <br> quay.io/toolbx-images/rockylinux-toolbox:9 <br> quay.io/toolbx-images/rockylinux-toolbox:latest |
-| Ubuntu (Toolbox) | 16.04 <br> 18.04 <br> 20.04 <br> 22.04 <br> 24.04 | quay.io/toolbx/ubuntu-toolbox:16.04 <br> quay.io/toolbx/ubuntu-toolbox:18.04 <br> quay.io/toolbx/ubuntu-toolbox:20.04 <br> quay.io/toolbx/ubuntu-toolbox:22.04 <br> quay.io/toolbx/ubuntu-toolbox:24.04 <br> quay.io/toolbx/ubuntu-toolbox:latest |
+| Ubuntu (Toolbox) | 16.04 <br> 18.04 <br> 20.04 <br> 22.04 <br> 24.04 <br> 26.04 | quay.io/toolbx/ubuntu-toolbox:16.04 <br> quay.io/toolbx/ubuntu-toolbox:18.04 <br> quay.io/toolbx/ubuntu-toolbox:20.04 <br> quay.io/toolbx/ubuntu-toolbox:22.04 <br> quay.io/toolbx/ubuntu-toolbox:24.04 <br> quay.io/toolbx/ubuntu-toolbox:26.04 <br> quay.io/toolbx/ubuntu-toolbox:latest |
 | Chainguard Wolfi (Toolbox) | | quay.io/toolbx-images/wolfi-toolbox:latest |
 | Ublue | ubuntu-toolbox <br> fedora-toolbox <br> wolfi-toolbox <br> archlinux-distrobox | ghcr.io/ublue-os/ubuntu-toolbox <br> ghcr.io/ublue-os/fedora-toolbox <br> ghcr.io/ublue-os/wolfi-toolbox <br> ghcr.io/ublue-os/arch-toolbox |
 | | | |
-| AlmaLinux | 8 <br> 8-minimal <br> 9 <br> 9-minimal | docker.io/library/almalinux:8 <br> docker.io/library/almalinux:9 |
-| Alpine Linux | 3.20 <br> 3.21 <br> 3.22 <br> edge | docker.io/library/alpine:3.20 <br> docker.io/library/alpine:3.21 <br> docker.io/library/alpine:3.22 <br> docker.io/library/alpine:edge <br> docker.io/library/alpine:latest |
-| AmazonLinux | 1 <br> 2 <br> 2023 | public.ecr.aws/amazonlinux/amazonlinux:1 <br> public.ecr.aws/amazonlinux/amazonlinux:2 <br>  public.ecr.aws/amazonlinux/amazonlinux:2023 |
+| AlmaLinux | 8 <br> 8-minimal <br> 9 <br> 9-minimal <br> 10 | docker.io/library/almalinux:8 <br> docker.io/library/almalinux:9 <br> docker.io/library/almalinux:10 |
+| Alpine Linux | 3.21 <br> 3.22 <br> 3.23 <br> 3.24 <br> edge | docker.io/library/alpine:3.21 <br> docker.io/library/alpine:3.22 <br> docker.io/library/alpine:3.23 <br> docker.io/library/alpine:3.24 <br> docker.io/library/alpine:edge <br> docker.io/library/alpine:latest |
+| AmazonLinux | 2 <br> 2023 | public.ecr.aws/amazonlinux/amazonlinux:2 <br>  public.ecr.aws/amazonlinux/amazonlinux:2023 |
 | Archlinux | | docker.io/library/archlinux:latest |
 | Blackarch | | docker.io/blackarchlinux/blackarch:latest |
-| CentOS Stream | 8 <br> 9 <br> 10 | quay.io/centos/centos:stream8 <br> quay.io/centos/centos:stream9 <br> quay.io/centos/centos:stream10 |
+| CentOS Stream | 9 <br> 10 | quay.io/centos/centos:stream9 <br> quay.io/centos/centos:stream10 |
 | Chainguard Wolfi | | cgr.dev/chainguard/wolfi-base:latest |
 | Chimera Linux | | docker.io/chimeralinux/chimera:latest |
 | Debian | 7 <br> 8 <br> 9 <br> 10 <br> 11 <br> 12 <br> 13 | docker.io/debian/eol:wheezy <br> docker.io/debian/eol:buster <br> docker.io/debian/eol:bullseye <br> docker.io/library/debian:bookworm-backports <br> docker.io/library/debian:stable-backports |
 | Debian | Testing | docker.io/library/debian:testing  <br>  docker.io/library/debian:testing-backports |
 | Debian | Unstable | docker.io/library/debian:unstable |
 | deepin | 20 (apricot) <br> 23 (beige) | docker.io/linuxdeepin/apricot <br> docker.io/linuxdeepin/deepin:beige |
-| Fedora | 38 <br> 39 <br> 40 <br> 41 <br> 42 <br> 43 <br> 44 <br> Rawhide | quay.io/fedora/fedora:38 <br> quay.io/fedora/fedora:39 <br> quay.io/fedora/fedora:40 <br> quay.io/fedora/fedora:41 <br> quay.io/fedora/fedora:42 <br> quay.io/fedora/fedora:43 <br> quay.io/fedora/fedora:44 <br> quay.io/fedora/fedora:rawhide |
+| Fedora | 42 <br> 43 <br> 44 <br> Rawhide | quay.io/fedora/fedora:42 <br> quay.io/fedora/fedora:43 <br> quay.io/fedora/fedora:44 <br> quay.io/fedora/fedora:rawhide |
 | Gentoo Linux | rolling | docker.io/gentoo/stage3:latest |
 | KDE neon | Latest | invent-registry.kde.org/neon/docker-images/plasma:latest |
 | Kali Linux | rolling | docker.io/kalilinux/kali-rolling:latest |
@@ -191,8 +191,8 @@ Distrobox guests tested successfully with the following container images:
 | openSUSE | Leap | registry.opensuse.org/opensuse/leap:latest |
 | openSUSE | Tumbleweed | registry.opensuse.org/opensuse/distrobox:latest <br> registry.opensuse.org/opensuse/tumbleweed:latest <br>  registry.opensuse.org/opensuse/toolbox:latest <br> registry.opensuse.org/opensuse/distrobox-bpftrace:latest |
 | Oracle Linux | 8 <br> 8-slim <br> 9 <br> 9-slim <br> 10 <br> 10-slim | container-registry.oracle.com/os/oraclelinux:8 <br> container-registry.oracle.com/os/oraclelinux:8-slim <br> container-registry.oracle.com/os/oraclelinux:9 <br> container-registry.oracle.com/os/oraclelinux:9-slim <br> container-registry.oracle.com/os/oraclelinux:10 <br> container-registry.oracle.com/os/oraclelinux:10-slim |
-| RedHat (UBI) | 7 <br> 8 <br> 9 | registry.access.redhat.com/ubi7/ubi <br> registry.access.redhat.com/ubi8/ubi <br> registry.access.redhat.com/ubi8/ubi-init <br> registry.access.redhat.com/ubi8/ubi-minimal <br> registry.access.redhat.com/ubi9/ubi <br> registry.access.redhat.com/ubi9/ubi-init <br> registry.access.redhat.com/ubi9/ubi-minimal |
-| Rocky Linux | 8 <br> 8-minimal <br> 9 | quay.io/rockylinux/rockylinux:8 <br> quay.io/rockylinux/rockylinux:8-minimal <br> quay.io/rockylinux/rockylinux:9 <br> quay.io/rockylinux/rockylinux:latest |
+| RedHat (UBI) | 8 <br> 9 <br> 10 | registry.access.redhat.com/ubi8/ubi <br> registry.access.redhat.com/ubi8/ubi-init <br> registry.access.redhat.com/ubi8/ubi-minimal <br> registry.access.redhat.com/ubi9/ubi <br> registry.access.redhat.com/ubi9/ubi-init <br> registry.access.redhat.com/ubi9/ubi-minimal <br> registry.access.redhat.com/ubi10/ubi <br> registry.access.redhat.com/ubi10/ubi-init <br> registry.access.redhat.com/ubi10/ubi-minimal |
+| Rocky Linux | 8 <br> 8-minimal <br> 9 <br> 10 | quay.io/rockylinux/rockylinux:8 <br> quay.io/rockylinux/rockylinux:8-minimal <br> quay.io/rockylinux/rockylinux:9 <br> quay.io/rockylinux/rockylinux:10 <br> quay.io/rockylinux/rockylinux:latest |
 | Slackware | | docker.io/vbatts/slackware:current |
 | SteamOS | | ghcr.io/linuxserver/steamos:latest |
 | Ubuntu | 14.04 <br> 16.04 <br> 18.04 <br> 20.04 <br> 22.04 <br> 24.04 <br> 26.04 | docker.io/library/ubuntu:14.04 <br> docker.io/library/ubuntu:16.04 <br> docker.io/library/ubuntu:18.04 <br> docker.io/library/ubuntu:20.04 <br> docker.io/library/ubuntu:22.04 <br> docker.io/library/ubuntu:24.04 <br> docker.io/library/ubuntu:26.04 |

--- a/hack/ci/commands.sh
+++ b/hack/ci/commands.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project:
+#    https://github.com/89luca89/distrobox
+#
+# Copyright (C) 2021 distrobox contributors
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+#
+# usage: commands.sh <image> <podman|docker>
+
+set -u
+
+IMAGE="${1:?usage: commands.sh <image> <podman|docker>}"
+MODE="${2:?backend required: podman|docker}"
+
+case "${MODE}" in
+	podman) CM=podman ;;
+	docker) CM=docker ;;
+	*)
+		printf 'unknown backend: %s (use podman|docker)\n' "${MODE}" >&2
+		exit 2
+		;;
+esac
+export DBX_CONTAINER_MANAGER="${CM}"
+DBX="${DBX:-distrobox}"
+
+dbx()
+{
+	"${DBX}" "$@"
+}
+engine()
+{
+	"${CM}" "$@"
+}
+
+fails=0
+pass()
+{
+	printf '  \033[1;32mPASS\033[0m %s\n' "${1}"
+}
+fail()
+{
+	printf '  \033[1;31mFAIL\033[0m %s\n' "${1}"
+	fails=$((fails + 1))
+	if [ -n "${2:-}" ]; then
+		printf '%s\n' "${2}" | tr '\r' '\n' | sed 's/^/      | /'
+	fi
+}
+ok()
+{
+	desc="${1}"
+	shift
+	if out="$("$@" < /dev/null 2>&1)"; then pass "${desc}"; else fail "${desc}" "${out}"; fi
+}
+count()
+{
+	engine ps -a -q 2> /dev/null | wc -l | tr -d ' '
+}
+warmup()
+{
+	dbx enter --name "${1}" -- true < /dev/null > /dev/null 2>&1 || true
+}
+eq()
+{
+	if [ "${2}" = "${3}" ]; then pass "${1}"; else fail "${1}" "got '${2}', want '${3}'"; fi
+}
+contains()
+{
+	if printf '%s' "${2}" | grep -qE "${3}"; then pass "${1}"; else fail "${1}" "want /${3}/ in: ${2}"; fi
+}
+enter_out()
+{
+	b="${1}"
+	shift
+	dbx enter --name "${b}" -- "$@" < /dev/null 2> /dev/null | tr -d '\r\000\n'
+}
+
+printf '\n== commands: image=%s backend=%s ==\n' "${IMAGE}" "${MODE}"
+engine pull "${IMAGE}" > /dev/null 2>&1 || true
+
+# Captured while pristine, to gate the destructive --all tests (which act on EVERY
+# distrobox) so a developer's own boxes are never touched. CI runners are clean.
+pre_boxes="$(dbx list 2> /dev/null | tail -n +2 | grep -c .)"
+
+# ---- ephemeral: a temporary box, auto-removed on exit ----
+before="$(count)"
+ok "ephemeral runs a command" dbx ephemeral --yes --image "${IMAGE}" -- true
+after="$(count)"
+if [ "${before}" = "${after}" ]; then
+	pass "ephemeral leaves no leftover container"
+else
+	fail "ephemeral leaves no leftover container" "before=${before} after=${after}"
+fi
+
+# ---- flag checks that spin no container (fast) ----
+ok "--version prints" dbx --version
+contains "create --compatibility lists images" "$(dbx create --compatibility < /dev/null 2>&1)" 'alpine|ubuntu|fedora|debian'
+contains "create --dry-run prints the engine command" "$(dbx create --dry-run --image "${IMAGE}" --name dbx-cmd-dry < /dev/null 2>&1)" "${CM}.*create"
+if dbx list 2> /dev/null | grep -q dbx-cmd-dry; then fail "create --dry-run creates nothing" "dbx-cmd-dry present"; else pass "create --dry-run creates nothing"; fi
+nc="$(dbx list --no-color < /dev/null 2>&1)"
+if printf '%s' "${nc}" | grep -q "$(printf '\033')"; then fail "list --no-color emits no ANSI" "escape found"; else pass "list --no-color emits no ANSI"; fi
+ok "ls alias resolves to list" dbx ls
+
+# ---- base box -> generate-entry + clone (guarded on create success) ----
+gbox="dbx-cmd-genentry"
+cbox="${gbox}-clone"
+if cout="$(dbx create --yes --no-entry --image "${IMAGE}" --name "${gbox}" < /dev/null 2>&1)"; then
+	pass "create (base box)"
+	# First enter triggers setup; sudo writes a marker into the container rootfs
+	# (not a host-shared path) so a clone must carry it.
+	dbx enter --name "${gbox}" -- sudo -n touch /dbx-clone-marker < /dev/null > /dev/null 2>&1 || true
+
+	desktop="${XDG_DATA_HOME:-${HOME}/.local/share}/applications/${gbox}.desktop"
+	geout="$(dbx generate-entry "${gbox}" < /dev/null 2>&1)"
+	if [ -f "${desktop}" ]; then pass "generate-entry writes a .desktop"; else fail "generate-entry writes a .desktop" "expected ${desktop}; generate-entry said: ${geout}"; fi
+	dbx generate-entry --delete "${gbox}" < /dev/null > /dev/null 2>&1 || true
+	if [ ! -f "${desktop}" ]; then pass "generate-entry --delete removes it"; else fail "generate-entry --delete removes it" "${desktop} still present"; fi
+
+	dbx stop --yes "${gbox}" < /dev/null > /dev/null 2>&1 || true
+	if clout="$(dbx create --yes --clone "${gbox}" --name "${cbox}" < /dev/null 2>&1)"; then
+		pass "clone a stopped box"
+		warmup "${cbox}"
+		marker="$(dbx enter --name "${cbox}" -- sh -c 'test -f /dbx-clone-marker && printf yes' < /dev/null 2>&1 | tr -d '\r\000\n')"
+		if [ "${marker}" = "yes" ]; then pass "clone carries the rootfs marker"; else fail "clone carries the rootfs marker" "marker /dbx-clone-marker missing; enter returned: '${marker}'"; fi
+	else
+		fail "clone a stopped box" "${clout}"
+		fail "clone carries the rootfs marker" "no clone created"
+	fi
+else
+	fail "create (base box)" "${cout}"
+fi
+
+# ---- create/enter flags + engine-level mechanics, on one box ----
+fbox="dbx-cmd-flags"
+vdir="$(mktemp -d)"
+: > "${vdir}/vfile"
+if fout="$(dbx create --yes --no-entry --image "${IMAGE}" --name "${fbox}" \
+	--hostname dbxflagshost \
+	--volume "${vdir}:/mnt/vol" \
+	--init-hooks 'touch /dbx-hook-ran' \
+	--additional-flags '--env CREATEVAR=cval' < /dev/null 2>&1)"; then
+	pass "create with a flag bundle"
+	warmup "${fbox}"
+	eq "--hostname sets the hostname" "$(enter_out "${fbox}" uname -n)" "dbxflagshost"
+	ok "--volume mounts a host dir" dbx enter --name "${fbox}" -- test -f /mnt/vol/vfile
+	ok "--init-hooks runs at setup" dbx enter --name "${fbox}" -- test -f /dbx-hook-ran
+	eq "create --additional-flags forwards --env" "$(enter_out "${fbox}" printenv CREATEVAR)" "cval"
+	eq "enter --additional-flags forwards --env" \
+		"$(dbx enter --name "${fbox}" --additional-flags '--env ENTERVAR=eval' -- printenv ENTERVAR < /dev/null 2> /dev/null | tr -d '\r\000\n')" "eval"
+	hm="${HOME}/.dbx-cmd-home-$$"
+	: > "${hm}"
+	ok 'host $HOME is shared into the box' dbx enter --name "${fbox}" -- test -f "${hm}"
+	rm -f "${hm}"
+	eq "host env var forwarded" \
+		"$(MY_DBX_VAR=fwd dbx enter --name "${fbox}" -- printenv MY_DBX_VAR < /dev/null 2> /dev/null | tr -d '\r\000\n')" "fwd"
+	badv="$(DBX_CMD_BAD='has$dollar' dbx enter --name "${fbox}" -- printenv DBX_CMD_BAD < /dev/null 2> /dev/null | tr -d '\r\000\n')"
+	if [ -z "${badv}" ]; then pass "env var with special chars is filtered"; else fail "env var with special chars is filtered" "leaked '${badv}'"; fi
+	pn="$(enter_out "${fbox}" printenv PATH)"
+	pc="$(dbx enter --name "${fbox}" --clean-path -- printenv PATH < /dev/null 2> /dev/null | tr -d '\r\000\n')"
+	if [ -n "${pc}" ] && [ "${pc}" != "${pn}" ] && printf '%s' ":${pc}:" | grep -q ':/usr/bin:'; then pass "enter --clean-path resets PATH to FHS"; else fail "enter --clean-path resets PATH to FHS" "normal='${pn}' clean='${pc}'"; fi
+	eq 'enter --no-workdir starts in $HOME' \
+		"$(dbx enter --name "${fbox}" --no-workdir -- pwd < /dev/null 2> /dev/null | tr -d '\r\000\n')" "${HOME}"
+	contains "enter --dry-run prints the engine command" "$(dbx enter --name "${fbox}" --dry-run -- true < /dev/null 2>&1)" "${CM}.*exec"
+else
+	fail "create with a flag bundle" "${fout}"
+fi
+dbx rm --force "${fbox}" < /dev/null > /dev/null 2>&1 || true
+rm -rf "${vdir}"
+
+# ---- --home (custom HOME) + rm --rm-home ----
+chome="$(mktemp -d)/box-home"
+if dbx create --yes --no-entry --image "${IMAGE}" --name dbx-cmd-home --home "${chome}" < /dev/null > /dev/null 2>&1; then
+	warmup dbx-cmd-home
+	eq "--home sets a custom HOME" "$(enter_out dbx-cmd-home printenv HOME)" "${chome}"
+	dbx rm --rm-home --force dbx-cmd-home < /dev/null > /dev/null 2>&1 || true
+	if [ -d "${chome}" ]; then fail "rm --rm-home removes the custom home" "${chome} still present"; else pass "rm --rm-home removes the custom home"; fi
+else
+	fail "--home sets a custom HOME" "create --home failed"
+	fail "rm --rm-home removes the custom home" "no box created"
+fi
+rm -rf "${chome%/*}"
+
+# ---- assemble: create/rm boxes from a manifest ----
+mani="$(mktemp)"
+printf '[dbx-cmd-assemble]\nimage=%s\n' "${IMAGE}" > "${mani}"
+ok "assemble create" dbx assemble create --file "${mani}"
+if dbx list | grep -q dbx-cmd-assemble; then pass "assemble created the box"; else fail "assemble created the box" "dbx-cmd-assemble not in distrobox list"; fi
+ok "assemble rm" dbx assemble rm --file "${mani}"
+if dbx list | grep -q dbx-cmd-assemble; then fail "assemble rm removed the box" "dbx-cmd-assemble still in distrobox list"; else pass "assemble rm removed the box"; fi
+rm -f "${mani}"
+
+# ---- assemble: --dry-run, --name (single entry), --replace ----
+mani2="$(mktemp)"
+printf '[dbx-cmd-asm1]\nimage=%s\n\n[dbx-cmd-asm2]\nimage=%s\n' "${IMAGE}" "${IMAGE}" > "${mani2}"
+if dbx assemble create --file "${mani2}" --dry-run < /dev/null > /dev/null 2>&1 && ! dbx list 2> /dev/null | grep -q dbx-cmd-asm; then pass "assemble --dry-run creates nothing"; else fail "assemble --dry-run creates nothing" "$(dbx list 2> /dev/null | grep dbx-cmd-asm || true)"; fi
+ok "assemble create --name (single entry)" dbx assemble create --file "${mani2}" --name dbx-cmd-asm1
+if dbx list 2> /dev/null | grep -q dbx-cmd-asm1 && ! dbx list 2> /dev/null | grep -q dbx-cmd-asm2; then pass "assemble --name builds only the named entry"; else fail "assemble --name builds only the named entry" "$(dbx list 2> /dev/null | grep dbx-cmd-asm || true)"; fi
+ok "assemble create --replace" dbx assemble create --file "${mani2}" --name dbx-cmd-asm1 --replace
+dbx assemble rm --file "${mani2}" < /dev/null > /dev/null 2>&1 || true
+rm -f "${mani2}"
+
+# ---- multi-box --all flags (act on EVERY distrobox; guarded for safety) ----
+# Runs only from a clean start so a dev's own boxes are never touched (CI is clean).
+if [ "${pre_boxes}" = "0" ]; then
+	dbx create --yes --no-entry --image "${IMAGE}" --name dbx-cmd-all1 < /dev/null > /dev/null 2>&1 || true
+	dbx create --yes --no-entry --image "${IMAGE}" --name dbx-cmd-all2 < /dev/null > /dev/null 2>&1 || true
+	warmup dbx-cmd-all1
+	warmup dbx-cmd-all2
+	appdir="${XDG_DATA_HOME:-${HOME}/.local/share}/applications"
+	icon="${HOME}/.dbx-cmd-icon.png"
+	: > "${icon}"
+	dbx generate-entry --all < /dev/null > /dev/null 2>&1 || true
+	if [ -f "${appdir}/dbx-cmd-all1.desktop" ] && [ -f "${appdir}/dbx-cmd-all2.desktop" ]; then pass "generate-entry --all covers every box"; else fail "generate-entry --all covers every box" "missing .desktop in ${appdir}"; fi
+	dbx generate-entry dbx-cmd-all1 --icon "${icon}" < /dev/null > /dev/null 2>&1 || true
+	contains "generate-entry --icon sets a custom icon" "$(cat "${appdir}/dbx-cmd-all1.desktop" 2> /dev/null)" "Icon=${icon}"
+	dbx generate-entry --all --delete < /dev/null > /dev/null 2>&1 || true
+	rm -f "${icon}"
+	ok "stop --all stops every box" dbx stop --all --yes
+	ok "upgrade --all upgrades every box" dbx upgrade --all
+	dbx rm --all --force < /dev/null > /dev/null 2>&1 || true
+	if [ "$(dbx list 2> /dev/null | tail -n +2 | grep -c .)" = "0" ]; then pass "rm --all removes every box"; else fail "rm --all removes every box" "boxes remain"; fi
+else
+	printf '  \033[1;33mSKIP\033[0m --all flag tests (%s pre-existing distrobox(es); would be destructive)\n' "${pre_boxes}"
+fi
+
+# ---- cleanup ----
+dbx rm --force "${gbox}" "${cbox}" "${fbox}" < /dev/null > /dev/null 2>&1 || true
+if [ -z "${DBX_E2E_KEEP_IMAGE:-}" ]; then
+	engine rmi -f "${IMAGE}" > /dev/null 2>&1 || true
+fi
+
+printf '== commands result: %d failed ==\n' "${fails}"
+[ "${fails}" -eq 0 ]

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# This file is part of the distrobox project:
+#    https://github.com/89luca89/distrobox
+#
+# Copyright (C) 2021 distrobox contributors
+#
+# distrobox is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# distrobox is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+#
+# usage: e2e.sh <image> <podman|docker>
+
+set -u
+
+IMAGE="${1:?usage: e2e.sh <image> <podman|docker>}"
+MODE="${2:?backend required: podman|docker}"
+
+case "${MODE}" in
+	podman) CM=podman ;;
+	docker) CM=docker ;;
+	*)
+		printf 'unknown backend: %s (use podman|docker)\n' "${MODE}" >&2
+		exit 2
+		;;
+esac
+export DBX_CONTAINER_MANAGER="${CM}"
+DBX="${DBX:-distrobox}"
+
+dbx()
+{
+	"${DBX}" "$@"
+}
+engine()
+{
+	"${CM}" "$@"
+}
+
+name="$(basename "${IMAGE}" | sed -E 's/[:.]/-/g')"
+fails=0
+
+pass()
+{
+	printf '  \033[1;32mPASS\033[0m %s\n' "${1}"
+}
+fail()
+{
+	printf '  \033[1;31mFAIL\033[0m %s\n' "${1}"
+	fails=$((fails + 1))
+	if [ -n "${2:-}" ]; then
+		# \r -> \n so distrobox progress output (carriage returns) is readable
+		# line-by-line instead of one smeared line.
+		printf '%s\n' "${2}" | tr '\r' '\n' | sed 's/^/      | /'
+	fi
+}
+eq()
+{
+	if [ "${2}" = "${3}" ]; then pass "${1}"; else fail "${1}" "got '${2}', want '${3}'"; fi
+}
+ok()
+{
+	desc="${1}"
+	shift
+	if out="$("$@" < /dev/null 2>&1)"; then
+		pass "${desc}"
+	else
+		fail "${desc}" "${out}"
+	fi
+}
+enter_out()
+{
+	dbx enter --name "${name}" -- "$@" < /dev/null 2> /dev/null | tr -d '\r\000\n'
+}
+
+# dump the box's logs (distrobox-init setup output). Only meaningful when the
+# container itself won't come up, so it's called only on create/restart failure.
+dump_logs()
+{
+	printf '  --- %s logs for %s (tail) ---\n' "${MODE}" "${name}"
+	engine logs "${name}" 2>&1 | tail -40 | sed 's/^/      | /' || true
+}
+
+printf '\n== e2e: image=%s backend=%s name=%s ==\n' "${IMAGE}" "${MODE}" "${name}"
+
+case "${name}" in
+	*init*) create_flags="--pull --yes --image ${IMAGE} --name ${name} --init --unshare-all" ;;
+	*) create_flags="--pull --yes --image ${IMAGE} --name ${name} --additional-packages nano" ;;
+esac
+# shellcheck disable=SC2086 # create_flags is intentionally word-split
+if create_out="$(dbx create ${create_flags} < /dev/null 2>&1)"; then
+	pass "create"
+else
+	fail "create" "${create_out}"
+	dump_logs
+	printf '== result: %d failed ==\n' "${fails}"
+	exit 1
+fi
+
+# Warm up: the first enter STARTS the container, and `podman start` echoes the
+# box name to stdout (plus first-boot setup streams). Do it once, discarded, so
+# the checks below capture only their own command's output.
+ok "enter" dbx enter --name "${name}" -- true
+
+# --- systemd boots for --init images ---
+case "${name}" in
+	*init*)
+		sysstate="$(enter_out systemctl is-system-running)"
+		case "${sysstate}" in
+			running | degraded | starting) pass "systemd is running (--init): ${sysstate}" ;;
+			*) fail "systemd is running (--init)" "got '${sysstate}'" ;;
+		esac
+		;;
+	*) ;;
+esac
+
+# --- core promises (hard) ---
+eq "enter runs as the host user" "$(enter_out whoami)" "$(whoami)"
+sudo_out="$(enter_out sudo -n whoami)"
+case "${sudo_out}" in
+	*root*) pass "passwordless sudo inside the box" ;;
+	*) fail "passwordless sudo inside the box" "want 'root' in output, got '${sudo_out}'" ;;
+esac
+
+# --- additional-packages: nano (plain images only; init skips it, see create) ---
+case "${name}" in
+	*init*) ;;
+	*) ok "additional-packages installed nano" dbx enter --name "${name}" -- sh -c 'command -v nano' ;;
+esac
+
+# --- lifecycle (hard) ---
+ok "upgrade" dbx upgrade "${name}"
+ok "stop" dbx stop --yes "${name}"
+# restart: entering a stopped box must bring it back up. timeout(1) guards a
+# stuck setup, but it needs a real executable (dbx is a shell function), so call
+# the binary directly.
+restart_out="$(timeout 180 "${DBX}" enter --name "${name}" -- true < /dev/null 2>&1)"
+rc=$?
+if [ "${rc}" -eq 0 ]; then
+	pass "enter restarts a stopped box"
+else
+	fail "enter restarts a stopped box" "${restart_out}"
+	dump_logs
+fi
+
+ok "rm" dbx rm --force "${name}"
+if [ -z "${DBX_E2E_KEEP_IMAGE:-}" ]; then
+	engine rmi -f "${IMAGE}" > /dev/null 2>&1 || true
+fi
+
+printf '== result: %d failed ==\n' "${fails}"
+[ "${fails}" -eq 0 ]

--- a/pkg/commands/create_internal_test.go
+++ b/pkg/commands/create_internal_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// This file is part of the distrobox project:
+//    https://github.com/89luca89/distrobox
+//
+// Copyright (C) 2021 distrobox contributors
+//
+// distrobox is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 3
+// as published by the Free Software Foundation.
+//
+// distrobox is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/89luca89/distrobox/pkg/config"
+)
+
+// TestCreateCommand_makeContainerName_Slug pins the image->name slug logic with
+// the exact examples from create.go's doc comment.
+//
+// It also documents a doc/code mismatch: the comment claims
+// "ubuntu:20.04 -> ubuntu-20.04", but the code also does ReplaceAll(".", "-"),
+// so the real output is "ubuntu-20-04". This asserts the ACTUAL behavior; see
+// plans/tests/tests-to-adopt.md §2 — reconcile the doc against the code (or vice
+// versa) and update this case with the decision.
+func TestCreateCommand_makeContainerName_Slug(t *testing.T) {
+	c := &CreateCommand{cfg: &config.Values{
+		DefaultContainerImage: "registry.fedoraproject.org/fedora-toolbox:latest",
+		DefaultContainerName:  "my-distrobox",
+	}}
+
+	for _, tc := range []struct {
+		image string
+		want  string
+	}{
+		{"alpine", "alpine"},
+		{"registry.fedoraproject.org/fedora-toolbox:39", "fedora-toolbox-39"},
+		{"ghcr.io/void-linux/void-linux:latest-full-x86_64", "void-linux-latest-full-x86_64"},
+		{"ubuntu:20.04", "ubuntu-20-04"}, // actual behavior; doc says "ubuntu-20.04"
+	} {
+		assert.Equal(t, tc.want, c.makeContainerName(&CreateOptions{}, tc.image), tc.image)
+	}
+}

--- a/pkg/containermanager/helpers_test.go
+++ b/pkg/containermanager/helpers_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// This file is part of the distrobox project:
+//    https://github.com/89luca89/distrobox
+//
+// Copyright (C) 2021 distrobox contributors
+//
+// distrobox is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 3
+// as published by the Free Software Foundation.
+//
+// distrobox is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
+package containermanager_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/89luca89/distrobox/pkg/containermanager"
+)
+
+// TestPathExistsAndIsSymlink covers the symlink edge cases that drive mount
+// decisions in makeCreateCommand (e.g. the /dev/shm symlink branch, selinux,
+// /var/home). PathExists uses Stat (follows links); IsSymlink uses Lstat.
+func TestPathExistsAndIsSymlink(t *testing.T) {
+	assert.False(t, containermanager.PathExists("/does/not/exist"))
+
+	dir := t.TempDir()
+	assert.True(t, containermanager.PathExists(dir))
+	assert.False(t, containermanager.IsSymlink(dir))
+
+	// Broken symlink: Stat fails (false), Lstat sees the link (true).
+	broken := filepath.Join(dir, "broken")
+	require.NoError(t, os.Symlink("/nope/nope", broken))
+	assert.False(t, containermanager.PathExists(broken))
+	assert.True(t, containermanager.IsSymlink(broken))
+
+	// Symlink to an existing target: both true.
+	good := filepath.Join(dir, "good")
+	require.NoError(t, os.Symlink(dir, good))
+	assert.True(t, containermanager.PathExists(good))
+	assert.True(t, containermanager.IsSymlink(good))
+}
+
+// TestFilterEnvVars pins the enter env allow/deny logic: excluded prefixes, the
+// XDG_*_DIRS pattern, and values containing shell-special characters are dropped.
+func TestFilterEnvVars(t *testing.T) {
+	for _, k := range []string{"HOME", "PATH", "SHELL", "HOSTNAME", "XDG_SEAT", "XDG_CONFIG_DIRS", "_UNDERSCORE"} {
+		t.Setenv(k, "x")
+	}
+	t.Setenv("DBX_TEST_KEEP", "keep")
+	t.Setenv("DBX_TEST_BAD", "has$dollar") // '$' -> excluded
+
+	has := func(prefix string) bool {
+		for _, e := range containermanager.FilterEnvVars() {
+			if strings.HasPrefix(e, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, has("DBX_TEST_KEEP="))
+	for _, dropped := range []string{
+		"HOME=", "PATH=", "SHELL=", "HOSTNAME=", "XDG_SEAT=", "XDG_CONFIG_DIRS=", "_UNDERSCORE=", "DBX_TEST_BAD=",
+	} {
+		assert.False(t, has(dropped), dropped)
+	}
+}
+
+// TestGetWorkDir covers the /run/host prefixing and the noWorkDir branch.
+func TestGetWorkDir(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	got, err := containermanager.GetWorkDir("/home/tester", true) // noWorkDir -> container home
+	require.NoError(t, err)
+	assert.Equal(t, "/home/tester", got)
+
+	got, err = containermanager.GetWorkDir(wd, false) // cwd under home -> as-is
+	require.NoError(t, err)
+	assert.Equal(t, wd, got)
+
+	got, err = containermanager.GetWorkDir("/definitely/not/a/prefix/xyzzy", false) // outside -> /run/host
+	require.NoError(t, err)
+	assert.Equal(t, "/run/host"+wd, got)
+}
+
+// TestBuildXDGPaths covers dedup + append of standard paths onto the env value.
+func TestBuildXDGPaths(t *testing.T) {
+	t.Setenv("DBX_TEST_XDG", "/a:/b")
+	assert.Equal(t, "/a:/b:/c", containermanager.BuildXDGPaths("DBX_TEST_XDG", []string{"/b", "/c"}))
+
+	assert.Equal(t, "/usr/local/share:/usr/share",
+		containermanager.BuildXDGPaths("DBX_TEST_XDG_UNSET_UNIQUE_9421", []string{"/usr/local/share", "/usr/share"}))
+}

--- a/pkg/containermanager/providers/parsing_extra_internal_test.go
+++ b/pkg/containermanager/providers/parsing_extra_internal_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// This file is part of the distrobox project:
+//    https://github.com/89luca89/distrobox
+//
+// Copyright (C) 2021 distrobox contributors
+//
+// distrobox is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 3
+// as published by the Free Software Foundation.
+//
+// distrobox is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with distrobox; if not, see <http://www.gnu.org/licenses/>.
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParsePodmanContainerList_Fixtures asserts the podman `ps --format json`
+// parser against a captured fixture, so a podman JSON change is caught here
+// rather than in the field. Refresh testdata/podman-ps.json from a real
+// `podman ps -a --no-trunc --format json` (scrubbed) when adding new versions.
+func TestParsePodmanContainerList_Fixtures(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "podman-ps.json"))
+	require.NoError(t, err)
+
+	got, err := parsePodmanContainerList(string(raw))
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "fedora-box", got[0].Name)
+	assert.Equal(t, "abc123def456", got[0].ID) // truncated to 12 chars
+	assert.Equal(t, "distrobox", got[0].Labels["manager"])
+	assert.Equal(t, "0", got[0].Labels["distrobox.unshare_groups"])
+	assert.Equal(t, "ubuntu-box", got[1].Name)
+}
+
+// TestParseContainerList_DockerFixtures asserts the docker `ps --format '{{json .}}'`
+// (JSONL) parser, including the comma-joined Labels string -> map conversion.
+func TestParseContainerList_DockerFixtures(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "docker-ps.json"))
+	require.NoError(t, err)
+
+	got, err := parseContainerList(string(raw))
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "fedora-box", got[0].Name)
+	assert.Equal(t, "abc123def456", got[0].ID)
+	assert.Equal(t, "distrobox", got[0].Labels["manager"])
+	assert.Equal(t, "0", got[0].Labels["distrobox.unshare_groups"])
+	assert.Equal(t, "ubuntu-box", got[1].Name)
+}
+
+// TestParseLabels pins the docker label-string parser, including the known
+// limitation that a label value containing a comma is mis-split.
+func TestParseLabels(t *testing.T) {
+	got := parseLabels("manager=distrobox,distrobox.unshare_groups=0")
+	assert.Equal(t, "distrobox", got["manager"])
+	assert.Equal(t, "0", got["distrobox.unshare_groups"])
+
+	assert.Empty(t, parseLabels(""))
+
+	got = parseLabels("k=a,b") // value with a comma -> the ",b" tail is dropped
+	assert.Equal(t, "a", got["k"])
+	_, hasB := got["b"]
+	assert.False(t, hasB)
+}

--- a/pkg/containermanager/providers/testdata/docker-ps.json
+++ b/pkg/containermanager/providers/testdata/docker-ps.json
@@ -1,0 +1,2 @@
+{"Command":"sleep infinity","CreatedAt":"2 hours ago","ID":"abc123def456000000000000000000000000000000000000000000000000abcd","Image":"fedora-toolbox:39","Labels":"manager=distrobox,distrobox.unshare_groups=0","Names":"fedora-box","State":"running","Status":"Up 2 hours"}
+{"Command":"/bin/bash","CreatedAt":"3 hours ago","ID":"def456abc123000000000000000000000000000000000000000000000000ef01","Image":"ubuntu:22.04","Labels":"manager=distrobox","Names":"ubuntu-box","State":"exited","Status":"Exited (0) 1 hour ago"}

--- a/pkg/containermanager/providers/testdata/podman-ps.json
+++ b/pkg/containermanager/providers/testdata/podman-ps.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Command": ["sleep", "infinity"],
+    "CreatedAt": "2 hours ago",
+    "ID": "abc123def456000000000000000000000000000000000000000000000000abcd",
+    "Image": "registry.fedoraproject.org/fedora-toolbox:39",
+    "Labels": {"manager": "distrobox", "distrobox.unshare_groups": "0"},
+    "Names": ["fedora-box"],
+    "State": "running",
+    "Status": "Up 2 hours"
+  },
+  {
+    "Command": ["/bin/bash"],
+    "CreatedAt": "3 hours ago",
+    "ID": "def456abc123000000000000000000000000000000000000000000000000ef01",
+    "Image": "docker.io/library/ubuntu:22.04",
+    "Labels": {"manager": "distrobox"},
+    "Names": ["ubuntu-box"],
+    "State": "exited",
+    "Status": "Exited (0) 1 hour ago"
+  }
+]


### PR DESCRIPTION
Builds on the existing compatibility CI. The per-distro e2e suite now also runs
as a fast image subset that gates every PR, alongside a new distro-agnostic
CLI/flag suite so the v2 binary is proven on each supported distro and on both
podman and docker before merge, not only in the post-merge full matrix. The gate
and the full matrix now share one reusable workflow, and image lists live only in
the Makefile, so `make e2e-one IMAGE=… CM=…` reproduces any CI cell locally.

Contextually added some fixtures tests for the behavior of slug generation, env-var filtering, and the
ps parser so refactors can't silently change them