### PR TITLE
fix(tests): run tests rootless, fix archlinux, fix internal script extraction path

### DIFF
--- a/hack/test/nvidia-test.sh
+++ b/hack/test/nvidia-test.sh
@@ -54,9 +54,20 @@ fail()
 	poweroff -f
 	exit 1
 }
+# Box ops run rootless as the cloud user; runuser -u
+# has no login session, so env supplies what rootless podman needs.
+as_user()
+{
+	runuser -u "${TEST_USER}" -- env \
+		HOME="/home/${TEST_USER}" \
+		XDG_RUNTIME_DIR="/run/user/${TEST_UID}" \
+		DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${TEST_UID}/bus" \
+		PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+		"$@"
+}
 dbx()
 {
-	/usr/local/bin/distrobox "$@"
+	as_user /usr/local/bin/distrobox "$@"
 }
 outok()
 {
@@ -152,6 +163,21 @@ esac
 ldconfig 2> /dev/null || true
 
 install -m0755 /mnt/share/distrobox /usr/local/bin/distrobox || fail "install distrobox"
+
+# Rootless prep: cloud images ship no subuid/subgid and lock the user, so grant
+# ranges and start a lingering session (/run/user/<uid> + systemd --user).
+TEST_USER="$(getent passwd 1000 | cut -d: -f1)"
+[ -n "${TEST_USER}" ] || fail "no default non-root user (uid 1000) in ${DISTRO} image"
+TEST_UID="$(id -u "${TEST_USER}")"
+grep -q "^${TEST_USER}:" /etc/subuid 2> /dev/null || printf '%s:100000:65536\n' "${TEST_USER}" >> /etc/subuid
+grep -q "^${TEST_USER}:" /etc/subgid 2> /dev/null || printf '%s:100000:65536\n' "${TEST_USER}" >> /etc/subgid
+loginctl enable-linger "${TEST_USER}" || fail "enable-linger ${TEST_USER}"
+for _ in $(seq 1 30); do
+	[ -S "/run/user/${TEST_UID}/bus" ] && break
+	sleep 1
+done
+[ -S "/run/user/${TEST_UID}/bus" ] || log "WARN: no user bus for ${TEST_USER}; rootless podman will use the cgroupfs manager"
+log "running box tests rootless as ${TEST_USER} (uid ${TEST_UID})"
 
 # Every driver file is required in the guest except these non-runtime bits.
 is_excluded()
@@ -451,6 +477,11 @@ PROBE
 		log "guest ${box}: ${n} problem(s) (of ${nreq} files)"
 		bad="${bad} ${box}"
 	else log "guest ${box}: OK (${nreq} files)"; fi
+
+	# Purge box + image so the next guest reuses the freed blocks (the qcow2 never
+	# shrinks); best-effort.
+	dbx rm --yes --force "${name}" > "${SERIAL}" 2>&1 || true
+	as_user podman rmi --force "${box}" > "${SERIAL}" 2>&1 || true
 done
 
 [ -z "${bad}" ] || fail "guest images failed:${bad}"

--- a/hack/test/vm-run.sh
+++ b/hack/test/vm-run.sh
@@ -38,7 +38,7 @@ SHARE="${2:?share dir required}"
 OUT="${3:?out dir required}"
 
 case "${DISTRO}" in
-	ubuntu) IMG_URL="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img" ;;
+	ubuntu) IMG_URL="https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img" ;;
 	fedora) IMG_URL="https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2" ;;
 	arch) IMG_URL="https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2" ;;
 	debian) IMG_URL="https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2" ;;

--- a/internal/inside-distrobox/scripts.go
+++ b/internal/inside-distrobox/scripts.go
@@ -35,15 +35,10 @@ var initScript string
 //go:embed assets/distrobox-export
 var exportScripts string
 
-// ProvisionScripts ensures that all necessary scripts are created in the given directory.
-// It returns scriptsDir unchanged on success.
+// ProvisionScripts ensures the helper scripts exist on disk and returns their
+// directory: scriptsDir when they are already there or it is writable, else a
+// per-user data dir (so a system-wide install still works when run rootless).
 func ProvisionScripts(scriptsDir string) (string, error) {
-	dir := scriptsDir
-	//nolint:gosec // 0755 is the same as from distrobox v1, let's keep it for compatibility
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create scripts directory: %w", err)
-	}
-
 	scripts := []struct {
 		name    string
 		content string
@@ -53,12 +48,34 @@ func ProvisionScripts(scriptsDir string) (string, error) {
 		{"distrobox-export", exportScripts},
 	}
 
+	// Reuse scripts already present (e.g. packaged), even if read-only.
+	allPresent := true
 	for _, script := range scripts {
-		if exists(script.name) {
+		if _, err := os.Stat(filepath.Join(scriptsDir, script.name)); err != nil {
+			allPresent = false
+			break
+		}
+	}
+	if allPresent {
+		return scriptsDir, nil
+	}
+
+	// Extract into scriptsDir, or a per-user dir when it is not writable.
+	dir := scriptsDir
+	//nolint:gosec // 0755 is the same as from distrobox v1, let's keep it for compatibility
+	if err := os.MkdirAll(dir, 0755); err != nil || !dirWritable(dir) {
+		dir = userScriptsDir()
+	}
+	//nolint:gosec // 0755 is the same as from distrobox v1, let's keep it for compatibility
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create scripts directory %s: %w", dir, err)
+	}
+
+	for _, script := range scripts {
+		destFilePath := filepath.Join(dir, script.name)
+		if _, err := os.Stat(destFilePath); err == nil {
 			continue
 		}
-
-		destFilePath := filepath.Join(dir, script.name)
 		//nolint:gosec // 0755 is the same as from distrobox v1, let's keep it for compatibility
 		if err := os.WriteFile(destFilePath, []byte(script.content), 0755); err != nil {
 			return "", fmt.Errorf("failed to write script %s: %w", script.name, err)
@@ -68,15 +85,28 @@ func ProvisionScripts(scriptsDir string) (string, error) {
 	return dir, nil
 }
 
-// exists reports whether a script with the given name is already
-// available on the host.
-func exists(name string) bool {
-	if exe, err := os.Executable(); err == nil {
-		dir := filepath.Dir(exe)
-		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
-			return true
-		}
+// dirWritable reports whether a file can be created in dir (probes with a temp file).
+func dirWritable(dir string) bool {
+	probe, err := os.CreateTemp(dir, ".dbx-write-probe-")
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+	}()
+
+	return true
+}
+
+// userScriptsDir is the per-user fallback for extracted scripts.
+func userScriptsDir() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "distrobox")
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		return filepath.Join(home, ".local", "share", "distrobox")
 	}
 
-	return false
+	return filepath.Join(os.TempDir(), "distrobox")
 }

