### PR TITLE
fix(enter): use a real isatty check for --tty allocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.10.1 h1:7Kx9H50hrHbRbyxgO1KP6/BcbiGRz0uYh5YyQ30JEEY=
 github.com/urfave/cli/v3 v3.10.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"os"
 
+	"golang.org/x/term"
+
 	"github.com/urfave/cli/v3"
 
 	"github.com/89luca89/distrobox/pkg/commands"
@@ -90,7 +92,9 @@ func printResult(result *commands.ListResult, noColor bool) {
 	}
 }
 
+// isTerminal reports whether stdout is a real terminal. A char-device test
+// would treat /dev/null (or any redirect) as a terminal and emit color
+// codes into pipes/files.
 func isTerminal() bool {
-	stat, _ := os.Stdout.Stat()
-	return (stat.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }

--- a/pkg/containermanager/containermanager.go
+++ b/pkg/containermanager/containermanager.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/term"
+
 	"github.com/89luca89/distrobox/pkg/ui"
 )
 
@@ -401,14 +403,13 @@ func FilterEnvVars() []string {
 
 // IsTTY returns true if both stdin and stdout are terminals.
 // Mirrors the shell's: if [ ! -t 0 ] || [ ! -t 1 ]; then headless=1; fi
+//
+// A real isatty check is required: a char-device test would treat
+// /dev/null as a terminal, making a headless `distrobox enter ...
+// > /dev/null 2>&1` allocate a --tty and fail on engines that refuse
+// to attach a non-terminal stdin to a tty (e.g. docker exec).
 func IsTTY() bool {
-	if fi, err := os.Stdin.Stat(); err != nil || fi.Mode()&os.ModeCharDevice == 0 {
-		return false
-	}
-	if fi, err := os.Stdout.Stat(); err != nil || fi.Mode()&os.ModeCharDevice == 0 {
-		return false
-	}
-	return true
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func GetWorkDir(containerHome string, noWorkDir bool) (string, error) {

--- a/pkg/containermanager/containermanager_test.go
+++ b/pkg/containermanager/containermanager_test.go
@@ -20,6 +20,7 @@
 package containermanager_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,31 @@ func TestContainer_IsDistrobox_DistroboxKeyPrefix(t *testing.T) {
 		},
 	}
 	assert.True(t, c.IsDistrobox())
+}
+
+// TestIsTTY_DevNullNotATerminal guards against the char-device heuristic:
+// /dev/null is a character device but NOT a terminal, and treating it as one
+// made headless invocations (`enter ... > /dev/null 2>&1`) allocate a --tty
+// that docker exec rejects with "cannot attach stdin to a TTY-enabled
+// container because stdin is not a terminal".
+func TestIsTTY_DevNullNotATerminal(t *testing.T) {
+	// Swap both stdio fds to /dev/null for the duration of the test.
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	origStdin := os.Stdin
+	origStdout := os.Stdout
+	defer func() {
+		os.Stdin = origStdin
+		os.Stdout = origStdout
+	}()
+
+	os.Stdin = devNull
+	os.Stdout = devNull
+
+	assert.False(t, containermanager.IsTTY(),
+		"stdin/stdout pointing at /dev/null must not be considered a tty")
 }

--- a/pkg/containermanager/containermanager_test.go
+++ b/pkg/containermanager/containermanager_test.go
@@ -21,9 +21,11 @@ package containermanager_test
 
 import (
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/89luca89/distrobox/pkg/containermanager"
 )
@@ -115,23 +117,29 @@ func TestContainer_IsDistrobox_DistroboxKeyPrefix(t *testing.T) {
 // made headless invocations (`enter ... > /dev/null 2>&1`) allocate a --tty
 // that docker exec rejects with "cannot attach stdin to a TTY-enabled
 // container because stdin is not a terminal".
+//
+// os.Stdin/os.Stdout are never reassigned (go-reassign forbids it): the
+// process' real fd 0/1 are dup2'd to /dev/null, which is what IsTTY()
+// ioctls through os.Stdin.Fd()/os.Stdout.Fd().
 func TestIsTTY_DevNullNotATerminal(t *testing.T) {
-	// Swap both stdio fds to /dev/null for the duration of the test.
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
-	if err != nil {
-		t.Fatalf("open %s: %v", os.DevNull, err)
-	}
+	require.NoError(t, err, "open %s", os.DevNull)
 	defer devNull.Close()
 
-	origStdin := os.Stdin
-	origStdout := os.Stdout
+	// Keep the real fds around so we can restore them on the way out.
+	savedStdin, err := syscall.Dup(syscall.Stdin)
+	require.NoError(t, err, "dup stdin")
+	savedStdout, err := syscall.Dup(syscall.Stdout)
+	require.NoError(t, err, "dup stdout")
 	defer func() {
-		os.Stdin = origStdin
-		os.Stdout = origStdout
+		_ = syscall.Dup2(savedStdin, syscall.Stdin)
+		_ = syscall.Dup2(savedStdout, syscall.Stdout)
+		_ = syscall.Close(savedStdin)
+		_ = syscall.Close(savedStdout)
 	}()
 
-	os.Stdin = devNull
-	os.Stdout = devNull
+	require.NoError(t, syscall.Dup2(int(devNull.Fd()), syscall.Stdin), "dup2 stdin")
+	require.NoError(t, syscall.Dup2(int(devNull.Fd()), syscall.Stdout), "dup2 stdout")
 
 	assert.False(t, containermanager.IsTTY(),
 		"stdin/stdout pointing at /dev/null must not be considered a tty")


### PR DESCRIPTION
`containermanager.IsTTY()` detected a "terminal" by checking for a character device (`os.ModeCharDevice`). `/dev/null` is a character device, so headless invocations (`distrobox enter ... < /dev/null > /dev/null 2>&1`) were treated as interactive, allocating `docker exec --tty`.

Docker rejects that with "cannot attach stdin to a TTY-enabled container because stdin is not a terminal", so the exec failed before running the command, e.g. `sudo -n touch` in the e2e clone test never ran and the clone lost its rootfs marker. Podman tolerated the flag, hiding the bug.