### PR TITLE
fix(export): protect existing host binaries

### DIFF
--- a/docs/usage/distrobox-export.md
+++ b/docs/usage/distrobox-export.md
@@ -23,6 +23,7 @@ automatically be launched from the container it is exported from.
 	--list-apps:		list applications exported from this container
 	--list-binaries		list binaries exported from this container, use -ep to specify custom paths to search
 	--delete/-d:		delete exported application or binary
+	--force/-f:		overwrite an existing non-distrobox binary export
 	--export-label/-el:	label to add to exported application name.
 				Use "none" to disable.
 				Defaults to (on \$container_name)
@@ -40,7 +41,7 @@ Using `distrobox-export` from **inside** the container will let you use them fro
 # EXAMPLES
 
 	distrobox-export --app mpv [--extra-flags "flags"] [--delete] [--sudo]
-	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--delete] [--sudo]
+	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--delete] [--force] [--sudo]
 
 **App export example**
 
@@ -66,6 +67,9 @@ your `env` or project.
 
 The exported binaries will be exported in the "--export-path" of choice as a wrapper
 script that acts naturally both on the host and in the container.
+
+When the destination already exists, binary export refuses to replace a file that was not
+created by distrobox. Use `--force` when intentionally replacing such a file.
 
 **Additional flags**
 

--- a/internal/inside-distrobox/assets/distrobox-export
+++ b/internal/inside-distrobox/assets/distrobox-export
@@ -38,6 +38,7 @@ exported_app=""
 exported_app_label=""
 exported_bin=""
 exported_delete=0
+force=0
 extra_flags=""
 enter_flags=""
 # Use DBX_HOST_HOME if defined, else fallback to HOME
@@ -87,7 +88,7 @@ distrobox version: ${version}
 Usage:
 
 	distrobox-export --app mpv [--extra-flags "flags"] [--enter-flags "flags"] [--delete] [--sudo]
-	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--enter-flags "flags"] [--delete] [--sudo]
+	distrobox-export --bin /path/to/bin [--export-path ~/.local/bin] [--extra-flags "flags"] [--enter-flags "flags"] [--delete] [--force] [--sudo]
 
 Options:
 
@@ -96,6 +97,7 @@ Options:
 	--list-apps:		list applications exported from this container
 	--list-binaries:	list binaries exported from this container, use -ep to specify custom paths to search
 	--delete/-d:		delete exported application or binary
+	--force/-f:		overwrite an existing non-distrobox binary export
 	--export-label/-el:	label to add to exported application name.
 				Use "none" to disable.
 				Defaults to (on \$container_name)
@@ -185,6 +187,10 @@ while :; do
 			;;
 		-d | --delete)
 			exported_delete=1
+			shift
+			;;
+		-f | --force)
+			force=1
 			shift
 			;;
 		-*) # Invalid options.
@@ -351,6 +357,7 @@ EOF
 #   dest_path: string path where to export the binary
 #   exported_bin: string path to the binary to export
 #   exported_delete: bool delete the binary exported
+#   force: bool overwrite an existing non-distrobox binary export
 # Expected env variables:
 #   None
 # Outputs:
@@ -382,6 +389,12 @@ export_binary()
 				"${exported_bin}" "${container_name}" "${dest_path}"
 			return 0
 		fi
+		return 1
+	fi
+
+	# Never overwrite a file that was not created by distrobox.
+	if [ -e "${dest_file}" ] && [ "${force}" -eq 0 ] && ! grep -q "^# distrobox_binary$" "${dest_file}"; then
+		printf >&2 "Error: destination file %s already exists and is not a distrobox export; use --force to overwrite it.\n" "${dest_file}"
 		return 1
 	fi
 

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -21,6 +21,7 @@ package insidedistrobox_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -90,6 +91,77 @@ func TestProvisionScripts_DetectOnPath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, marker, string(got), "%s was overwritten despite existing on PATH", name)
 	}
+}
+
+// TestExportBinaryProtectsExistingFiles runs the POSIX distrobox-export script
+// through dash to ensure an existing host file is never replaced unless it is
+// an export created by distrobox itself.
+func TestExportBinaryProtectsExistingFiles(t *testing.T) {
+	dashPath, err := exec.LookPath("dash")
+	require.NoError(t, err)
+
+	originalPath := os.Getenv("PATH")
+	isolatePath(t)
+	scriptsDir := t.TempDir()
+	_, err = insidedistrobox.ProvisionScripts(scriptsDir)
+	require.NoError(t, err)
+	t.Setenv("PATH", originalPath)
+
+	tmpDir := t.TempDir()
+	guestBin := filepath.Join(tmpDir, "guest", "demo-tool")
+	existingPath := filepath.Join(tmpDir, "existing")
+	wrapperPath := filepath.Join(tmpDir, "wrapper")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guestBin), 0755))
+	require.NoError(t, os.WriteFile(guestBin, []byte("#!/bin/sh\necho guest binary\n"), 0755))
+	require.NoError(t, os.MkdirAll(existingPath, 0755))
+	existingFile := filepath.Join(existingPath, "demo-tool")
+	original := []byte("#!/bin/sh\necho host original\n")
+	require.NoError(t, os.WriteFile(existingFile, original, 0755))
+
+	t.Setenv("CONTAINER_ID", "first")
+	t.Setenv("container", "1")
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("DISTROBOX_HOST_HOME", tmpDir)
+	t.Setenv("DISTROBOX_PATH", "distrobox")
+
+	runExport := func(containerName, exportPath string, force bool) ([]byte, error) {
+		t.Setenv("CONTAINER_ID", containerName)
+		t.Setenv("DISTROBOX_EXPORT_PATH", exportPath)
+		args := []string{"--bin", guestBin}
+		if force {
+			args = append(args, "--force")
+		}
+		cmd := exec.Command(dashPath, append([]string{filepath.Join(scriptsDir, "distrobox-export")}, args...)...)
+		return cmd.CombinedOutput()
+	}
+
+	output, err := runExport("first", existingPath, false)
+	require.Error(t, err)
+	assert.Contains(t, string(output), "already exists")
+	got, err := os.ReadFile(existingFile)
+	require.NoError(t, err)
+	assert.Equal(t, original, got)
+
+	output, err = runExport("forced", existingPath, true)
+	require.NoError(t, err, string(output))
+	forced, err := os.ReadFile(existingFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(forced), "# distrobox_binary")
+	assert.Contains(t, string(forced), "# name: forced")
+
+	output, err = runExport("first", wrapperPath, false)
+	require.NoError(t, err, string(output))
+	wrapperFile := filepath.Join(wrapperPath, "demo-tool")
+	wrapper, err := os.ReadFile(wrapperFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(wrapper), "# distrobox_binary")
+
+	output, err = runExport("updated", wrapperPath, false)
+	require.NoError(t, err, string(output))
+	updated, err := os.ReadFile(wrapperFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# distrobox_binary")
+	assert.Contains(t, string(updated), "# name: updated")
 }
 
 // TestProvisionScripts_ExtractsAdjacentToBinary verifies that ProvisionScripts


### PR DESCRIPTION
## Summary

- refuse to overwrite existing host binaries that were not created by Distrobox
- add `--force` for intentional replacement while preserving normal wrapper updates
- document the behavior and cover refusal, forced replacement, and wrapper updates

## Testing

- `make test`
- `dash -n internal/inside-distrobox/assets/distrobox-export`
- ShellCheck and shfmt
- `git diff --check`

Fixes #2200.