--- a/internal/inside-distrobox/scripts_test.go
+++ b/internal/inside-distrobox/scripts_test.go
@@ -48,19 +48,9 @@ func assertAllScripts(t *testing.T, dir string) {
 	}
 }
 
-// isolatePath wipes PATH for the duration of the test so the PATH branch
-// of exists() never finds a system-installed distrobox-init while we are
-// trying to exercise other resolution branches.
-func isolatePath(t *testing.T) {
-	t.Helper()
-	t.Setenv("PATH", "")
-}
-
-// TestProvisionScripts_CustomDir checks that ProvisionScripts writes all three
-// scripts into the given directory and returns it unchanged.
+// writes the scripts into a writable dir and returns it unchanged.
 func TestProvisionScripts_CustomDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	isolatePath(t)
 
 	dir, err := insidedistrobox.ProvisionScripts(tmpDir)
 	require.NoError(t, err)
@@ -68,35 +58,27 @@ func TestProvisionScripts_CustomDir(t *testing.T) {
 	assertAllScripts(t, dir)
 }
 
-// TestProvisionScripts_DetectOnPath confirms the skip-write shortcut via
-// the PATH branch of exists(): when the helper scripts already exist
-// somewhere on PATH, ProvisionScripts leaves them byte-for-byte
-// untouched rather than overwriting from the embedded copies.
-func TestProvisionScripts_DetectOnPath(t *testing.T) {
-	writeDir := t.TempDir()
-	scriptsDir := t.TempDir()
+// scripts already in the target dir are reused byte-for-byte, not overwritten.
+func TestProvisionScripts_ReusesPresent(t *testing.T) {
+	dir := t.TempDir()
 	marker := "#!/bin/sh\n# pre-existing-marker\n"
 	for _, name := range expectedScripts {
-		require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, name), []byte(marker), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(marker), 0755))
 	}
 
-	t.Setenv("PATH", scriptsDir)
-
-	_, err := insidedistrobox.ProvisionScripts(writeDir)
+	got, err := insidedistrobox.ProvisionScripts(dir)
 	require.NoError(t, err)
+	require.Equal(t, dir, got)
 
 	for _, name := range expectedScripts {
-		got, err := os.ReadFile(filepath.Join(scriptsDir, name))
+		b, err := os.ReadFile(filepath.Join(dir, name))
 		require.NoError(t, err)
-		require.Equal(t, marker, string(got), "%s was overwritten despite existing on PATH", name)
+		require.Equal(t, marker, string(b), "%s was overwritten despite already being present", name)
 	}
 }
 
-// TestProvisionScripts_ExtractsAdjacentToBinary verifies that ProvisionScripts
-// writes to the given directory.
+// writes into the given directory when it is writable and empty.
 func TestProvisionScripts_ExtractsAdjacentToBinary(t *testing.T) {
-	isolatePath(t)
-
 	exe, err := os.Executable()
 	require.NoError(t, err)
 	exeDir := filepath.Dir(exe)
@@ -112,6 +94,24 @@ func TestProvisionScripts_ExtractsAdjacentToBinary(t *testing.T) {
 	dir, err := insidedistrobox.ProvisionScripts(exeDir)
 	require.NoError(t, err)
 	require.Equal(t, exeDir, dir)
+	assertAllScripts(t, dir)
+}
+
+// an unwritable target dir falls back to the per-user data dir.
+func TestProvisionScripts_FallsBackWhenUnwritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write into any directory; cannot exercise the fallback")
+	}
+	roDir := filepath.Join(t.TempDir(), "install")
+	require.NoError(t, os.Mkdir(roDir, 0o500))
+
+	home := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", home)
+
+	dir, err := insidedistrobox.ProvisionScripts(roDir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, ".local", "share", "distrobox"), dir)
 	assertAllScripts(t, dir)
 }
 


### PR DESCRIPTION
- scripts.go: ProvisionScripts reuses the helpers if already present, else extracts into the install dir when writable, otherwise falls back to $XDG_DATA_HOME/distrobox. Fixes rootless create/enter for a system-wide install (/usr/local/bin), which died with "permission denied"
- hack/test/nvidia-test.sh: run box ops rootless as the cloud user
- hack/test/vm-run.sh: bump the ubuntu image to resolute.