### PR TITLE
fix(init): use UID for systemd user units

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -3008,8 +3008,8 @@ if [ -e /usr/lib/systemd/systemd ] || [ -e /lib/systemd/systemd ]; then
 	    systemctl is-system-running | grep -E 'running|degraded' && break; \
 		echo 'waiting for systemd to come up...\n' && sleep 1 && timeout=\$(( timeout -1 )); \
 	done && \
-	systemctl start user@${container_user_name}.service && \
-	systemctl start user-integration@${container_user_name}.service && \
+	systemctl start user@${container_user_uid}.service && \
+	systemctl start user-integration@${container_user_uid}.service && \
 	loginctl enable-linger ${container_user_name} || : && \
 	echo container_setup_done" &
 

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -66,6 +66,13 @@ func TestProvisionScripts_CustomDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tmpDir, dir)
 	assertAllScripts(t, dir)
+
+	initScript, err := os.ReadFile(filepath.Join(dir, "distrobox-init"))
+	require.NoError(t, err)
+	assert.Contains(t, string(initScript), "systemctl start user@${container_user_uid}.service")
+	assert.Contains(t, string(initScript), "systemctl start user-integration@${container_user_uid}.service")
+	assert.NotContains(t, string(initScript), "systemctl start user@${container_user_name}.service")
+	assert.NotContains(t, string(initScript), "systemctl start user-integration@${container_user_name}.service")
 }
 
 // TestProvisionScripts_DetectOnPath confirms the skip-write shortcut via


### PR DESCRIPTION
Starting `user@<name>.service` and then enabling linger can start both
`user@<name>.service` and `user@<uid>.service` for the same account.

Both managers use `/run/user/<uid>`. This wastes memory and can make user
generators fail with `File exists`.

Use the numeric UID for `user@` and `user-integration@`.

Tests:

- `go test ./...`
- `go vet ./...`
- `make build`
- ShellCheck on `distrobox-init`
