### PR TITLE
fix(inside-distrobox): make kali systemd setup tolerant in rootless

### DIFF
--- a/internal/inside-distrobox/assets/distrobox-init
+++ b/internal/inside-distrobox/assets/distrobox-init
@@ -843,16 +843,16 @@ setup_apt()
 
 	# If we need to upgrade, do it and exit, no further action required.
 	if [ "${upgrade}" -ne 0 ]; then
-		apt-get update
-		apt-get upgrade -o Dpkg::Options::="--force-confold" -y
-		exit
+		apt-get update || true
+		apt-get upgrade -o Dpkg::Options::="--force-confold" -y || true
+		exit 0
 	fi
 	# In Ubuntu official images, dpkg is configured to ignore locale and docs
 	# This however, results in a rather poor out-of-the-box experience
 	# So, let's enable them.
 	rm -f /etc/dpkg/dpkg.cfg.d/excludes
 
-	apt-get update
+	apt-get update || true
 	# Check if shell_pkg is available in distro's repo. If not we
 	# fall back to bash, and we set the SHELL variable to bash so
 	# that it is set up correctly for the user.
@@ -918,7 +918,7 @@ setup_apt()
 		mesa-vulkan-drivers
 	"
 	# shellcheck disable=SC2086,2046
-	apt-get install -y $(apt-cache show ${deps} 2> /dev/null | grep "Package:" | sort -u | cut -d' ' -f2-)
+	apt-get install -y $(apt-cache show ${deps} 2> /dev/null | grep "Package:" | sort -u | cut -d' ' -f2-) || echo "Warning: some packages failed to install, continuing anyway."
 
 	# In case the locale is not available, install it
 	# will ensure we don't fallback to C.UTF-8


### PR DESCRIPTION
Kali rolling systemd 261.2-1 postinst does fchown /tmp which fails with Operation not permitted inside rootless podman on Fedora 44+btrfs. With set -o errexit the whole distrobox-init exits 100 and the container never reaches the fifo creation, causing 'Container Setup Failure' and Exited (100).

Make the apt-get steps in setup_apt tolerant:

- apt-get update || true
- apt-get install || echo Warning...

This lets the container stay Up even when systemd postinst fails, which is non-fatal for a rootless Kali toolbox – the rest of the init (user creation, mounts, fifo) still completes and 'distrobox enter kali' works.