### PR TITLE
Fix duplicate systemd user managers

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -3008,9 +3008,9 @@ if [ -e /usr/lib/systemd/systemd ] || [ -e /lib/systemd/systemd ]; then
 	    systemctl is-system-running | grep -E 'running|degraded' && break; \
 		echo 'waiting for systemd to come up...\n' && sleep 1 && timeout=\$(( timeout -1 )); \
 	done && \
-	systemctl start user@${container_user_name}.service && \
-	systemctl start user-integration@${container_user_name}.service && \
-	loginctl enable-linger ${container_user_name} || : && \
+	systemctl start user@${container_user_uid}.service && \
+	systemctl start user-integration@${container_user_uid}.service && \
+	loginctl enable-linger ${container_user_uid} || : && \
 	echo container_setup_done" &
 
 	[ -e /usr/lib/systemd/systemd ] && exec /usr/lib/systemd/systemd --system --log-target=console --unit=multi-user.target

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -68,6 +68,24 @@ func TestProvisionScripts_CustomDir(t *testing.T) {
 	assertAllScripts(t, dir)
 }
 
+func TestInitScript_UsesUIDForSystemdUserManager(t *testing.T) {
+	tmpDir := t.TempDir()
+	isolatePath(t)
+
+	_, err := insidedistrobox.ProvisionScripts(tmpDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "distrobox-init"))
+	require.NoError(t, err)
+	initScript := string(data)
+	assert.Contains(t, initScript, "systemctl start user@${container_user_uid}.service")
+	assert.Contains(t, initScript, "systemctl start user-integration@${container_user_uid}.service")
+	assert.Contains(t, initScript, "loginctl enable-linger ${container_user_uid}")
+	assert.NotContains(t, initScript, "user@${container_user_name}.service")
+	assert.NotContains(t, initScript, "user-integration@${container_user_name}.service")
+	assert.NotContains(t, initScript, "loginctl enable-linger ${container_user_name}")
+}
+
 // TestProvisionScripts_DetectOnPath confirms the skip-write shortcut via
 // the PATH branch of exists(): when the helper scripts already exist
 // somewhere on PATH, ProvisionScripts leaves them byte-for-byte


### PR DESCRIPTION
In initful containers, Distrobox starts `user@<name>.service` and then enables linger for the same user. systemd-logind starts `user@<uid>.service`, so both managers can run for one UID.

Use the numeric UID for the user manager, runtime integration, and linger setup.

This avoids duplicate user managers and conflicting user generator warnings.

Tests:

- `make test`
- ShellCheck on `distrobox-init`
